### PR TITLE
feat: add Polish translations for DFU mode and additional UI strings

### DIFF
--- a/i18n/locales/pl.json
+++ b/i18n/locales/pl.json
@@ -9,7 +9,9 @@
     "connect": "Połącz",
     "disconnect": "Rozłącz",
     "continue": "Kontynuuj",
-    "close_dialog": "Zamknij okno"
+    "close_dialog": "Zamknij okno",
+    "dismiss": "Odrzuć",
+    "close": "Zamknij"
   },
   "state": {
     "connected": "Połączony",
@@ -29,7 +31,7 @@
     "subheading": "Jeśli na podłączonym urządzeniu jest już zainstalowany Meshtastic, możesz go automatycznie wykryć:",
     "auto_detect": "Automatyczne wykrywanie",
     "supported_devices": "Obsługiwane urządzenia",
-    "diy_devices": "Urządzenia DIY"
+    "diy_devices": "Urządzenia wspierane przez społeczność"
   },
   "firmware": {
     "title": "Firmware",
@@ -105,6 +107,7 @@
   "serial": {
     "instructions": "Jeśli proces rozłączania trwa zbyt długo, możesz ręcznie odłączyć urządzenie.",
     "disconnect": "Rozłącz",
+    "reconnect": "Spróbuj ponownie połączyć",
     "log_levels": {
       "all": "Wszystkie",
       "debug": "Debug",
@@ -112,5 +115,15 @@
       "warn": "Ostrzeżenie",
       "error": "Błąd"
     }
+  },
+  "dfu": {
+    "success_title": "Tryb DFU",
+    "success_message": "Urządzenie pomyślnie weszło w tryb DFU",
+    "error_title": "Tryb DFU nieudany",
+    "error_message": "Nie udało się wejść w tryb DFU. Odłącz i podłącz ponownie urządzenie, a następnie spróbuj ponownie. Jeśli problem się powtarza, odśwież stronę.",
+    "error_connection_title": "Połączenie z urządzeniem nieudane",
+    "error_connection": "Nie udało się połączyć z urządzeniem lub urządzenie może już być w trybie DFU. Odłącz i podłącz ponownie urządzenie, a następnie spróbuj ponownie. Jeśli problem się powtarza, odśwież stronę.",
+    "error_unresponsive_title": "Urządzenie nie odpowiada",
+    "error_unresponsive": "Urządzenie nie odpowiada. Upewnij się, że jest prawidłowo podłączone i nie znajduje się w trybie DFU. Jeśli problem się powtarza, odśwież stronę."
   }
 }


### PR DESCRIPTION
# Description

For some reason I can't log in to CrowdIn :( Maybe somebody can add those missing keys.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests as appropriate
- [ ] All existing tests pass

---

## Hardware Model Acceptance Policy

### New Hardware Model Acceptance Policy

Due to limited availability and ongoing support, new Hardware Models will only be accepted from [Meshtastic Backers and Partners](https://meshtastic.com/). The Meshtastic team reserves the right to make exceptions to this policy.

#### Alternative for Community Contributors

You are welcome to use one of the existing DIY hardware models in your PlatformIO environment and create a pull request in the firmware project. Please note the following conditions:

- The device will **not** be officially supported by the core Meshtastic team.
- The device will **not** appear in the [Web Flasher](https://flasher.meshtastic.org/) or Github release assets.
- You will be responsible for ongoing maintenance and support.
- Community-contributed / DIY hardware models are considered experimental and will likely have limited or no testing.

#### Getting Official Support

To have your hardware model officially supported and included in the Meshtastic ecosystem, consider becoming a Meshtastic Backer or Partner. Visit [meshtastic.com](https://meshtastic.com/) for more information about partnership opportunities.

---

## Protected Files Notice

**The following files are protected and changes to them will be automatically rejected:**

- `public/data/hardware-list.json` - Auto-generated Hardware definitions (additionally see policy above)
- `types/resources.ts` - Auto-generated resource definitions
- `i18n/locales/**` - Translation files (managed via [Crowdin](https://meshtastic.crowdin.com/web-flasher))
