### PR TITLE
fix(i18n): implement robust translation fallback system for all locales

### DIFF
--- a/components/ToastNotifications.vue
+++ b/components/ToastNotifications.vue
@@ -41,7 +41,7 @@
                 @click="reloadPage"
                 class="ml-2 text-sm font-medium text-red-400 hover:text-red-300 transition-colors duration-200"
               >
-                Reload
+                {{ $t('actions.reload') }}
               </button>
             </div>
           </div>

--- a/i18n.config.ts
+++ b/i18n.config.ts
@@ -1,0 +1,10 @@
+export default defineI18nConfig(() => ({
+  legacy: false,
+  fallbackLocale: 'en',
+  // Ensure missing translations fall back to English
+  silentTranslationWarn: false,
+  silentFallbackWarn: false,
+  // Enable fallback for missing keys
+  fallbackWarn: false,
+  missingWarn: false
+}))

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -11,7 +11,8 @@
     "continue": "Continue",
     "close_dialog": "Close dialog",
     "dismiss": "Dismiss",
-    "close": "Close"
+    "close": "Close",
+    "reload": "Reload"
   },
   "state": {
     "connected": "Connected",

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -122,6 +122,7 @@ export default defineNuxtConfig({
     lazy: true,
     langDir: 'locales/',
     strategy: 'no_prefix',
+    vueI18n: './i18n.config.ts',
     bundle: {
       optimizeTranslationDirective: false,
     },


### PR DESCRIPTION
# Description

Implement robust translation fallback system for all locales to ensure users always see meaningful text instead of translation keys. This PR fixes the issue where raw translation keys like 'dfu.error_connection_title' were being displayed to users when Polish translations were missing or when the i18n system failed in Pinia store contexts.

Before (Polish language with missing translations)
<img width="555" height="251" alt="Screenshot 2025-09-18 at 22 29 09" src="https://github.com/user-attachments/assets/f534b533-55cc-4015-b25d-a49c51e715c9" />

After (Polish language with missing translations and fallback to english)
<img width="586" height="340" alt="Screenshot 2025-09-18 at 22 26 45" src="https://github.com/user-attachments/assets/1843210d-c2ef-43d4-ae89-c94dc06bf183" />


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests as appropriate
- [x] All existing tests pass

---

## Hardware Model Acceptance Policy

### New Hardware Model Acceptance Policy

Due to limited availability and ongoing support, new Hardware Models will only be accepted from [Meshtastic Backers and Partners](https://meshtastic.com/). The Meshtastic team reserves the right to make exceptions to this policy.

#### Alternative for Community Contributors

You are welcome to use one of the existing DIY hardware models in your PlatformIO environment and create a pull request in the firmware project. Please note the following conditions:

- The device will **not** be officially supported by the core Meshtastic team.
- The device will **not** appear in the [Web Flasher](https://flasher.meshtastic.org/) or Github release assets.
- You will be responsible for ongoing maintenance and support.
- Community-contributed / DIY hardware models are considered experimental and will likely have limited or no testing.

#### Getting Official Support

To have your hardware model officially supported and included in the Meshtastic ecosystem, consider becoming a Meshtastic Backer or Partner. Visit [meshtastic.com](https://meshtastic.com/) for more information about partnership opportunities.

---

## Protected Files Notice

**The following files are protected and changes to them will be automatically rejected:**

- `public/data/hardware-list.json` - Auto-generated Hardware definitions (additionally see policy above)
- `types/resources.ts` - Auto-generated resource definitions
- `i18n/locales/**` - Translation files (managed via [Crowdin](https://meshtastic.crowdin.com/web-flasher))
