### PR TITLE
Add Details of Event Firmware to Release Notes

### DIFF
--- a/public/data/manifest.json
+++ b/public/data/manifest.json
@@ -11,6 +11,6 @@
     "title": "Hamvention Firmware",
     "version": "2.6.8.9cd180b",
     "githubioPrefix": "event/dayton2025",
-    "release_notes": "### Experimental firmware for Hamvention 2025\n\n⚠️Erase flash and flash the latest experimental firmware for Hamvention 2025.\n\n### Important Notes\n- This firmware is experimental and may not be stable.\n- Use at your own risk.\n- Ensure you have a backup of your current configuration before flashing."
+    "release_notes": "### Experimental firmware for Hamvention 2025\n\n⚠️ Erase flash and flash the latest experimental firmware for Hamvention 2025.\n\n### Important Notes\n\n - This firmware is experimental and may not be stable.\n - Use at your own risk.\n - Ensure you have a backup of your current configuration before flashing.\n\n### Notable changes in the *Dayton 2025* firmware:\n\n - Preset: `Short_Turbo`\n - Channel: 31 (`917.25` MHz)\n - 3 Default Channels:\n   - Hamvention `OEu8wB3AItGBvza4YSHh+5a3LlW/dCJ+nWr7SNZMsaE=`\n   - NodeChat `TiIdi8MJG+IRnIkS8iUZXRU+MHuGtuzEasOWXp4QndU=`\n   - YardSale `FW/+RtRWY4pUQxPy72xjifAGMFLONl6x6LuG5iZbHVg=`\n\n### Some notable stuff EVENT_MODE does (in general):\n\n - Disables non-standard port numbers\n - Disables public MQTT reporting\n - Does not allow setting hop limit higher than 3\n - Coerces telemetry / nodeinfo reporting intervals to be more conservative"
   }
 }


### PR DESCRIPTION
Closes #168 which asked for documentation on differences between mainline firmware and event firmware, I figured we could add some brief info to the release notes. 

I can't seem to get it to format correctly. 

Trying for this:
```
Some notable stuff EVENT_MODE does (in general):
- Disables non-standard protobuf port numbers
- Disables public MQTT reporting
- Does not allow setting hop limit higher than 3
- Coerces telemetry / nodeinfo reporting intervals to be more conservative

Notable changes in the *Dayton 2025* firmware:
- Preset: Short_Turbo
- Channel: 31 (`917.25`mhz)
- 3 Default Channels
  - Hamvention `OEu8wB3AItGBvza4YSHh+5a3LlW/dCJ+nWr7SNZMsaE=`
  - NodeChat `TiIdi8MJG+IRnIkS8iUZXRU+MHuGtuzEasOWXp4QndU=`
  - YardSale `FW/+RtRWY4pUQxPy72xjifAGMFLONl6x6LuG5iZbHVg=`
```

But it's coming out flat. I probably did something wrong. 