### PR TITLE
fix: Flash firmware UI selection and missing state bug

### DIFF
--- a/components/targets/Esp32.vue
+++ b/components/targets/Esp32.vue
@@ -167,6 +167,7 @@ const startOver = () => {
 }
 
 const flash = () => {
+    firmwareStore.$state.partitionScheme = deviceStore.$state.selectedTarget.partitionScheme;
     if (firmwareStore.$state.shouldCleanInstall) {  
         cleanInstallEsp32();
     } else {
@@ -202,7 +203,6 @@ const canInstallInkHud = computed(() => {
 
 watch(() => firmwareStore.$state.shouldInstallMui, () => {
     canBundleWebUI.value = !firmwareStore.$state.shouldInstallMui;
-    firmwareStore.$state.partitionScheme = deviceStore.$state.selectedTarget.partitionScheme;
 });
 
 watch(() => firmwareStore.$state.shouldCleanInstall, async () => {

--- a/components/targets/Esp32.vue
+++ b/components/targets/Esp32.vue
@@ -213,7 +213,7 @@ watch(() => firmwareStore.$state.shouldCleanInstall, async () => {
         const foundWebUI = entries.find(entry => entry.filename.startsWith('littlefswebui'));
         canBundleWebUI.value = !!foundWebUI;
     } else if (firmwareStore.selectedFirmware) {
-        canBundleWebUI.value = await checkIfRemoteFileExists(firmwareStore.getReleaseFileUrl(littleFsFileName.value));
+        canBundleWebUI.value = await checkIfRemoteFileExists(firmwareStore.getReleaseFileUrl(littleFsFileName.value)) && !firmwareStore.$state.shouldInstallMui;
     }
     else {
         canBundleWebUI.value = false;


### PR DESCRIPTION
Issue: MeshtasticUi selection would be enabled when enabling 'Full Erase and Install' which would then show the 'Bundle Web UI' state. Not intended because disabling MeshtasticUi and re-enabling it would hide 'Bundle Web UI'.
![image](https://github.com/user-attachments/assets/eb748ff1-2abe-4cbb-ac4a-cd1c4651d50d)

Reproduction Steps:
- Select target device: T-Deck
- Flash
- Continue
- Ensure MeshtasticUi is enabled
- Enable Full Erase and Install

Error condition reached. MeshtasticUi is enabled but Bundle Web UI can also be toggled. Changing state for either checkbox disables the other.

Also noticed that the last write in error cases was `Writing at 0xc30000...` and successful cases were `Writing at 0xc90000...`. Tracked issue to missing state for partitionScheme when MeshtasticUi selection was not changed from original state.
