### PR TITLE
Format Text for ESP32-S3

### DIFF
--- a/components/targets/Esp32.vue
+++ b/components/targets/Esp32.vue
@@ -53,7 +53,12 @@
                             This process could take a minute. 
                         </p>
                         <p>
+                        <div class="p-4 mb-4 my-2 text-sm text-blue-800 rounded-lg bg-blue-50 dark:bg-gray-800 dark:text-blue-400" role="alert">
+                            <span class="font-medium">
+                            <InformationCircleIcon class="h-4 w-4 inline" />
                             After the flashing process is complete, you may need to press the RST button if the device does not reboot automatically.
+                       </span>
+                  </div>
                         </p>
                     </li>
                 </ol>


### PR DESCRIPTION
Adds the same formatting from the verbiage on firmware download mode, to the verbiage on resetting the device when it's finished. This way it pops out more. Closes #54 

<img width="938" alt="Screenshot 2024-04-02 at 5 17 39 PM" src="https://github.com/meshtastic/web-flasher/assets/6912600/e04d89c8-9a80-41c5-8c99-1c0b85b08288">
