### PR TITLE
Add Link To Docs for Key Backup

### DIFF
--- a/components/targets/Esp32.vue
+++ b/components/targets/Esp32.vue
@@ -67,7 +67,7 @@
                                     Back up the device’s public and private keys before a full erase and install to restore them after re-flashing if needed.
                                 </span>
                             </div>
-                            <div class="flex items-center">
+                            <div class="flex items-center mt-2">
                                 <LinkIcon class="h-4 w-4 mr-1 text-red-800 dark:text-red-400" />
                                 <a href="https://meshtastic.org/docs/configuration/radio/security/#security-keys---backup-and-restore" target="_blank" class="underline text-red-800 dark:text-red-400">
                                     Check out this guide in our documentation.</a>

--- a/components/targets/Esp32.vue
+++ b/components/targets/Esp32.vue
@@ -26,7 +26,6 @@
                                 </button>
                             </span>
                         </div>
-
                     </li>
                     <li class="mb-10 ms-8">
                         <span class="absolute flex items-center justify-center w-6 h-6 bg-blue-100 rounded-full -start-3 ring-8 ring-white dark:ring-gray-900 dark:bg-blue-900">
@@ -55,14 +54,24 @@
                         </h3>
                         <label class="relative inline-flex items-center me-5 cursor-pointer" v-if="canFullInstall()">
                             <input type="checkbox" value="" class="sr-only peer" v-model="firmwareStore.$state.shouldCleanInstall">
-                            <div class="w-11 h-6 bg-gray-200 rounded-full peer peer-focus:ring-4 dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-red-600"></div>
-                            <span class="ms-3 text-sm font-medium text-gray-900 dark:text-gray-300">Full Erase and Install</span>
-                        </label>
-                        <div v-if="firmwareStore.$state.shouldCleanInstall" role="alert" class="flex p-4 mb-4 mt-2 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-gray-800 dark:text-red-400">
-                            <InformationCircleIcon class="flex-shrink-0 inline w-5 h-5 mr-3" />
-                            <span class="font-medium">
-                                Back up the device’s public and private keys before a full erase and install to restore them after re-flashing if needed.
+                            <div class="w-11 h-6 bg-gray-200 rounded-full peer peer-focus:ring-4 dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-red-600">
+                            </div>
+                            <span class="ms-3 text-sm font-medium text-gray-900 dark:text-gray-300">
+                                Full Erase and Install
                             </span>
+                        </label>
+                        <div v-if="firmwareStore.$state.shouldCleanInstall" role="alert" class="flex flex-col p-4 mb-4 mt-2 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-gray-800 dark:text-red-400">
+                            <div class="flex items-center">
+                                <InformationCircleIcon class="flex-shrink-0 inline w-4 h-4 mr-1" />
+                                <span>
+                                    Back up the device’s public and private keys before a full erase and install to restore them after re-flashing if needed.
+                                </span>
+                            </div>
+                            <div class="flex items-center">
+                                <LinkIcon class="h-4 w-4 mr-1 text-red-800 dark:text-red-400" />
+                                <a href="https://meshtastic.org/docs/configuration/radio/security/#security-keys---backup-and-restore" target="_blank" class="underline text-red-800 dark:text-red-400">
+                                    Check out this guide in our documentation.</a>
+                            </div>
                         </div>
                         <p>
                             This process could take a minute. 
@@ -70,8 +79,8 @@
                         <div>
                             <div class="p-4 mb-4 my-2 text-sm text-blue-800 rounded-lg bg-blue-50 dark:bg-gray-800 dark:text-blue-400" role="alert">
                                 <span class="font-medium">
-                                        <InformationCircleIcon class="h-4 w-4 inline" />
-                                        After the flashing process is complete, you may need to press the RST button if the device does not reboot automatically or says "waiting to download" in the console.
+                                    <InformationCircleIcon class="h-4 w-4 inline" />
+                                    After the flashing process is complete, you may need to press the RST button if the device does not reboot automatically or says "waiting to download" in the console.
                                 </span>
                             </div>
                         </div>
@@ -103,6 +112,7 @@ import '@/node_modules/xterm/css/xterm.css';
 import {
   CpuChipIcon,
   InformationCircleIcon,
+  LinkIcon,
 } from '@heroicons/vue/24/solid';
 
 import { useDeviceStore } from '../../stores/deviceStore';


### PR DESCRIPTION
Adds a link to the "Full Erase and Install" alert regarding keys. 
<img width="883" alt="Screenshot 2024-11-16 at 9 58 19 AM" src="https://github.com/user-attachments/assets/ae152381-5aa5-4cad-82c3-3c93b19bb3e5">

Closes #122 