### PR TITLE
Add WebSerial Detection and Warning

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -2,7 +2,9 @@
   <div>
     <!-- Warning for browsers that do not support WebSerial API -->
     <div v-if="!isWebSerialSupported" class="unsupported-browser-warning">
-      <p>Your browser does not support the WebSerial API. Please switch to a compatible browser for full functionality.</p>
+      <p>Your browser does not support the WebSerial API. Please switch to a
+      <a href="https://meshtastic.org/docs/software/web-client#serial-usb" class="text-blue-500 hover:text-blue-700">compatible browser</a>
+      for full functionality.</p>
     </div>
     <Head>
       <Title>Meshtastic Flasher</Title>
@@ -58,9 +60,9 @@
       <div class="container mx-auto px-5 py-4 text-center">
         <p>
           Powered by
-          <a href="https://vercel.com/?utm_source=meshtastic&utm_campaign=oss" class="text-blue-500 hover:text-blue-700">▲ Vercel</a>
+          <a href="https://vercel.com/?utm_source=meshtastic&utm_campaign=oss">▲ Vercel</a>
           | Meshtastic® is a registered trademark of Meshtastic LLC. |
-          <a href="https://meshtastic.org/docs/legal" class="text-blue-500 hover:text-blue-700">Legal Information</a>.
+          <a href="https://meshtastic.org/docs/legal">Legal Information</a>.
         </p>
       </div>
     </footer>

--- a/app.vue
+++ b/app.vue
@@ -2,9 +2,7 @@
   <div>
     <!-- Warning for browsers that do not support WebSerial API -->
     <div v-if="!isWebSerialSupported" class="unsupported-browser-warning">
-      <p>Your browser does not support the WebSerial API. Please switch to a
-      <a href="https://meshtastic.org/docs/software/web-client#serial-usb" class="text-blue-500 hover:text-blue-700">compatible browser</a>
-      for full functionality.</p>
+      <p>Your browser does not support the WebSerial API. Please switch to a compatible browser, such as Chrome or Edge, for full functionality.</p>
     </div>
     <Head>
       <Title>Meshtastic Flasher</Title>

--- a/app.vue
+++ b/app.vue
@@ -1,5 +1,9 @@
 <template>
   <div>
+    <!-- Warning for browsers that do not support WebSerial API -->
+    <div v-if="!isWebSerialSupported" class="unsupported-browser-warning">
+      <p>Your browser does not support the WebSerial API. Please switch to a compatible browser for full functionality.</p>
+    </div>
     <Head>
       <Title>Meshtastic Flasher</Title>
       <Meta name="description" :content="title" />
@@ -64,20 +68,23 @@
 </template>
 
 <script setup>
+import { ref, onMounted } from 'vue';
 import 'flowbite';
-
-import {
-  initDropdowns,
-  initModals,
-  initTooltips,
-} from 'flowbite';
-
+import { initDropdowns, initModals, initTooltips } from 'flowbite';
 import { BoltIcon } from '@heroicons/vue/24/solid';
+
+// WebSerial API support check
+const isWebSerialSupported = ref(false);
+
+const checkWebSerialSupport = () => {
+  isWebSerialSupported.value = 'serial' in navigator;
+};
 
 onMounted(() => {
   initDropdowns();
   initModals();
   initTooltips();
+  checkWebSerialSupport();
 });
 </script>
 
@@ -100,5 +107,11 @@ onMounted(() => {
   }
   .footer a:hover {
     text-decoration: underline;
+  }
+  .unsupported-browser-warning {
+    background-color: #ffcc00;
+    color: black;
+    padding: 10px;
+    text-align: center;
   }
 </style>


### PR DESCRIPTION
This PR adds WebSerial detection and presents a very visible warning if not detected. This is so that a user is aware their browser is not compatible with the WebSerial flashing tech being used with the Meshtastic flasher. 