### PR TITLE
Provide clarity around stability of alpha/beta

### DIFF
--- a/components/Firmware.vue
+++ b/components/Firmware.vue
@@ -22,7 +22,7 @@
                 </li>
             </ul>
             <div class="px-4 py-2 text-sm text-gray-900" v-if="!store.couldntFetchFirmwareApi">
-                <strong>Alpha</strong>
+                <strong>Unstable (Alpha)</strong>
             </div>
             <ul class="py-2 text-sm text-gray-800" aria-labelledby="dropdownInformationButton" v-if="!store.couldntFetchFirmwareApi">
                 <li v-for="release in store.$state.alpha">
@@ -32,7 +32,7 @@
                 </li>
             </ul>
             <div class="px-4 py-2 text-sm text-gray-900 dark:text-white" v-if="!store.couldntFetchFirmwareApi">
-                <strong>Stable</strong>
+                <strong>Stable (Beta)</strong>
             </div>
             <ul class="py-2 text-sm text-gray-800" aria-labelledby="dropdownInformationButton" v-if="!store.couldntFetchFirmwareApi">
                 <li v-for="release in store.$state.stable">


### PR DESCRIPTION
## What
Adds the word Unstable to the Alpha heading
Adds the word Beta to the Stable Heading

## Why
We were mixing terms (Alpha/Stable) instead of using like terms (Alpha/Beta or Stable/Unstable). This change should help make it clear to less savvy users(Stable/Unstable), while still showing advanced users titles they are familiar with (Alpha/Beta)

## Screenshots
### Before
<img width="405" alt="Screenshot 2024-12-08 at 1 41 12 PM" src="https://github.com/user-attachments/assets/2c841561-76b7-462c-8493-76276d386df8">

### After
<img width="386" alt="Screenshot 2024-12-08 at 1 40 42 PM" src="https://github.com/user-attachments/assets/b89af3df-5825-4c96-b876-ce5c4aab7019">

