### PR TITLE
fix: update vueI18n path in nuxt.config.ts

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -8,11 +8,11 @@ export default defineNuxtConfig({
     head: {
       script: process.env.COOKIEYES_CLIENT_ID
         ? [
-            {
-              src: `https://cdn-cookieyes.com/client_data/${process.env.COOKIEYES_CLIENT_ID}/script.js`,
-              async: true,
-            },
-          ]
+          {
+            src: `https://cdn-cookieyes.com/client_data/${process.env.COOKIEYES_CLIENT_ID}/script.js`,
+            async: true,
+          },
+        ]
         : [],
     },
   },
@@ -122,7 +122,7 @@ export default defineNuxtConfig({
     lazy: true,
     langDir: 'locales/',
     strategy: 'no_prefix',
-    vueI18n: './i18n.config.ts',
+    vueI18n: '../i18n.config.ts',
     bundle: {
       optimizeTranslationDirective: false,
     },


### PR DESCRIPTION
# Description

# Fix i18n Configuration Path

## Problem

`@nuxtjs/i18n` was showing a warning because it couldn't find the Vue I18n configuration file. The path was being interpreted relative to the `i18n/` directory instead of the project root.

<img width="710" height="381" alt="Screenshot 2025-10-12 at 14 57 41" src="https://github.com/user-attachments/assets/a23b0df6-fac2-4de2-b46d-1595767cdc07" />


## Solution

Updated the `vueI18n` path in `nuxt.config.ts` from `'./i18n.config.ts'` to `'../i18n.config.ts'` to correctly reference the configuration file at the project root.

<img width="548" height="341" alt="Screenshot 2025-10-12 at 14 56 54" src="https://github.com/user-attachments/assets/e5ba9fb8-f40e-480a-90d6-969b52eaabcf" />

## Changes

-   **File**: `nuxt.config.ts` (line 125)
-   **Change**: `vueI18n: './i18n.config.ts'` → `vueI18n: '../i18n.config.ts'`

Fixes the i18n configuration loading issue with no breaking changes.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests as appropriate
- [ ] All existing tests pass

---

## Hardware Model Acceptance Policy

### New Hardware Model Acceptance Policy

Due to limited availability and ongoing support, new Hardware Models will only be accepted from [Meshtastic Backers and Partners](https://meshtastic.com/). The Meshtastic team reserves the right to make exceptions to this policy.

#### Alternative for Community Contributors

You are welcome to use one of the existing DIY hardware models in your PlatformIO environment and create a pull request in the firmware project. Please note the following conditions:

- The device will **not** be officially supported by the core Meshtastic team.
- The device will **not** appear in the [Web Flasher](https://flasher.meshtastic.org/) or Github release assets.
- You will be responsible for ongoing maintenance and support.
- Community-contributed / DIY hardware models are considered experimental and will likely have limited or no testing.

#### Getting Official Support

To have your hardware model officially supported and included in the Meshtastic ecosystem, consider becoming a Meshtastic Backer or Partner. Visit [meshtastic.com](https://meshtastic.com/) for more information about partnership opportunities.

---

## Protected Files Notice

**The following files are protected and changes to them will be automatically rejected:**

- `public/data/hardware-list.json` - Auto-generated Hardware definitions (additionally see policy above)
- `types/resources.ts` - Auto-generated resource definitions
- `i18n/locales/**` - Translation files (managed via [Crowdin](https://meshtastic.crowdin.com/web-flasher))
