### PR TITLE
feat: add eslint config and scripts with basic vue rules

### DIFF
--- a/.trunk/configs/svgo.config.js
+++ b/.trunk/configs/svgo.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   plugins: [
     {
-      name: "preset-default",
+      name: 'preset-default',
       params: {
         overrides: {
           removeViewBox: false, // https://github.com/svg/svgo/issues/1128
@@ -11,4 +11,4 @@ module.exports = {
       },
     },
   ],
-};
+}

--- a/app.vue
+++ b/app.vue
@@ -1,40 +1,66 @@
 <template>
   <div>
     <!-- Warning for browsers that do not support WebSerial API -->
-    <div v-if="!isWebSerialSupported" class="unsupported-browser-warning">
+    <div
+      v-if="!isWebSerialSupported"
+      class="unsupported-browser-warning"
+    >
       <p>{{ $t('browser_warning') }}</p>
     </div>
     <Head>
       <Title>{{ $t('title') }}</Title>
-      <Meta name="description" :content="$t('description')" />
+      <Meta
+        name="description"
+        :content="$t('description')"
+      />
     </Head>
 
-    <section id="main" class="text-gray-400 body-font px-3 sm:px-5">
-      <transition name="flash" mode="out-in">
-        <div class="container py-1 mx-auto transition duration-900 ease-in-out max-w-7xl" v-show="!serialMonitorStore.isConnected">
+    <section
+      id="main"
+      class="text-gray-400 body-font px-3 sm:px-5"
+    >
+      <transition
+        name="flash"
+        mode="out-in"
+      >
+        <div
+          v-show="!serialMonitorStore.isConnected"
+          class="container py-1 mx-auto transition duration-900 ease-in-out max-w-7xl"
+        >
           <div class="flex flex-col content-center justify-center">
             <div class="flex flex-wrap sm:flex-row flex-col py-1">
               <LogoHeader />
             </div>
-            <hr class="w-full mx-auto mb-4 border-gray-600" />
+            <hr class="w-full mx-auto mb-4 border-gray-600">
           </div>
           <div class="flex flex-wrap sm:-m-4 -mx-2 sm:-mx-4 -mb-10 -mt-4">
             <div class="p-2 sm:p-4 md:w-1/3 sm:mb-0 mb-6">
               <div class="rounded-lg h-80 overflow-hidden flex flex-col items-center display-inline">
-                <img :src="selectedDeviceImage" class="h-64 w-64 mb-6 mx-auto" :alt="$t('device.title')" />
+                <img
+                  :src="selectedDeviceImage"
+                  class="h-64 w-64 mb-6 mx-auto"
+                  :alt="$t('device.title')"
+                >
                 <Device />
               </div>
-              <h2 class="text-lg sm:text-xl font-medium title-font text-white mt-5">{{ $t('device.title') }}</h2>
+              <h2 class="text-lg sm:text-xl font-medium title-font text-white mt-5">
+                {{ $t('device.title') }}
+              </h2>
               <p class="text-sm sm:text-base leading-relaxed mt-2">
                 {{ $t('device.instructions') }}
               </p>
             </div>
             <div class="p-2 sm:p-4 md:w-1/3 sm:mb-0 mb-6">
               <div class="rounded-lg h-80 flex flex-col items-center">
-                <FolderDown class="h-60 w-60 p-5 mt-10 mb-10 mx-auto text-white" :alt="$t('firmware.title')" />
+                <FolderDown
+                  class="h-60 w-60 p-5 mt-10 mb-10 mx-auto text-white"
+                  :alt="$t('firmware.title')"
+                />
                 <Firmware />
               </div>
-              <h2 class="text-lg sm:text-xl font-medium title-font text-white mt-5">{{ $t('firmware.title') }}</h2>
+              <h2 class="text-lg sm:text-xl font-medium title-font text-white mt-5">
+                {{ $t('firmware.title') }}
+              </h2>
               <p class="text-sm sm:text-base leading-relaxed mt-2">
                 {{ $t('firmware.instructions') }}
               </p>
@@ -44,7 +70,9 @@
                 <Zap class="h-60 w-60 p-5 mt-10 mb-10 mx-auto text-white" />
                 <Flash />
               </div>
-              <h2 class="text-lg sm:text-xl font-medium title-font text-white mt-5">Flash</h2>
+              <h2 class="text-lg sm:text-xl font-medium title-font text-white mt-5">
+                Flash
+              </h2>
               <p class="text-sm sm:text-base leading-relaxed mt-2">
                 {{ $t('flash.instructions') }}
               </p>
@@ -53,13 +81,26 @@
         </div>
       </transition>
       <div class="flex flex-wrap justify-center gap-1 mt-4">
-        <button type="button" v-if="!serialMonitorStore.isConnected" @click="monitorSerial" class="bottom-button border-meshtastic text-meshtastic">
+        <button
+          v-if="!serialMonitorStore.isConnected"
+          type="button"
+          class="bottom-button border-meshtastic text-meshtastic"
+          @click="monitorSerial"
+        >
           {{ $t('buttons.serial_monitor') }} <Terminal class="h-4 w-4 shrink-0" />
         </button>
-        <a href="https://meshtastic.org/docs" v-if="!serialMonitorStore.isConnected" class="bottom-button border-meshtastic text-meshtastic">
+        <a
+          v-if="!serialMonitorStore.isConnected"
+          href="https://meshtastic.org/docs"
+          class="bottom-button border-meshtastic text-meshtastic"
+        >
           {{ $t('buttons.meshtastic_docs') }} <BookOpen class="h-4 w-4 shrink-0" />
         </a>
-        <a href="https://github.com/meshtastic/web-flasher" v-if="!serialMonitorStore.isConnected" class="bottom-button border-meshtastic text-meshtastic">
+        <a
+          v-if="!serialMonitorStore.isConnected"
+          href="https://github.com/meshtastic/web-flasher"
+          class="bottom-button border-meshtastic text-meshtastic"
+        >
           {{ $t('buttons.contribute') }}
           <Github class="w-4 h-4 shrink-0" />
         </a>
@@ -68,53 +109,64 @@
     </section>
 
     <SerialMonitor />
-    
+
     <ToastNotifications />
 
-    <footer id="footer" class="halloween-theme footer text-white mt-4 py-4">
+    <footer
+      id="footer"
+      class="halloween-theme footer text-white mt-4 py-4"
+    >
       <canvas>
         <div class="container mx-auto px-3 sm:px-5 py-2 sm:py-4 text-center">
           <p class="text-xs sm:text-sm">
             Powered by
             <a href="https://vercel.com/?utm_source=meshtastic&utm_campaign=oss">▲ Vercel</a>
-            <span class="hidden sm:inline">|</span><br class="sm:hidden" />
+            <span class="hidden sm:inline">|</span><br class="sm:hidden">
             Meshtastic® is a registered trademark of Meshtastic LLC.
-            <span class="hidden sm:inline">|</span><br class="sm:hidden" />
+            <span class="hidden sm:inline">|</span><br class="sm:hidden">
             <a href="https://meshtastic.org/docs/legal">Legal Information</a>.
           </p>
         </div>
       </canvas>
     </footer>
     <div class="fixed right-2 sm:-end-4 bottom-4 sm:bottom-6 group z-50">
-      <button type="button" :disabled="true" 
-        :class="{ 
+      <button
+        type="button"
+        :disabled="true"
+        :class="{
           'text-purple-400 border-purple-400 animate-pulse': serialMonitorStore.isConnected && !serialMonitorStore.isReaderLocked,
           'border-meshtastic text-meshtastic animate-pulse': (serialMonitorStore.isConnected && serialMonitorStore.isReaderLocked) || firmwareStore.isConnected,
-          'border-gray-700 text-gray-300': !isConnected
-        }" 
-        class="inline border focus:ring-4 focus:outline-none font-medium rounded-lg text-xs px-2 sm:px-4 py-1 text-center backdrop-blur-sm hover:shadow transition duration-300 ease-in-out">
+          'border-gray-700 text-gray-300': !isConnected,
+        }"
+        class="inline border focus:ring-4 focus:outline-none font-medium rounded-lg text-xs px-2 sm:px-4 py-1 text-center backdrop-blur-sm hover:shadow transition duration-300 ease-in-out"
+      >
         {{ connectionButtonLabel }}
-        <span v-if="serialMonitorStore.isConnected && !serialMonitorStore.isReaderLocked" class="inline-flex w-2 h-2 me-2 bg-purple-400 rounded-full"></span>
-        <span v-else-if="isConnected" class="inline-flex w-2 h-2 me-2 bg-green-500 rounded-full"></span>
-        <span v-else class="inline-flex w-2 h-2 me-2 bg-gray-300 rounded-full"></span>
+        <span
+          v-if="serialMonitorStore.isConnected && !serialMonitorStore.isReaderLocked"
+          class="inline-flex w-2 h-2 me-2 bg-purple-400 rounded-full"
+        />
+        <span
+          v-else-if="isConnected"
+          class="inline-flex w-2 h-2 me-2 bg-green-500 rounded-full"
+        />
+        <span
+          v-else
+          class="inline-flex w-2 h-2 me-2 bg-gray-300 rounded-full"
+        />
       </button>
     </div>
   </div>
 </template>
 
 <script setup>
-import 'flowbite';
-import { useI18n } from 'vue-i18n';
-const { t } = useI18n();
-import { onMounted } from 'vue';
-
 import {
   initAccordions,
   initDrawers,
   initDropdowns,
   initModals,
-  initTooltips,
-} from 'flowbite';
+  initTooltips } from 'flowbite'
+import { useI18n } from 'vue-i18n'
+import { onMounted } from 'vue'
 
 import {
   Zap,
@@ -122,71 +174,74 @@ import {
   Terminal,
   FolderDown,
   Github,
-} from 'lucide-vue-next';
+} from 'lucide-vue-next'
 
-import { useDeviceStore } from './stores/deviceStore';
-import { useFirmwareStore } from './stores/firmwareStore';
-import { useSerialMonitorStore } from './stores/serialMonitorStore';
+import { useDeviceStore } from './stores/deviceStore'
+import { useFirmwareStore } from './stores/firmwareStore'
+import { useSerialMonitorStore } from './stores/serialMonitorStore'
 
-const serialMonitorStore = useSerialMonitorStore();
-const firmwareStore = useFirmwareStore();
-const deviceStore = useDeviceStore();
+const { t } = useI18n()
+
+const serialMonitorStore = useSerialMonitorStore()
+const firmwareStore = useFirmwareStore()
+const deviceStore = useDeviceStore()
 
 const monitorSerial = async () => {
-  await serialMonitorStore.monitorSerial();
-};
+  await serialMonitorStore.monitorSerial()
+}
 
 const selectedDeviceImage = computed(() => {
   if (deviceStore.selectedTarget?.images?.length) {
-    return `/img/devices/${deviceStore.selectedTarget.images[0]}`;
+    return `/img/devices/${deviceStore.selectedTarget.images[0]}`
   }
-  return '/img/devices/unknown.svg';
-});
+  return '/img/devices/unknown.svg'
+})
 
 const connectionButtonLabel = computed(() => {
   if (firmwareStore.isFlashing) {
-    return t('state.flashing');
+    return t('state.flashing')
   }
   if ((serialMonitorStore.isConnected && !serialMonitorStore.isReaderLocked) || (firmwareStore.isConnected && !firmwareStore.isReaderLocked)) {
-    return t('state.disconnecting');
+    return t('state.disconnecting')
   }
-  return isConnected.value ? t('state.connected') : t('state.disconnected');
-});
+  return isConnected.value ? t('state.connected') : t('state.disconnected')
+})
 
 const isConnected = computed(() => {
-  return serialMonitorStore.isConnected || firmwareStore.isConnected;
-});
+  return serialMonitorStore.isConnected || firmwareStore.isConnected
+})
 
 // WebSerial API support check
 const isWebSerialSupported = computed(() => {
-  return 'serial' in navigator;
-});
-const konamiKeys = ['ArrowUp', 'ArrowUp', 'ArrowDown', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'ArrowLeft', 'ArrowRight', 'b', 'a'];
-const konamiCodeIndex = ref(0);
+  return 'serial' in navigator
+})
+const konamiKeys = ['ArrowUp', 'ArrowUp', 'ArrowDown', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'ArrowLeft', 'ArrowRight', 'b', 'a']
+const konamiCodeIndex = ref(0)
 window.addEventListener('keydown', (event) => {
   if (event.key === konamiKeys[konamiCodeIndex.value]) {
-    console.log('konami code key match', konamiCodeIndex.value);
-    konamiCodeIndex.value++;
+    console.log('konami code key match', konamiCodeIndex.value)
+    konamiCodeIndex.value++
     if (konamiCodeIndex.value === konamiKeys.length) {
       console.log('Unlocking pre-release section')
-      document.body.classList.add('konami-code');
-      document.getElementById('main').classList.add('konami-code');
-      document.getElementById('footer').classList.add('konami-code');
-      firmwareStore.$state.prereleaseUnlocked = true;
-      konamiCodeIndex.value = 0;
+      document.body.classList.add('konami-code')
+      document.getElementById('main').classList.add('konami-code')
+      document.getElementById('footer').classList.add('konami-code')
+      firmwareStore.$state.prereleaseUnlocked = true
+      konamiCodeIndex.value = 0
     }
-  } else {
-    konamiCodeIndex.value = 0;
   }
-});
+  else {
+    konamiCodeIndex.value = 0
+  }
+})
 
 onMounted(() => {
-  initDropdowns();
-  initModals();
-  initTooltips();
-  initDrawers();
-  initAccordions();
-});
+  initDropdowns()
+  initModals()
+  initTooltips()
+  initDrawers()
+  initAccordions()
+})
 </script>
 
 <style>
@@ -229,7 +284,7 @@ onMounted(() => {
     /* Standard */
     transition: all 1s ease-in;
   }
-  .invert { 
+  .invert {
     -webkit-filter: invert(1);
     filter: invert(1);
   }

--- a/components/Device.vue
+++ b/components/Device.vue
@@ -1,104 +1,238 @@
 <template>
-    <div>
-        <button id="selectDeviceButton" data-modal-target="device-modal" data-modal-toggle="device-modal" class="display-inline content-center text-black bg-meshtastic hover:bg-gray-200 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center inline-flex items-center" type="button">
-            {{ selectedTarget.replace('_', '-') }}
-        </button>
-        <button data-tooltip-target="tooltip-auto" class="mx-2 display-inline content-center px-3 py-2 text-xs font-medium text-center  hover:bg-gray-200 focus:ring-4 focus:outline-none focus:ring-blue-300 rounded-lg inline-flex items-center text-white hover:text-black"
-            type="button"
-            @click="() => store.autoSelectHardware($t)">
-            <Rocket class="h-4 w-4" :class="{'animate-bounce': !store.$state.selectedTarget?.hwModel }" />
-        </button>
-        <div id="tooltip-auto" role="tooltip" class="absolute z-10 invisible inline-block px-3 py-2 text-sm font-medium text-white transition-opacity duration-300 rounded-lg shadow-sm opacity-0 tooltip bg-gray-700">
-            {{ $t('device.auto_detect') }}
-            <div class="tooltip-arrow" data-popper-arrow></div>
-        </div>
-        <div id="device-modal" tabindex="-1" aria-hidden="true" class="dark hidden overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 justify-center items-center w-full md:inset-0 h-[calc(100%-1rem)] max-h-full">
-            <div class="relative p-2 sm:p-4 w-full max-h-full" :class="{ 'max-w-4xl': vendorCobrandingTag.length > 0, 'max-w-7xl': vendorCobrandingTag.length == 0 }">
-                <div class="relative rounded-lg shadow bg-zinc-700">
-                    <DeviceHeader />
-                    <div class="flex items-center justify-center py-2 px-2 overflow-x-auto">
-                        <button @click="store.setSelectedTag('all')" type="button" class="text-gray-100 border-gray-900 hover:border-gray-400 bg-green-800 hover:bg-green-700 focus:ring focus:ring-gray-200 rounded-md text-xs px-2 py-1.5 text-center me-1 whitespace-nowrap flex-shrink-0">{{ $t('device.all_devices') }}</button>
-                        <button v-if="vendorCobrandingTag.length === 0" @click="store.setSelectedTag('RAK')" type="button" class="text-gray-100 border-gray-900 hover:border-gray-400 bg-gray-900 hover:bg-gray-800 focus:ring focus:ring-gray-200 rounded-md text-xs px-2 py-1.5 text-center me-1 whitespace-nowrap flex-shrink-0">RAK</button>
-                        <button v-if="vendorCobrandingTag.length === 0" @click="store.setSelectedTag('B&Q')" type="button" class="text-gray-100 border-gray-900 hover:border-gray-400 bg-gray-900 hover:bg-gray-800 focus:ring focus:ring-gray-200 rounded-md text-xs px-2 py-1.5 text-center me-1 whitespace-nowrap flex-shrink-0">B&Q</button>
-                        <button v-if="vendorCobrandingTag.length === 0" @click="store.setSelectedTag('LilyGo')" type="button" class="text-gray-100 border-gray-900 hover:border-gray-400 bg-gray-900 hover:bg-gray-800 focus:ring focus:ring-gray-200 rounded-md text-xs px-2 py-1.5 text-center me-1 whitespace-nowrap flex-shrink-0">LilyGo</button>
-                        <button v-if="vendorCobrandingTag.length === 0" @click="store.setSelectedTag('Seeed')" type="button" class="text-gray-100 border-gray-900 hover:border-gray-400 bg-gray-900 hover:bg-gray-800 focus:ring focus:ring-gray-200 rounded-md text-xs px-2 py-1.5 text-center me-1 whitespace-nowrap flex-shrink-0">Seeed</button>
-                        <button v-if="vendorCobrandingTag.length === 0" @click="store.setSelectedTag('Heltec')" type="button" class="text-gray-100 border-gray-900 hover:border-gray-400 bg-gray-900 hover:bg-gray-800 focus:ring focus:ring-gray-200 rounded-md text-xs px-2 py-1.5 text-center me-1 whitespace-nowrap flex-shrink-0">Heltec</button>
-                        <button v-if="vendorCobrandingTag.length === 0" @click="store.setSelectedTag('Elecrow')" type="button" class="text-gray-100 border-gray-900 hover:border-gray-400 bg-gray-900 hover:bg-gray-800 focus:ring focus:ring-gray-200 rounded-md text-xs px-2 py-1.5 text-center me-1 whitespace-nowrap flex-shrink-0">Elecrow</button>
-                        <button v-if="vendorCobrandingTag.length === 0" @click="store.setSelectedTag('M5Stack')" type="button" class="text-gray-100 border-gray-900 hover:border-gray-400 bg-gray-900 hover:bg-gray-800 focus:ring focus:ring-gray-200 rounded-md text-xs px-2 py-1.5 text-center me-1 whitespace-nowrap flex-shrink-0">M5Stack</button>
-                        <button v-if="vendorCobrandingTag.length === 0" @click="store.setSelectedTag('NomadStar')" type="button" class="text-gray-100 border-gray-900 hover:border-gray-400 bg-gray-900 hover:bg-gray-800 focus:ring focus:ring-gray-200 rounded-md text-xs px-2 py-1.5 text-center me-1 whitespace-nowrap flex-shrink-0">NomadStar</button>
-                        <button v-if="vendorCobrandingTag.length === 0" @click="store.setSelectedTag('muzi')" type="button" class="text-gray-100 border-gray-900 hover:border-gray-400 bg-gray-900 hover:bg-gray-800 focus:ring focus:ring-gray-200 rounded-md text-xs px-2 py-1.5 text-center me-1 whitespace-nowrap flex-shrink-0">muzi ᴡᴏʀᴋꜱ</button>
-                        <br />
-                        <button @click="store.setSelectedTag(arch)" v-for="arch in store.allArchs" type="button" class="border-gray-900 focus:ring focus:ring-gray-200 hover:border-gray-700 bg-indigo-500 hover:bg-indigo-400 text-gray-100 rounded-md text-xs px-2 py-1.5 text-center me-1 whitespace-nowrap flex-shrink-0">{{ arch }}</button>
-                    </div>
-                    <div class="p-3 sm:p-4 mb-1 mx-2 my-2 text-xs sm:text-sm rounded-lg bg-gray-800 text-gray-100" role="alert">
-                        <span class="font-medium">
-                            <Info class="h-4 w-4 inline" />
-                            {{ $t('device.subheading') }} <button type="button" @click="() => store.autoSelectHardware($t)" class="bg-meshtastic inline-flex py-1.5 sm:py-2 mx-1 sm:mx-2 px-2 sm:px-3 text-xs sm:text-sm font-medium rounded-md hover:bg-white text-black"><Rocket class="h-3 w-3 sm:h-4 sm:w-4 text-black" /> {{ $t('device.auto_detect') }}</button>
-                        </span>
-                    </div>
-                    <div v-if="vendorCobrandingTag.length === 0" class="p-1 sm:p-2 m-1 sm:m-2 flex flex-wrap items-center justify-center">
-                        <div class="w-full text-center">
-                            <h2 class="text-lg sm:text-xl">{{ $t('device.supported_devices') }}</h2>
-                        </div>
-                        <div v-for="device in store.sortedDevices.filter(d => isSupporterDevice(d) && d.supportLevel != 3)" class="w-full sm:w-auto sm:max-w-sm border hover:border-gray-300 border-gray-600 rounded-lg m-1 sm:m-2 cursor-pointer hover:scale-105 shadow hover:shadow-[0_35px_60px_-15px_rgba(200,200,200,.3)]" @click="setSelectedTarget(device)">
-                            <DeviceDetail :device="device" />
-                        </div>
-                        <hr class="w-full border-gray-400 my-4" />
-                        <div v-if="store.sortedDevices.filter(d => !isSupporterDevice(d) || d.supportLevel == 3).length > 0" class="w-full text-center">
-                            <h2 class="text-lg sm:text-xl text-yellow-400">{{ $t('device.diy_devices') }}</h2>
-                        </div>
-                        <div v-for="device in store.sortedDevices.filter(d => !isSupporterDevice(d) || d.supportLevel == 3)" class="w-full sm:w-auto sm:max-w-sm border hover:border-gray-300 border-gray-600 rounded-lg m-1 sm:m-2 cursor-pointer hover:scale-105 shadow hover:shadow-2xl" @click="setSelectedTarget(device)">
-                            <DeviceDetail :device="device" />
-                        </div>
-                    </div>
-                    <div v-else class="p-1 sm:p-2 m-1 sm:m-2 flex flex-wrap items-center justify-center">
-                        <div v-for="device in store.sortedDevices" class="w-full sm:w-auto sm:max-w-sm border hover:border-gray-300 border-gray-600 rounded-lg m-1 sm:m-2 cursor-pointer hover:scale-105 hover:shadow-2xl" @click="store.setSelectedTarget(device)">
-                            <DeviceDetail :device="device" />
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
+  <div>
+    <button
+      id="selectDeviceButton"
+      data-modal-target="device-modal"
+      data-modal-toggle="device-modal"
+      class="display-inline content-center text-black bg-meshtastic hover:bg-gray-200 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center inline-flex items-center"
+      type="button"
+    >
+      {{ selectedTarget.replace('_', '-') }}
+    </button>
+    <button
+      data-tooltip-target="tooltip-auto"
+      class="mx-2 display-inline content-center px-3 py-2 text-xs font-medium text-center  hover:bg-gray-200 focus:ring-4 focus:outline-none focus:ring-blue-300 rounded-lg inline-flex items-center text-white hover:text-black"
+      type="button"
+      @click="() => store.autoSelectHardware($t)"
+    >
+      <Rocket
+        class="h-4 w-4"
+        :class="{ 'animate-bounce': !store.$state.selectedTarget?.hwModel }"
+      />
+    </button>
+    <div
+      id="tooltip-auto"
+      role="tooltip"
+      class="absolute z-10 invisible inline-block px-3 py-2 text-sm font-medium text-white transition-opacity duration-300 rounded-lg shadow-sm opacity-0 tooltip bg-gray-700"
+    >
+      {{ $t('device.auto_detect') }}
+      <div
+        class="tooltip-arrow"
+        data-popper-arrow
+      />
     </div>
+    <div
+      id="device-modal"
+      tabindex="-1"
+      aria-hidden="true"
+      class="dark hidden overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 justify-center items-center w-full md:inset-0 h-[calc(100%-1rem)] max-h-full"
+    >
+      <div
+        class="relative p-2 sm:p-4 w-full max-h-full"
+        :class="{ 'max-w-4xl': vendorCobrandingTag.length > 0, 'max-w-7xl': vendorCobrandingTag.length == 0 }"
+      >
+        <div class="relative rounded-lg shadow bg-zinc-700">
+          <DeviceHeader />
+          <div class="flex items-center justify-center py-2 px-2 overflow-x-auto">
+            <button
+              type="button"
+              class="text-gray-100 border-gray-900 hover:border-gray-400 bg-green-800 hover:bg-green-700 focus:ring focus:ring-gray-200 rounded-md text-xs px-2 py-1.5 text-center me-1 whitespace-nowrap flex-shrink-0"
+              @click="store.setSelectedTag('all')"
+            >
+              {{ $t('device.all_devices') }}
+            </button>
+            <button
+              v-if="vendorCobrandingTag.length === 0"
+              type="button"
+              class="text-gray-100 border-gray-900 hover:border-gray-400 bg-gray-900 hover:bg-gray-800 focus:ring focus:ring-gray-200 rounded-md text-xs px-2 py-1.5 text-center me-1 whitespace-nowrap flex-shrink-0"
+              @click="store.setSelectedTag('RAK')"
+            >
+              RAK
+            </button>
+            <button
+              v-if="vendorCobrandingTag.length === 0"
+              type="button"
+              class="text-gray-100 border-gray-900 hover:border-gray-400 bg-gray-900 hover:bg-gray-800 focus:ring focus:ring-gray-200 rounded-md text-xs px-2 py-1.5 text-center me-1 whitespace-nowrap flex-shrink-0"
+              @click="store.setSelectedTag('B&Q')"
+            >
+              B&Q
+            </button>
+            <button
+              v-if="vendorCobrandingTag.length === 0"
+              type="button"
+              class="text-gray-100 border-gray-900 hover:border-gray-400 bg-gray-900 hover:bg-gray-800 focus:ring focus:ring-gray-200 rounded-md text-xs px-2 py-1.5 text-center me-1 whitespace-nowrap flex-shrink-0"
+              @click="store.setSelectedTag('LilyGo')"
+            >
+              LilyGo
+            </button>
+            <button
+              v-if="vendorCobrandingTag.length === 0"
+              type="button"
+              class="text-gray-100 border-gray-900 hover:border-gray-400 bg-gray-900 hover:bg-gray-800 focus:ring focus:ring-gray-200 rounded-md text-xs px-2 py-1.5 text-center me-1 whitespace-nowrap flex-shrink-0"
+              @click="store.setSelectedTag('Seeed')"
+            >
+              Seeed
+            </button>
+            <button
+              v-if="vendorCobrandingTag.length === 0"
+              type="button"
+              class="text-gray-100 border-gray-900 hover:border-gray-400 bg-gray-900 hover:bg-gray-800 focus:ring focus:ring-gray-200 rounded-md text-xs px-2 py-1.5 text-center me-1 whitespace-nowrap flex-shrink-0"
+              @click="store.setSelectedTag('Heltec')"
+            >
+              Heltec
+            </button>
+            <button
+              v-if="vendorCobrandingTag.length === 0"
+              type="button"
+              class="text-gray-100 border-gray-900 hover:border-gray-400 bg-gray-900 hover:bg-gray-800 focus:ring focus:ring-gray-200 rounded-md text-xs px-2 py-1.5 text-center me-1 whitespace-nowrap flex-shrink-0"
+              @click="store.setSelectedTag('Elecrow')"
+            >
+              Elecrow
+            </button>
+            <button
+              v-if="vendorCobrandingTag.length === 0"
+              type="button"
+              class="text-gray-100 border-gray-900 hover:border-gray-400 bg-gray-900 hover:bg-gray-800 focus:ring focus:ring-gray-200 rounded-md text-xs px-2 py-1.5 text-center me-1 whitespace-nowrap flex-shrink-0"
+              @click="store.setSelectedTag('M5Stack')"
+            >
+              M5Stack
+            </button>
+            <button
+              v-if="vendorCobrandingTag.length === 0"
+              type="button"
+              class="text-gray-100 border-gray-900 hover:border-gray-400 bg-gray-900 hover:bg-gray-800 focus:ring focus:ring-gray-200 rounded-md text-xs px-2 py-1.5 text-center me-1 whitespace-nowrap flex-shrink-0"
+              @click="store.setSelectedTag('NomadStar')"
+            >
+              NomadStar
+            </button>
+            <button
+              v-if="vendorCobrandingTag.length === 0"
+              type="button"
+              class="text-gray-100 border-gray-900 hover:border-gray-400 bg-gray-900 hover:bg-gray-800 focus:ring focus:ring-gray-200 rounded-md text-xs px-2 py-1.5 text-center me-1 whitespace-nowrap flex-shrink-0"
+              @click="store.setSelectedTag('muzi')"
+            >
+              muzi ᴡᴏʀᴋꜱ
+            </button>
+            <br>
+            <button
+              v-for="arch in store.allArchs"
+              type="button"
+              class="border-gray-900 focus:ring focus:ring-gray-200 hover:border-gray-700 bg-indigo-500 hover:bg-indigo-400 text-gray-100 rounded-md text-xs px-2 py-1.5 text-center me-1 whitespace-nowrap flex-shrink-0"
+              @click="store.setSelectedTag(arch)"
+            >
+              {{ arch }}
+            </button>
+          </div>
+          <div
+            class="p-3 sm:p-4 mb-1 mx-2 my-2 text-xs sm:text-sm rounded-lg bg-gray-800 text-gray-100"
+            role="alert"
+          >
+            <span class="font-medium">
+              <Info class="h-4 w-4 inline" />
+              {{ $t('device.subheading') }} <button
+                type="button"
+                class="bg-meshtastic inline-flex py-1.5 sm:py-2 mx-1 sm:mx-2 px-2 sm:px-3 text-xs sm:text-sm font-medium rounded-md hover:bg-white text-black"
+                @click="() => store.autoSelectHardware($t)"
+              ><Rocket class="h-3 w-3 sm:h-4 sm:w-4 text-black" /> {{ $t('device.auto_detect') }}</button>
+            </span>
+          </div>
+          <div
+            v-if="vendorCobrandingTag.length === 0"
+            class="p-1 sm:p-2 m-1 sm:m-2 flex flex-wrap items-center justify-center"
+          >
+            <div class="w-full text-center">
+              <h2 class="text-lg sm:text-xl">
+                {{ $t('device.supported_devices') }}
+              </h2>
+            </div>
+            <div
+              v-for="device in store.sortedDevices.filter(d => isSupporterDevice(d) && d.supportLevel != 3)"
+              class="w-full sm:w-auto sm:max-w-sm border hover:border-gray-300 border-gray-600 rounded-lg m-1 sm:m-2 cursor-pointer hover:scale-105 shadow hover:shadow-[0_35px_60px_-15px_rgba(200,200,200,.3)]"
+              @click="setSelectedTarget(device)"
+            >
+              <DeviceDetail :device="device" />
+            </div>
+            <hr class="w-full border-gray-400 my-4">
+            <div
+              v-if="store.sortedDevices.filter(d => !isSupporterDevice(d) || d.supportLevel == 3).length > 0"
+              class="w-full text-center"
+            >
+              <h2 class="text-lg sm:text-xl text-yellow-400">
+                {{ $t('device.diy_devices') }}
+              </h2>
+            </div>
+            <div
+              v-for="device in store.sortedDevices.filter(d => !isSupporterDevice(d) || d.supportLevel == 3)"
+              class="w-full sm:w-auto sm:max-w-sm border hover:border-gray-300 border-gray-600 rounded-lg m-1 sm:m-2 cursor-pointer hover:scale-105 shadow hover:shadow-2xl"
+              @click="setSelectedTarget(device)"
+            >
+              <DeviceDetail :device="device" />
+            </div>
+          </div>
+          <div
+            v-else
+            class="p-1 sm:p-2 m-1 sm:m-2 flex flex-wrap items-center justify-center"
+          >
+            <div
+              v-for="device in store.sortedDevices"
+              class="w-full sm:w-auto sm:max-w-sm border hover:border-gray-300 border-gray-600 rounded-lg m-1 sm:m-2 cursor-pointer hover:scale-105 hover:shadow-2xl"
+              @click="store.setSelectedTarget(device)"
+            >
+              <DeviceDetail :device="device" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </template>
 
 <script lang="ts" setup>
-import type { DeviceHardware } from '~/types/api';
+import type { DeviceHardware } from '~/types/api'
 import {
   supportedVendorDeviceTags,
   vendorCobrandingTag,
-} from '~/types/resources';
+} from '~/types/resources'
 
 import {
   Info,
   Rocket,
-} from 'lucide-vue-next';
+} from 'lucide-vue-next'
 
-import { useDeviceStore } from '../stores/deviceStore';
-import { useFirmwareStore } from '../stores/firmwareStore';
-import DeviceDetail from './DeviceDetail.vue';
-import { useI18n } from 'vue-i18n';
+import { useDeviceStore } from '../stores/deviceStore'
+import { useFirmwareStore } from '../stores/firmwareStore'
+import DeviceDetail from './DeviceDetail.vue'
+import { useI18n } from 'vue-i18n'
 
-const { t } = useI18n();
+const { t } = useI18n()
 
-const store = useDeviceStore();
-const firmwareStore = useFirmwareStore();
-store.fetchList();
+const store = useDeviceStore()
+const firmwareStore = useFirmwareStore()
+store.fetchList()
 
 const isSupporterDevice = (device: DeviceHardware) => {
-  return device.tags?.some((tag: string) => supportedVendorDeviceTags.includes(tag));
+  return device.tags?.some((tag: string) => supportedVendorDeviceTags.includes(tag))
 }
 
 const setSelectedTarget = (device: DeviceHardware) => {
-  store.setSelectedTarget(device);
-  firmwareStore.clearState();
+  store.setSelectedTarget(device)
+  firmwareStore.clearState()
 
   // Auto-select MUI for devices that support it (after clearing state)
   if (device.hasMui === true) {
-    firmwareStore.$state.shouldInstallMui = true;
+    firmwareStore.$state.shouldInstallMui = true
   }
 }
 
-const selectedTarget = computed(() => store.$state.selectedTarget?.hwModel ? store.$state.selectedTarget?.displayName : t('device.select_device'));
-
+const selectedTarget = computed(() => store.$state.selectedTarget?.hwModel ? store.$state.selectedTarget?.displayName : t('device.select_device'))
 </script>

--- a/components/DeviceDetail.vue
+++ b/components/DeviceDetail.vue
@@ -1,48 +1,89 @@
 <template>
-    <div class="flex flex-col items-center p-2 w-full sm:w-56">
-        <h5 class="mb-1 text-xs sm:text-[0.75rem] text-white" :class="{ 'text-yellow-400': !isSupporterDevice(props.device) }">
-            {{ props.device.displayName }}
-            <div class="float-right items-center mx-1">
-              <BadgeCheck v-if="isSupporterDevice(props.device)" class="w-6 h-6 text-green-400 opacity-75" />
-              <ShieldAlert v-else class="w-6 h-6 text-yellow-400 opacity-75" />
-            </div>
-        </h5>
-        <div class="flex justify-start w-full">
-          <span class="text-xs font-medium me-2 px-2.5 py-0.5 h-6 rounded bg-blue-900 text-gray-100">
-            {{ props.device.architecture.replace('-','') }}
-          </span>
-          <span v-for="tag in props.device.tags" class="text-xs font-medium px-2.5 py-0.5 h-6 rounded bg-indigo-500 text-gray-100 me-1">
-            {{ tag }}
-          </span>
-          <img v-if="props.device.hasMui" src="/img/Meshtastic-UI-Short.svg" class="h-6 m-1 pb-1" alt="Meshtastic UI" />
-        </div>
-        <div v-if="props.device.images && isSupporterDevice(props.device)" class="relative w-24 h-24 sm:w-32 sm:h-32 m-2">
-            <img v-for="(image, index) in props.device.images" :key="image" class="absolute inset-0 w-24 h-24 sm:w-32 sm:h-32" :style="{ left: `${index * 15}px` }" :src="`/img/devices/${image}`" :alt="props.device.displayName"/>
-        </div>
-        <img v-else class="w-24 h-24 sm:w-32 sm:h-32 m-2" :src="`/img/devices/unknown.svg`" :alt="props.device.displayName"/>
-        <div class="flex justify-start w-full">
-          <div v-if="props.device.supportLevel! < 3" class="product-link">
-            <a :href="deviceUrl" target="_blank" rel="noopener" title="Manufacturer page (external link)" class="text-gray-100 hover:text-white">
-              <Link2Icon class="w-6 h-6 text-meshtastic transition-transform duration-300 ease-in-out hover:scale-110 hover:rotate-12 cursor-default" />
-            </a>
-          </div>
-        </div>
+  <div class="flex flex-col items-center p-2 w-full sm:w-56">
+    <h5
+      class="mb-1 text-xs sm:text-[0.75rem] text-white"
+      :class="{ 'text-yellow-400': !isSupporterDevice(props.device) }"
+    >
+      {{ props.device.displayName }}
+      <div class="float-right items-center mx-1">
+        <BadgeCheck
+          v-if="isSupporterDevice(props.device)"
+          class="w-6 h-6 text-green-400 opacity-75"
+        />
+        <ShieldAlert
+          v-else
+          class="w-6 h-6 text-yellow-400 opacity-75"
+        />
+      </div>
+    </h5>
+    <div class="flex justify-start w-full">
+      <span class="text-xs font-medium me-2 px-2.5 py-0.5 h-6 rounded bg-blue-900 text-gray-100">
+        {{ props.device.architecture.replace('-', '') }}
+      </span>
+      <span
+        v-for="tag in props.device.tags"
+        class="text-xs font-medium px-2.5 py-0.5 h-6 rounded bg-indigo-500 text-gray-100 me-1"
+      >
+        {{ tag }}
+      </span>
+      <img
+        v-if="props.device.hasMui"
+        src="/img/Meshtastic-UI-Short.svg"
+        class="h-6 m-1 pb-1"
+        alt="Meshtastic UI"
+      >
     </div>
+    <div
+      v-if="props.device.images && isSupporterDevice(props.device)"
+      class="relative w-24 h-24 sm:w-32 sm:h-32 m-2"
+    >
+      <img
+        v-for="(image, index) in props.device.images"
+        :key="image"
+        class="absolute inset-0 w-24 h-24 sm:w-32 sm:h-32"
+        :style="{ left: `${index * 15}px` }"
+        :src="`/img/devices/${image}`"
+        :alt="props.device.displayName"
+      >
+    </div>
+    <img
+      v-else
+      class="w-24 h-24 sm:w-32 sm:h-32 m-2"
+      :src="`/img/devices/unknown.svg`"
+      :alt="props.device.displayName"
+    >
+    <div class="flex justify-start w-full">
+      <div
+        v-if="props.device.supportLevel! < 3"
+        class="product-link"
+      >
+        <a
+          :href="deviceUrl"
+          target="_blank"
+          rel="noopener"
+          title="Manufacturer page (external link)"
+          class="text-gray-100 hover:text-white"
+        >
+          <Link2Icon class="w-6 h-6 text-meshtastic transition-transform duration-300 ease-in-out hover:scale-110 hover:rotate-12 cursor-default" />
+        </a>
+      </div>
+    </div>
+  </div>
 </template>
 
 <script lang="ts" setup>
-import type { DeviceHardware } from '~/types/api';
-import { supportedVendorDeviceTags } from '~/types/resources';
-import { useFirmwareStore } from '../stores/firmwareStore';
-import { computed } from 'vue';
-
-const firmwareStore = useFirmwareStore();
+import type { DeviceHardware } from '~/types/api'
+import { supportedVendorDeviceTags } from '~/types/resources'
+import { useFirmwareStore } from '../stores/firmwareStore'
+import { computed } from 'vue'
 
 import {
   BadgeCheck,
   ShieldAlert,
-  Link2Icon
-} from 'lucide-vue-next';
+  Link2Icon,
+} from 'lucide-vue-next'
+
+const firmwareStore = useFirmwareStore()
 
 const props = defineProps({
   device: {
@@ -53,13 +94,13 @@ const props = defineProps({
 
 const isSupporterDevice = (device: DeviceHardware) => {
   // Add your logic to determine if the device is a supporter device
-  return device.tags?.some(t => supportedVendorDeviceTags.includes(t));
-};
+  return device.tags?.some(t => supportedVendorDeviceTags.includes(t))
+}
 
 const deviceUrl = computed(() => {
   if (props.device.url) {
-    return props.device.url;
+    return props.device.url
   }
-  return `https://msh.to/${props.device.platformioTarget}`;
-});
+  return `https://msh.to/${props.device.platformioTarget}`
+})
 </script>

--- a/components/DeviceHeader.vue
+++ b/components/DeviceHeader.vue
@@ -1,17 +1,19 @@
 <template>
-    <div class="flex items-center justify-between p-3 sm:p-4 md:p-5 border-b rounded-t order-gray-600">
-        <h3 class="text-lg sm:text-xl font-semibold text-white">
-            {{ $t('device.header') }}
-        </h3>
-        <button type="button"
-            class="text-gray-400 bg-transparent hover:bg-gray-600 hover:text-white rounded-lg text-sm h-8 w-8 ms-auto inline-flex justify-center items-center"
-            data-modal-toggle="device-modal">
-            <X class="w-3 h-3" />
-            <span class="sr-only">{{ $t('actions.close_dialog') }}</span>
-        </button>
-    </div>
+  <div class="flex items-center justify-between p-3 sm:p-4 md:p-5 border-b rounded-t order-gray-600">
+    <h3 class="text-lg sm:text-xl font-semibold text-white">
+      {{ $t('device.header') }}
+    </h3>
+    <button
+      type="button"
+      class="text-gray-400 bg-transparent hover:bg-gray-600 hover:text-white rounded-lg text-sm h-8 w-8 ms-auto inline-flex justify-center items-center"
+      data-modal-toggle="device-modal"
+    >
+      <X class="w-3 h-3" />
+      <span class="sr-only">{{ $t('actions.close_dialog') }}</span>
+    </button>
+  </div>
 </template>
 
 <script setup>
-import { X } from 'lucide-vue-next';
+import { X } from 'lucide-vue-next'
 </script>

--- a/components/Firmware.vue
+++ b/components/Firmware.vue
@@ -1,168 +1,221 @@
 <template>
-    <div>
-        <button id="dropdownFirmwareButton" data-dropdown-toggle="dropdownFirmware"
-            class="content-center text-black bg-meshtastic hover:bg-gray-200 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center inline-flex items-center disabled:bg-gray-500"
-            :class="{ 'animate-bounce': store.prereleaseUnlocked && !store.$state.selectedFirmware?.id }" type="button"
-            :disabled="!canSelectFirmware">
-            {{ selectedVersion.replace('Meshtastic Firmware ', '').replace('Technical ', '') }}
-            <ChevronDown class="w-2.5 h-2.5 ms-3" />
-        </button>
-        <div id="dropdownFirmware" class="z-10 hidden bg-gray-200 divide-y divide-gray-600 rounded-lg shadow w-44 sm:w-56 max-w-xs">
-            <div v-if="store.prereleaseUnlocked && store.$state.previews.length > 0"
-                class="px-4 py-2 text-sm text-gray-900">
-                <strong>{{ $t('firmware.prerelease') }}</strong>
-            </div>
-            <ul v-if="store.prereleaseUnlocked && store.$state.previews.length > 0" class="py-2 text-sm text-gray-800"
-                aria-labelledby="dropdownInformationButton">
-                <li v-for="release in store.$state.previews">
-                    <a href="#" class="block px-4 py-1 hover:bg-gray-400 cursor-pointer"
-                        @click="setSelectedFirmware(release)">
-                        {{ release.title.replace('Meshtastic Firmware ', '').replace('Pre-release ', '') }}
-                    </a>
-                </li>
-            </ul>
-            <div class="px-4 py-2 text-sm text-gray-900" v-if="!store.couldntFetchFirmwareApi">
-                <strong>{{ $t('firmware.unstable') }}</strong>
-            </div>
-            <ul class="py-2 text-sm text-gray-800" aria-labelledby="dropdownInformationButton"
-                v-if="!store.couldntFetchFirmwareApi">
-                <li v-for="release in store.$state.alpha">
-                    <a href="#" class="block px-4 py-1 hover:bg-gray-400 cursor-pointer"
-                        @click="setSelectedFirmware(release)">
-                        {{ release.title.replace('Meshtastic Firmware ', '') }}
-                    </a>
-                </li>
-            </ul>
-            <div class="px-4 py-2 text-sm text-gray-900" v-if="!store.couldntFetchFirmwareApi">
-                <strong>{{ $t('firmware.stable') }}</strong>
-            </div>
-            <ul class="py-2 text-sm text-gray-800" aria-labelledby="dropdownInformationButton"
-                v-if="!store.couldntFetchFirmwareApi">
-                <li v-for="release in store.$state.stable">
-                    <span class="block px-4 py-1 hover:bg-gray-400 cursor-pointer"
-                        @click="setSelectedFirmware(release)">
-                        {{ release.title.replace('Meshtastic Firmware ', '') }}
-                    </span>
-                </li>
-            </ul>
-            <div class="px-3 sm:px-4 py-2 w-full sm:w-96 max-w-sm rounded-lg text-xs sm:text-sm text-gray-900 bg-yellow-100"
-                v-if="store.couldntFetchFirmwareApi">
-                <strong>{{ $t('firmware.error_fetching') }}</strong>
-                <br />
-                {{ $t('firmware.refresh_later') }}
-                {{ $t('firmware.upload_alternative') }}
-                <FolderOpen class="h-3 w-3 inline" /> {{ $t('firmware.icon') }}
-            </div>
-        </div>
-        <button data-tooltip-target="tooltip-file"
-            class="mx-2 display-inline content-center px-3 py-2 text-xs font-medium text-center hover:bg-gray-200 focus:ring-4 focus:outline-none focus:ring-blue-300 rounded-lg inline-flex items-center text-white hover:text-black"
-            type="button" for="file-upload" accept=".zip,.bin" @click="openFile()">
-            <FolderOpen class="h-4 w-4 "
-                :class="{ 'animate-bounce': (store.couldntFetchFirmwareApi && canSelectFirmware) }" />
-        </button>
-        <div id="tooltip-file" role="tooltip"
-            class="absolute z-10 invisible inline-block px-3 py-2 text-sm font-medium text-white transition-opacity duration-300  rounded-lg shadow-sm opacity-0 tooltip bg-zinc-700">
-            {{ $t('firmware.upload_tooltip') }}
-            <div class="tooltip-arrow" data-popper-arrow></div>
-        </div>
-        <input id="file_upload" type="file" class="hidden" @change="setFirmwareFile" />
+  <div>
+    <button
+      id="dropdownFirmwareButton"
+      data-dropdown-toggle="dropdownFirmware"
+      class="content-center text-black bg-meshtastic hover:bg-gray-200 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center inline-flex items-center disabled:bg-gray-500"
+      :class="{ 'animate-bounce': store.prereleaseUnlocked && !store.$state.selectedFirmware?.id }"
+      type="button"
+      :disabled="!canSelectFirmware"
+    >
+      {{ selectedVersion.replace('Meshtastic Firmware ', '').replace('Technical ', '') }}
+      <ChevronDown class="w-2.5 h-2.5 ms-3" />
+    </button>
+    <div
+      id="dropdownFirmware"
+      class="z-10 hidden bg-gray-200 divide-y divide-gray-600 rounded-lg shadow w-44 sm:w-56 max-w-xs"
+    >
+      <div
+        v-if="store.prereleaseUnlocked && store.$state.previews.length > 0"
+        class="px-4 py-2 text-sm text-gray-900"
+      >
+        <strong>{{ $t('firmware.prerelease') }}</strong>
+      </div>
+      <ul
+        v-if="store.prereleaseUnlocked && store.$state.previews.length > 0"
+        class="py-2 text-sm text-gray-800"
+        aria-labelledby="dropdownInformationButton"
+      >
+        <li v-for="release in store.$state.previews">
+          <a
+            href="#"
+            class="block px-4 py-1 hover:bg-gray-400 cursor-pointer"
+            @click="setSelectedFirmware(release)"
+          >
+            {{ release.title.replace('Meshtastic Firmware ', '').replace('Pre-release ', '') }}
+          </a>
+        </li>
+      </ul>
+      <div
+        v-if="!store.couldntFetchFirmwareApi"
+        class="px-4 py-2 text-sm text-gray-900"
+      >
+        <strong>{{ $t('firmware.unstable') }}</strong>
+      </div>
+      <ul
+        v-if="!store.couldntFetchFirmwareApi"
+        class="py-2 text-sm text-gray-800"
+        aria-labelledby="dropdownInformationButton"
+      >
+        <li v-for="release in store.$state.alpha">
+          <a
+            href="#"
+            class="block px-4 py-1 hover:bg-gray-400 cursor-pointer"
+            @click="setSelectedFirmware(release)"
+          >
+            {{ release.title.replace('Meshtastic Firmware ', '') }}
+          </a>
+        </li>
+      </ul>
+      <div
+        v-if="!store.couldntFetchFirmwareApi"
+        class="px-4 py-2 text-sm text-gray-900"
+      >
+        <strong>{{ $t('firmware.stable') }}</strong>
+      </div>
+      <ul
+        v-if="!store.couldntFetchFirmwareApi"
+        class="py-2 text-sm text-gray-800"
+        aria-labelledby="dropdownInformationButton"
+      >
+        <li v-for="release in store.$state.stable">
+          <span
+            class="block px-4 py-1 hover:bg-gray-400 cursor-pointer"
+            @click="setSelectedFirmware(release)"
+          >
+            {{ release.title.replace('Meshtastic Firmware ', '') }}
+          </span>
+        </li>
+      </ul>
+      <div
+        v-if="store.couldntFetchFirmwareApi"
+        class="px-3 sm:px-4 py-2 w-full sm:w-96 max-w-sm rounded-lg text-xs sm:text-sm text-gray-900 bg-yellow-100"
+      >
+        <strong>{{ $t('firmware.error_fetching') }}</strong>
+        <br>
+        {{ $t('firmware.refresh_later') }}
+        {{ $t('firmware.upload_alternative') }}
+        <FolderOpen class="h-3 w-3 inline" /> {{ $t('firmware.icon') }}
+      </div>
     </div>
+    <button
+      data-tooltip-target="tooltip-file"
+      class="mx-2 display-inline content-center px-3 py-2 text-xs font-medium text-center hover:bg-gray-200 focus:ring-4 focus:outline-none focus:ring-blue-300 rounded-lg inline-flex items-center text-white hover:text-black"
+      type="button"
+      for="file-upload"
+      accept=".zip,.bin"
+      @click="openFile()"
+    >
+      <FolderOpen
+        class="h-4 w-4 "
+        :class="{ 'animate-bounce': (store.couldntFetchFirmwareApi && canSelectFirmware) }"
+      />
+    </button>
+    <div
+      id="tooltip-file"
+      role="tooltip"
+      class="absolute z-10 invisible inline-block px-3 py-2 text-sm font-medium text-white transition-opacity duration-300  rounded-lg shadow-sm opacity-0 tooltip bg-zinc-700"
+    >
+      {{ $t('firmware.upload_tooltip') }}
+      <div
+        class="tooltip-arrow"
+        data-popper-arrow
+      />
+    </div>
+    <input
+      id="file_upload"
+      type="file"
+      class="hidden"
+      @change="setFirmwareFile"
+    >
+  </div>
 </template>
 
 <script lang="ts" setup>
-import type { FirmwareResource } from '~/types/api';
+import type { FirmwareResource } from '~/types/api'
 
-import { FolderOpen, ChevronDown } from 'lucide-vue-next';
+import { FolderOpen, ChevronDown } from 'lucide-vue-next'
 
-import { useDeviceStore } from '../stores/deviceStore';
-import { useFirmwareStore } from '../stores/firmwareStore';
-import { useI18n } from 'vue-i18n';
+import { useDeviceStore } from '../stores/deviceStore'
+import { useFirmwareStore } from '../stores/firmwareStore'
+import { useI18n } from 'vue-i18n'
 
-const { t } = useI18n();
+const { t } = useI18n()
 
-const store = useFirmwareStore();
-const deviceStore = useDeviceStore();
-store.fetchList();
+const store = useFirmwareStore()
+const deviceStore = useDeviceStore()
+store.fetchList()
 
 const selectedVersion = computed(() => {
-    if (store.$state.selectedFirmware?.id) {
-        return store.$state.selectedFirmware.title;
-    } else if (store.$state.selectedFile?.name) {
-        return store.$state.selectedFile?.name;
-    }
-    return t('firmware.select_firmware');
-});
+  if (store.$state.selectedFirmware?.id) {
+    return store.$state.selectedFirmware.title
+  }
+  else if (store.$state.selectedFile?.name) {
+    return store.$state.selectedFile?.name
+  }
+  return t('firmware.select_firmware')
+})
 
 const canSelectFirmware = computed(() => {
-    return deviceStore.selectedTarget?.hwModel > 0;
-});
+  return deviceStore.selectedTarget?.hwModel > 0
+})
 
 const openFile = () => {
-    document.getElementById('file_upload')?.click();
+  document.getElementById('file_upload')?.click()
 }
 
 const setFirmwareFile = (event: any) => {
-    store.setFirmwareFile(event.target.files[0]);
+  store.setFirmwareFile(event.target.files[0])
 }
 
 const setSelectedFirmware = (release: FirmwareResource) => {
-    store.setSelectedFirmware(release);
-    document.getElementById('dropdownFirmware')?.classList.toggle('hidden'); // Flowbite bug
+  store.setSelectedFirmware(release)
+  document.getElementById('dropdownFirmware')?.classList.toggle('hidden') // Flowbite bug
 }
 
 // Credit: https://codepen.io/yaclive/pen/EayLYO
 function doAnimation() {
-    console.log('doAnimation');
+  console.log('doAnimation')
   // Initialising the canvas
-  var canvas = document.querySelector('canvas');
-  var ctx = canvas?.getContext('2d');
+  const canvas = document.querySelector('canvas')
+  const ctx = canvas?.getContext('2d')
 
   if (!canvas || !ctx) {
-    return;
+    return
   }
 
   // Setting the width and height of the canvas
-  canvas.width = window.innerWidth;
-  canvas.height = window.innerHeight;
+  canvas.width = window.innerWidth
+  canvas.height = window.innerHeight
 
   // Setting up the letters
-  let letters = '/\\'.split('');;
+  const letters = '/\\'.split('')
 
   // Setting up the columns
-  const fontSize = 10;
-  const columns = canvas.width / fontSize;
+  const fontSize = 10
+  const columns = canvas.width / fontSize
 
   // Setting up the drops
-  let drops = new Array<number>();
-  for (var i = 0; i < columns; i++) {
-    drops[i] = 1;
+  const drops = new Array<number>()
+  for (let i = 0; i < columns; i++) {
+    drops[i] = 1
   }
 
   // Setting up the draw function
   function draw() {
     if (!canvas || !ctx) {
-      return;
+      return
     }
-    ctx.fillStyle = 'rgba(0, 0, 0, .1)';
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
-    for (var i = 0; i < drops.length; i++) {
-      var text = letters[Math.floor(Math.random() * letters.length)];
-      ctx.fillStyle = '#0f0';
-      ctx.fillText(text, i * fontSize, drops[i] * fontSize);
-      drops[i]++;
-      if (drops[i] * fontSize > canvas.height && Math.random() > .95) {
-        drops[i] = 0;
+    ctx.fillStyle = 'rgba(0, 0, 0, .1)'
+    ctx.fillRect(0, 0, canvas.width, canvas.height)
+    for (let i = 0; i < drops.length; i++) {
+      const text = letters[Math.floor(Math.random() * letters.length)]
+      ctx.fillStyle = '#0f0'
+      ctx.fillText(text, i * fontSize, drops[i] * fontSize)
+      drops[i]++
+      if (drops[i] * fontSize > canvas.height && Math.random() > 0.95) {
+        drops[i] = 0
       }
     }
   }
 
   // Loop the animation
-  setInterval(draw, 33);
+  setInterval(draw, 33)
 }
 
 watch(() => store.$state.selectedFirmware, (value) => {
   if (value?.id) {
     // doAnimation();
   }
-});
+})
 </script>

--- a/components/Flash.vue
+++ b/components/Flash.vue
@@ -1,80 +1,106 @@
 <template>
-    <div>
-        <button data-modal-target="flash-modal" data-modal-toggle="flash-modal"
-            class="inline text-black bg-meshtastic hover:bg-gray-200 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 disabled:bg-gray-500 text-center"
-            type="button" :disabled="!canFlash">
-            {{ $t('flash.title') }}
-        </button>
-        <button v-show="['nrf52840', 'rp2040'].includes(deviceStore.selectedArchitecture)" data-tooltip-target="tooltip-erase" class="mx-2 display-inline content-center px-3 py-2 text-xs font-medium text-center  hover:bg-gray-200 focus:ring-4 focus:outline-none focus:ring-blue-300 rounded-lg inline-flex items-center text-white hover:text-black"
-            type="button"
-            data-modal-target="erase-modal" 
-            data-modal-toggle="erase-modal">
-            <Trash class="h-4 w-4" :class="{'animate-pulse': deviceStore.$state.selectedTarget?.hwModel }" />
-        </button>
-        <div id="tooltip-erase" role="tooltip" class="absolute z-10 invisible inline-block px-3 py-2 text-sm font-medium text-white transition-opacity duration-300  rounded-lg shadow-sm opacity-0 tooltip bg-zinc-700">
-            {{ $t('flash.erase_flash_prefix') }} {{ deviceStore.selectedTarget?.displayName }}.
-            <div class="tooltip-arrow" data-popper-arrow></div>
-        </div>
-        <div id="flash-modal" tabindex="-1" aria-hidden="true"
-            class="dark hidden overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 justify-center items-center w-full md:inset-0 h-[calc(100%-1rem)] max-h-full">
-            <TargetsUf2 v-if="['nrf52840', 'rp2040'].includes(deviceStore.selectedArchitecture)" />
-            <TargetsEsp32 v-if="deviceStore.selectedArchitecture.startsWith('esp32')" />
-        </div>
-        <div id="erase-modal" tabindex="-1" aria-hidden="true"
-            class="dark hidden overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 justify-center items-center w-full md:inset-0 h-[calc(100%-1rem)] max-h-full">
-            <TargetsEraseUf2 v-if="['nrf52840', 'rp2040'].includes(deviceStore.selectedArchitecture)" />
-        </div>
+  <div>
+    <button
+      data-modal-target="flash-modal"
+      data-modal-toggle="flash-modal"
+      class="inline text-black bg-meshtastic hover:bg-gray-200 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 disabled:bg-gray-500 text-center"
+      type="button"
+      :disabled="!canFlash"
+    >
+      {{ $t('flash.title') }}
+    </button>
+    <button
+      v-show="['nrf52840', 'rp2040'].includes(deviceStore.selectedArchitecture)"
+      data-tooltip-target="tooltip-erase"
+      class="mx-2 display-inline content-center px-3 py-2 text-xs font-medium text-center  hover:bg-gray-200 focus:ring-4 focus:outline-none focus:ring-blue-300 rounded-lg inline-flex items-center text-white hover:text-black"
+      type="button"
+      data-modal-target="erase-modal"
+      data-modal-toggle="erase-modal"
+    >
+      <Trash
+        class="h-4 w-4"
+        :class="{ 'animate-pulse': deviceStore.$state.selectedTarget?.hwModel }"
+      />
+    </button>
+    <div
+      id="tooltip-erase"
+      role="tooltip"
+      class="absolute z-10 invisible inline-block px-3 py-2 text-sm font-medium text-white transition-opacity duration-300  rounded-lg shadow-sm opacity-0 tooltip bg-zinc-700"
+    >
+      {{ $t('flash.erase_flash_prefix') }} {{ deviceStore.selectedTarget?.displayName }}.
+      <div
+        class="tooltip-arrow"
+        data-popper-arrow
+      />
     </div>
+    <div
+      id="flash-modal"
+      tabindex="-1"
+      aria-hidden="true"
+      class="dark hidden overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 justify-center items-center w-full md:inset-0 h-[calc(100%-1rem)] max-h-full"
+    >
+      <TargetsUf2 v-if="['nrf52840', 'rp2040'].includes(deviceStore.selectedArchitecture)" />
+      <TargetsEsp32 v-if="deviceStore.selectedArchitecture.startsWith('esp32')" />
+    </div>
+    <div
+      id="erase-modal"
+      tabindex="-1"
+      aria-hidden="true"
+      class="dark hidden overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 justify-center items-center w-full md:inset-0 h-[calc(100%-1rem)] max-h-full"
+    >
+      <TargetsEraseUf2 v-if="['nrf52840', 'rp2040'].includes(deviceStore.selectedArchitecture)" />
+    </div>
+  </div>
 </template>
 
 <script lang="ts" setup>
-import { checkIfRemoteFileExists } from '~/utils/fileUtils';
+import { checkIfRemoteFileExists } from '~/utils/fileUtils'
 
-import { Trash } from 'lucide-vue-next';
+import { Trash } from 'lucide-vue-next'
 
-import { useDeviceStore } from '../stores/deviceStore';
-import { useFirmwareStore } from '../stores/firmwareStore';
-import { useSerialMonitorStore } from '../stores/serialMonitorStore';
+import { useDeviceStore } from '../stores/deviceStore'
+import { useFirmwareStore } from '../stores/firmwareStore'
+import { useSerialMonitorStore } from '../stores/serialMonitorStore'
 
-const firmwareStore = useFirmwareStore();
-const deviceStore = useDeviceStore();
-const serialMonitorStore = useSerialMonitorStore();
+const firmwareStore = useFirmwareStore()
+const deviceStore = useDeviceStore()
+const serialMonitorStore = useSerialMonitorStore()
 
-const fileExistsOnServer = ref(false);
+const fileExistsOnServer = ref(false)
 
 watch(() => firmwareStore.$state.selectedFirmware, async () => {
-    await preflightCheck();
-});
+  await preflightCheck()
+})
 
 watch(() => deviceStore.$state.selectedTarget, async () => {
-    await preflightCheck();
-});
+  await preflightCheck()
+})
 
 const preflightCheck = async () => {
-    if (!firmwareStore.hasOnlineFirmware) {
-        fileExistsOnServer.value = false;
-        return;
-    }
+  if (!firmwareStore.hasOnlineFirmware) {
+    fileExistsOnServer.value = false
+    return
+  }
 
-    if (['nrf52840', 'rp2040'].includes(deviceStore.selectedArchitecture)) {
-        const firmwareVersion = firmwareStore.selectedFirmware!.id.replace('v', '')
-        const firmwareFile = `firmware-${deviceStore.selectedTarget.platformioTarget}-${firmwareVersion}.uf2`
-        fileExistsOnServer.value = await checkIfRemoteFileExists(firmwareStore.getReleaseFileUrl(firmwareFile));
-    }
-    else if (deviceStore.selectedArchitecture.startsWith('esp32')) {
-        const firmwareFile = `firmware-${deviceStore.$state.selectedTarget.platformioTarget}-${firmwareStore.firmwareVersion}.bin`;
-        fileExistsOnServer.value = await checkIfRemoteFileExists(firmwareStore.getReleaseFileUrl(firmwareFile));
-    }
-    else {
-        fileExistsOnServer.value = false;
-    }
+  if (['nrf52840', 'rp2040'].includes(deviceStore.selectedArchitecture)) {
+    const firmwareVersion = firmwareStore.selectedFirmware!.id.replace('v', '')
+    const firmwareFile = `firmware-${deviceStore.selectedTarget.platformioTarget}-${firmwareVersion}.uf2`
+    fileExistsOnServer.value = await checkIfRemoteFileExists(firmwareStore.getReleaseFileUrl(firmwareFile))
+  }
+  else if (deviceStore.selectedArchitecture.startsWith('esp32')) {
+    const firmwareFile = `firmware-${deviceStore.$state.selectedTarget.platformioTarget}-${firmwareStore.firmwareVersion}.bin`
+    fileExistsOnServer.value = await checkIfRemoteFileExists(firmwareStore.getReleaseFileUrl(firmwareFile))
+  }
+  else {
+    fileExistsOnServer.value = false
+  }
 }
 
 // Either we have a custom zip file or a selected firmware release
 const canFlash = computed(() => {
-    const hasDevice = deviceStore.selectedTarget?.hwModel > 0;
-    const hasFirmware = firmwareStore.hasFirmwareFile || firmwareStore.hasOnlineFirmware;
-    return !serialMonitorStore.isConnected && hasDevice && hasFirmware 
-        && (fileExistsOnServer.value || firmwareStore.hasFirmwareFile);
-});
+  const hasDevice = deviceStore.selectedTarget?.hwModel > 0
+  const hasFirmware = firmwareStore.hasFirmwareFile || firmwareStore.hasOnlineFirmware
+  return !serialMonitorStore.isConnected && hasDevice && hasFirmware
+    && (fileExistsOnServer.value || firmwareStore.hasFirmwareFile)
+})
 </script>

--- a/components/LanguagePicker.vue
+++ b/components/LanguagePicker.vue
@@ -1,18 +1,33 @@
 <template>
   <div class="relative inline-block text-left">
-    <button id="languageDropdownButton" data-dropdown-toggle="languageDropdown" type="button" 
-            class="bottom-button border-meshtastic text-meshtastic">
+    <button
+      id="languageDropdownButton"
+      data-dropdown-toggle="languageDropdown"
+      type="button"
+      class="bottom-button border-meshtastic text-meshtastic"
+    >
       {{ currentLanguageFlag }} {{ $t('language') }}
       <ChevronDown class="w-2.5 h-2.5 ml-2 shrink-0" />
     </button>
 
     <!-- Dropdown menu -->
-    <div id="languageDropdown" class="z-10 hidden bg-white divide-y divide-gray-100 rounded-lg shadow w-48 dark:bg-zinc-700 dark:divide-gray-600">
-      <ul class="py-2 text-sm text-gray-700 dark:text-gray-200" aria-labelledby="languageDropdownButton">
-        <li v-for="locale in availableLocales" :key="locale.code">
-          <button @click="switchLanguage(locale.code)" 
-                  class="w-full text-left block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white"
-                  :class="{ 'bg-gray-100 dark:bg-gray-600': $i18n.locale === locale.code }">
+    <div
+      id="languageDropdown"
+      class="z-10 hidden bg-white divide-y divide-gray-100 rounded-lg shadow w-48 dark:bg-zinc-700 dark:divide-gray-600"
+    >
+      <ul
+        class="py-2 text-sm text-gray-700 dark:text-gray-200"
+        aria-labelledby="languageDropdownButton"
+      >
+        <li
+          v-for="locale in availableLocales"
+          :key="locale.code"
+        >
+          <button
+            class="w-full text-left block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white"
+            :class="{ 'bg-gray-100 dark:bg-gray-600': $i18n.locale === locale.code }"
+            @click="switchLanguage(locale.code)"
+          >
             {{ locale.flag }} {{ locale.name }}
           </button>
         </li>
@@ -54,7 +69,7 @@ const availableLocales = computed(() => {
   return locales.value.map(locale => ({
     code: locale.code,
     name: locale.name,
-    flag: flagMap[locale.code] || '🌐'
+    flag: flagMap[locale.code] || '🌐',
   }))
 })
 

--- a/components/LogoHeader.vue
+++ b/components/LogoHeader.vue
@@ -1,18 +1,36 @@
 <template>
-    <div class="mx-auto">
-        <h1 v-if="vendorCobrandingTag === 'RAK'" class="text-white text-3xl sm:text-5xl md:text-6xl inline-block ml-2 sm:ml-4 align-top tracking-wide">
-            <img src="@/assets/img/logo.svg" class="h-16 w-16 sm:h-24 sm:w-24 md:h-32 md:w-32 inline-block pt-0 mt-0" alt="Meshtastic Logo" />
-            x
-            <img src="@/public/img/icon_rak-cropped.svg" class="h-32 w-32 sm:h-48 sm:w-48 md:h-64 md:w-64 inline-block pt-0 mt-0" alt="RAK Logo" />
-            {{ $t('header_title') }}
-        </h1>
-        <h1 v-else class="text-white text-4xl sm:text-6xl md:text-7xl inline-block ml-2 sm:ml-4 justify-center text-center text-meshtastic tracking-wide">
-            <img src="@/assets/img/logo.svg" class="h-16 w-16 sm:h-24 sm:w-24 md:h-32 md:w-32 inline-block pt-0 mt-0" alt="Meshtastic Logo" />
-            {{ $t('header_title') }}
-        </h1>
-    </div>
+  <div class="mx-auto">
+    <h1
+      v-if="vendorCobrandingTag === 'RAK'"
+      class="text-white text-3xl sm:text-5xl md:text-6xl inline-block ml-2 sm:ml-4 align-top tracking-wide"
+    >
+      <img
+        src="@/assets/img/logo.svg"
+        class="h-16 w-16 sm:h-24 sm:w-24 md:h-32 md:w-32 inline-block pt-0 mt-0"
+        alt="Meshtastic Logo"
+      >
+      x
+      <img
+        src="@/public/img/icon_rak-cropped.svg"
+        class="h-32 w-32 sm:h-48 sm:w-48 md:h-64 md:w-64 inline-block pt-0 mt-0"
+        alt="RAK Logo"
+      >
+      {{ $t('header_title') }}
+    </h1>
+    <h1
+      v-else
+      class="text-white text-4xl sm:text-6xl md:text-7xl inline-block ml-2 sm:ml-4 justify-center text-center text-meshtastic tracking-wide"
+    >
+      <img
+        src="@/assets/img/logo.svg"
+        class="h-16 w-16 sm:h-24 sm:w-24 md:h-32 md:w-32 inline-block pt-0 mt-0"
+        alt="Meshtastic Logo"
+      >
+      {{ $t('header_title') }}
+    </h1>
+  </div>
 </template>
 
 <script lang="ts" setup>
-import { vendorCobrandingTag } from '~/types/resources';
+import { vendorCobrandingTag } from '~/types/resources'
 </script>

--- a/components/SerialMonitor.vue
+++ b/components/SerialMonitor.vue
@@ -1,7 +1,14 @@
 <template>
-  <div class="w-full mt-2" v-if="serialMonitorStore.isConnected || serialMonitorStore.terminalBuffer.length > 0">
+  <div
+    v-if="serialMonitorStore.isConnected || serialMonitorStore.terminalBuffer.length > 0"
+    class="w-full mt-2"
+  >
     <div class="flex items-center justify-center">
-      <div v-if="serialMonitorStore.isConnected && !serialMonitorStore.isReaderLocked" class="flex items-center p-4 mb-4 text-sm rounded-lg bg-gray-800 text-blue-400" role="alert">
+      <div
+        v-if="serialMonitorStore.isConnected && !serialMonitorStore.isReaderLocked"
+        class="flex items-center p-4 mb-4 text-sm rounded-lg bg-gray-800 text-blue-400"
+        role="alert"
+      >
         <Info class="flex-shrink-0 inline w-4 h-4 me-3" />
         <span class="sr-only">Info</span>
         <div>
@@ -10,48 +17,114 @@
       </div>
     </div>
     <div class="grid grid-cols-1 md:grid-cols-3 gap-2">
-      <div class="col"> 
+      <div class="col">
         <div class="flex items-center justify-start px-2 overflow-x-auto pb-2">
-          <button type="button" @click="logLevel = 'all'" class="relative border focus:ring-4 focus:outline-none rounded-full text-xs font-medium px-3 sm:px-4 py-1.5 text-center me-2 sm:me-3 mb-2 border-blue-500 text-blue-500 hover:text-white hover:bg-blue-500 bg-gray-900 focus:ring-blue-800 whitespace-nowrap flex-shrink-0">
+          <button
+            type="button"
+            class="relative border focus:ring-4 focus:outline-none rounded-full text-xs font-medium px-3 sm:px-4 py-1.5 text-center me-2 sm:me-3 mb-2 border-blue-500 text-blue-500 hover:text-white hover:bg-blue-500 bg-gray-900 focus:ring-blue-800 whitespace-nowrap flex-shrink-0"
+            @click="logLevel = 'all'"
+          >
             {{ $t('serial.log_levels.all') }}
-            <div v-if="logCounts.all > 0" class="absolute inline-flex items-center justify-center w-6 h-6 text-xs font-bold text-black bg-blue-500 rounded-full -top-3 -end-3">{{ logCounts.all }}</div>
+            <div
+              v-if="logCounts.all > 0"
+              class="absolute inline-flex items-center justify-center w-6 h-6 text-xs font-bold text-black bg-blue-500 rounded-full -top-3 -end-3"
+            >
+              {{ logCounts.all }}
+            </div>
           </button>
-          <button type="button" @click="logLevel = 'INFO  |'" class="relative border :outline-none rounded-full text-xs font-medium px-3 sm:px-4 py-1.5 text-center me-2 sm:me-3 mb-2 focus:ring-gray-800 text-white hover:bg-blue-500 whitespace-nowrap flex-shrink-0" >
+          <button
+            type="button"
+            class="relative border :outline-none rounded-full text-xs font-medium px-3 sm:px-4 py-1.5 text-center me-2 sm:me-3 mb-2 focus:ring-gray-800 text-white hover:bg-blue-500 whitespace-nowrap flex-shrink-0"
+            @click="logLevel = 'INFO  |'"
+          >
             {{ $t('serial.log_levels.info') }}
-            <div v-if="logCounts.info > 0" class="absolute inline-flex items-center justify-center w-6 h-6 text-xs font-bold text-black bg-gray-200 rounded-full -top-3 -end-3">{{ logCounts.info }}</div>
+            <div
+              v-if="logCounts.info > 0"
+              class="absolute inline-flex items-center justify-center w-6 h-6 text-xs font-bold text-black bg-gray-200 rounded-full -top-3 -end-3"
+            >
+              {{ logCounts.info }}
+            </div>
           </button>
-          <button type="button" @click="logLevel = 'DEBUG |'" class="relative border :outline-none rounded-full text-xs font-medium px-3 sm:px-4 py-1.5 text-center me-2 sm:me-3 mb-2 focus:ring-gray-800 border-blue-300 text-blue-300 hover:bg-blue-500 hover:text-white whitespace-nowrap flex-shrink-0">
+          <button
+            type="button"
+            class="relative border :outline-none rounded-full text-xs font-medium px-3 sm:px-4 py-1.5 text-center me-2 sm:me-3 mb-2 focus:ring-gray-800 border-blue-300 text-blue-300 hover:bg-blue-500 hover:text-white whitespace-nowrap flex-shrink-0"
+            @click="logLevel = 'DEBUG |'"
+          >
             {{ $t('serial.log_levels.debug') }}
-            <div v-if="logCounts.debug > 0" class="absolute inline-flex items-center justify-center w-6 h-6 text-xs font-bold text-black bg-blue-300 rounded-full -top-3 -end-3">{{ logCounts.debug }}</div>
+            <div
+              v-if="logCounts.debug > 0"
+              class="absolute inline-flex items-center justify-center w-6 h-6 text-xs font-bold text-black bg-blue-300 rounded-full -top-3 -end-3"
+            >
+              {{ logCounts.debug }}
+            </div>
           </button>
-          <button type="button" @click="logLevel = 'WARN  |'" class="relative border :outline-none rounded-full text-xs font-medium px-3 sm:px-4 py-1.5 text-center me-2 sm:me-3 mb-2 focus:ring-gray-800 border-orange-300 text-orange-300 hover:bg-orange-300 hover:text-white whitespace-nowrap flex-shrink-0">
+          <button
+            type="button"
+            class="relative border :outline-none rounded-full text-xs font-medium px-3 sm:px-4 py-1.5 text-center me-2 sm:me-3 mb-2 focus:ring-gray-800 border-orange-300 text-orange-300 hover:bg-orange-300 hover:text-white whitespace-nowrap flex-shrink-0"
+            @click="logLevel = 'WARN  |'"
+          >
             {{ $t('serial.log_levels.warn') }}
-            <div v-if="logCounts.warn > 0" class="absolute inline-flex items-center justify-center w-6 h-6 text-xs font-bold text-black bg-orange-300 rounded-full -top-3 -end-3">{{ logCounts.warn }}</div>
+            <div
+              v-if="logCounts.warn > 0"
+              class="absolute inline-flex items-center justify-center w-6 h-6 text-xs font-bold text-black bg-orange-300 rounded-full -top-3 -end-3"
+            >
+              {{ logCounts.warn }}
+            </div>
           </button>
-          <button type="button" @click="logLevel = 'ERROR |'" class="relative border :outline-none rounded-full text-xs font-medium px-3 sm:px-4 py-1.5 text-center me-2 sm:me-3 mb-2 focus:ring-gray-800 border-red-500 text-red-500 hover:bg-red-500 hover:text-white whitespace-nowrap flex-shrink-0">
+          <button
+            type="button"
+            class="relative border :outline-none rounded-full text-xs font-medium px-3 sm:px-4 py-1.5 text-center me-2 sm:me-3 mb-2 focus:ring-gray-800 border-red-500 text-red-500 hover:bg-red-500 hover:text-white whitespace-nowrap flex-shrink-0"
+            @click="logLevel = 'ERROR |'"
+          >
             {{ $t('serial.log_levels.error') }}
-            <div v-if="logCounts.error > 0" class="absolute inline-flex items-center justify-center w-6 h-6 text-xs font-bold text-black bg-red-500 rounded-full -top-3 -end-3">{{ logCounts.error }}</div>
+            <div
+              v-if="logCounts.error > 0"
+              class="absolute inline-flex items-center justify-center w-6 h-6 text-xs font-bold text-black bg-red-500 rounded-full -top-3 -end-3"
+            >
+              {{ logCounts.error }}
+            </div>
           </button>
         </div>
       </div>
       <div class="col">
         <div class="flex items-center justify-center md:justify-center">
-          <button v-if="serialMonitorStore.isConnected" @click="disconnect()"
-            class="border focus:ring-4 focus:outline-none font-medium text-purple-400 border-purple-400 hover:text-black hover:border-transparent hover:bg-white rounded-lg text-sm px-4 py-1 text-center me-2 mb-2  hover:shadow transition duration-300 ease-in-out">
+          <button
+            v-if="serialMonitorStore.isConnected"
+            class="border focus:ring-4 focus:outline-none font-medium text-purple-400 border-purple-400 hover:text-black hover:border-transparent hover:bg-white rounded-lg text-sm px-4 py-1 text-center me-2 mb-2  hover:shadow transition duration-300 ease-in-out"
+            @click="disconnect()"
+          >
             {{ $t('serial.disconnect') }}
           </button>
         </div>
         <!-- Auto scroll -->
       </div>
       <div class="col">
-        <div class="rounded-md shadow-sm flex justify-center md:justify-end px-2" role="group">
-          <button type="button" title="Clear logs" @click="clearTerminal" class="px-4 py-1.5 text-sm font-medium text-white border border-gray-200 rounded-s-lg hover:bg-gray-100 hover:text-black focus:z-10 focus:ring-2 focus:ring-blue-700">
+        <div
+          class="rounded-md shadow-sm flex justify-center md:justify-end px-2"
+          role="group"
+        >
+          <button
+            type="button"
+            title="Clear logs"
+            class="px-4 py-1.5 text-sm font-medium text-white border border-gray-200 rounded-s-lg hover:bg-gray-100 hover:text-black focus:z-10 focus:ring-2 focus:ring-blue-700"
+            @click="clearTerminal"
+          >
             <Trash class="h-4 w-4 inline" />
           </button>
-          <button type="button" title="Copy logs to clipboard" @click="copyToClipboard" class="px-4 py-1.5 text-sm font-medium text-white border-t border-b border-gray-200 hover:bg-gray-100 hover:text-black focus:z-10 focus:ring-2 focus:ring-blue-700">
+          <button
+            type="button"
+            title="Copy logs to clipboard"
+            class="px-4 py-1.5 text-sm font-medium text-white border-t border-b border-gray-200 hover:bg-gray-100 hover:text-black focus:z-10 focus:ring-2 focus:ring-blue-700"
+            @click="copyToClipboard"
+          >
             <Clipboard class="h-4 w-4 inline" />
           </button>
-          <button type="button" title="Save logs to file" @click="saveToFile" class="px-4 py-1.5 text-sm font-medium text-white border border-gray-200 rounded-e-lg hover:bg-gray-100 hover:text-black focus:z-10 focus:ring-2 focus:ring-blue-700">
+          <button
+            type="button"
+            title="Save logs to file"
+            class="px-4 py-1.5 text-sm font-medium text-white border border-gray-200 rounded-e-lg hover:bg-gray-100 hover:text-black focus:z-10 focus:ring-2 focus:ring-blue-700"
+            @click="saveToFile"
+          >
             <Download class="h-4 w-4 inline" />
           </button>
         </div>
@@ -59,13 +132,16 @@
     </div>
     <div class="inverse-toggle px-3 sm:px-5 shadow-lg text-gray-100 text-xs sm:text-sm font-mono subpixel-antialiased bg-gray-900 pb-6 pt-4 rounded-lg leading-normal overflow-hidden">
       <div class="top mb-2 flex">
-        <div class="h-3 w-3 bg-red-500 rounded-full"></div>
-        <div class="ml-2 h-3 w-3 bg-orange-300 rounded-full"></div>
-        <div class="ml-2 h-3 w-3 bg-green-500 rounded-full"></div>
+        <div class="h-3 w-3 bg-red-500 rounded-full" />
+        <div class="ml-2 h-3 w-3 bg-orange-300 rounded-full" />
+        <div class="ml-2 h-3 w-3 bg-green-500 rounded-full" />
       </div>
       <div class="mt-4 overflow-x-auto">
-        <p v-for="line in filteredTerminalBuffer" :class="logLevelClass(line)">
-          {{ line.replaceAll(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, "") }}<br />
+        <p
+          v-for="line in filteredTerminalBuffer"
+          :class="logLevelClass(line)"
+        >
+          {{ line.replaceAll(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, "") }}<br>
         </p>
       </div>
     </div>
@@ -73,70 +149,72 @@
 </template>
 
 <script setup>
-import { ref } from 'vue';
+import { ref } from 'vue'
 
 import {
   Download,
   Clipboard,
   Trash,
   Info,
-} from 'lucide-vue-next';
+} from 'lucide-vue-next'
 
-import { useSerialMonitorStore } from '../stores/serialMonitorStore';
+import { useSerialMonitorStore } from '../stores/serialMonitorStore'
 
-const serialMonitorStore = useSerialMonitorStore();
+const serialMonitorStore = useSerialMonitorStore()
 
-const logLevel = ref('all');
+const logLevel = ref('all')
 
 const filteredTerminalBuffer = computed(() => {
   if (logLevel.value === 'all') {
-    return serialMonitorStore.terminalBuffer;
+    return serialMonitorStore.terminalBuffer
   }
-  return serialMonitorStore.terminalBuffer.filter((line) => line.includes(logLevel.value.toUpperCase()));
-});
+  return serialMonitorStore.terminalBuffer.filter(line => line.includes(logLevel.value.toUpperCase()))
+})
 
 const disconnect = () => {
   if (serialMonitorStore.isConnected) {
-    serialMonitorStore.disconnect();
-  } 
-};
+    serialMonitorStore.disconnect()
+  }
+}
 
 const logCounts = computed(() => {
   return {
     all: serialMonitorStore.terminalBuffer.length,
-    info: serialMonitorStore.terminalBuffer.filter((line) => line.includes('INFO')).length,
-    debug: serialMonitorStore.terminalBuffer.filter((line) => line.includes('DEBUG')).length,
-    warn: serialMonitorStore.terminalBuffer.filter((line) => line.includes('WARN')).length,
-    error: serialMonitorStore.terminalBuffer.filter((line) => line.includes('ERROR')).length,
-  };
-});
+    info: serialMonitorStore.terminalBuffer.filter(line => line.includes('INFO')).length,
+    debug: serialMonitorStore.terminalBuffer.filter(line => line.includes('DEBUG')).length,
+    warn: serialMonitorStore.terminalBuffer.filter(line => line.includes('WARN')).length,
+    error: serialMonitorStore.terminalBuffer.filter(line => line.includes('ERROR')).length,
+  }
+})
 
 const clearTerminal = () => {
-  serialMonitorStore.terminalBuffer = [];
+  serialMonitorStore.terminalBuffer = []
 }
 
 const copyToClipboard = () => {
-  navigator.clipboard.writeText(serialMonitorStore.terminalBuffer.join('\n'));
+  navigator.clipboard.writeText(serialMonitorStore.terminalBuffer.join('\n'))
 }
 
 const saveToFile = () => {
-  const blob = new Blob([serialMonitorStore.terminalBuffer.join('\n')], { type: 'text/plain' });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = `meshtastic-log-${new Date().toISOString().replace(/:/g, '-')}.log`;
-  a.click();
-  URL.revokeObjectURL(url);
+  const blob = new Blob([serialMonitorStore.terminalBuffer.join('\n')], { type: 'text/plain' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `meshtastic-log-${new Date().toISOString().replace(/:/g, '-')}.log`
+  a.click()
+  URL.revokeObjectURL(url)
 }
 
 const logLevelClass = (line) => {
   if (line.includes('ERROR')) {
-    return 'text-red-500';
-  } else if (line.includes('WARN')) {
-    return 'text-orange-300';
-  } else if (line.includes('DEBUG')) {
-    return 'text-blue-300';
+    return 'text-red-500'
   }
-  return '';
+  else if (line.includes('WARN')) {
+    return 'text-orange-300'
+  }
+  else if (line.includes('DEBUG')) {
+    return 'text-blue-300'
+  }
+  return ''
 }
 </script>

--- a/components/ToastNotifications.vue
+++ b/components/ToastNotifications.vue
@@ -1,7 +1,10 @@
 <template>
   <Teleport to="body">
     <div class="fixed top-6 right-6 z-50 space-y-3">
-      <TransitionGroup name="toast" tag="div">
+      <TransitionGroup
+        name="toast"
+        tag="div"
+      >
         <div
           v-for="toast in toastStore.toasts"
           :key="toast.id"
@@ -10,17 +13,24 @@
           <div class="p-4">
             <div class="flex items-start">
               <div class="flex-shrink-0">
-                <component :is="getIcon(toast.type)" :class="getIconClass(toast.type)" class="h-6 w-6" />
+                <component
+                  :is="getIcon(toast.type)"
+                  :class="getIconClass(toast.type)"
+                  class="h-6 w-6"
+                />
               </div>
               <div class="ml-3 w-0 flex-1 pt-0.5">
-                <p class="text-sm font-medium text-gray-100">{{ toast.title }}</p>
-                <p class="mt-1 text-sm text-gray-300">{{ toast.message }}</p>
-                
+                <p class="text-sm font-medium text-gray-100">
+                  {{ toast.title }}
+                </p>
+                <p class="mt-1 text-sm text-gray-300">
+                  {{ toast.message }}
+                </p>
               </div>
               <div class="ml-4 flex-shrink-0 flex">
                 <button
-                  @click="toastStore.removeToast(toast.id)"
                   class="bg-transparent rounded-md inline-flex text-gray-400 hover:text-gray-200 hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-meshtastic focus:ring-offset-zinc-700 transition-colors duration-200"
+                  @click="toastStore.removeToast(toast.id)"
                 >
                   <span class="sr-only">{{ $t('actions.close') }}</span>
                   <X class="h-5 w-5" />
@@ -29,17 +39,20 @@
             </div>
           </div>
           <!-- Error toast with dismiss and reload buttons -->
-          <div v-if="toast.type === 'error'" class="bg-zinc-800 px-4 py-3 border-t border-gray-600">
+          <div
+            v-if="toast.type === 'error'"
+            class="bg-zinc-800 px-4 py-3 border-t border-gray-600"
+          >
             <div class="flex">
               <button
-                @click="toastStore.removeToast(toast.id)"
                 class="text-sm font-medium text-gray-300 hover:text-gray-100 transition-colors duration-200"
+                @click="toastStore.removeToast(toast.id)"
               >
                 {{ $t('actions.dismiss') }}
               </button>
               <button
-                @click="reloadPage"
                 class="ml-2 text-sm font-medium text-red-400 hover:text-red-300 transition-colors duration-200"
+                @click="reloadPage"
               >
                 {{ $t('actions.reload') }}
               </button>
@@ -52,41 +65,41 @@
 </template>
 
 <script setup lang="ts">
-import { useToastStore } from '~/stores/toastStore';
-import { CheckCircle, XCircle, AlertTriangle, Info, X } from 'lucide-vue-next';
+import { useToastStore } from '~/stores/toastStore'
+import { CheckCircle, XCircle, AlertTriangle, Info, X } from 'lucide-vue-next'
 
-const toastStore = useToastStore();
+const toastStore = useToastStore()
 
 const getIcon = (type: string) => {
   switch (type) {
     case 'success':
-      return CheckCircle;
+      return CheckCircle
     case 'error':
-      return XCircle;
+      return XCircle
     case 'warning':
-      return AlertTriangle;
+      return AlertTriangle
     case 'info':
     default:
-      return Info;
+      return Info
   }
-};
+}
 
 const getIconClass = (type: string) => {
   switch (type) {
     case 'success':
-      return 'text-green-400';
+      return 'text-green-400'
     case 'error':
-      return 'text-red-400';
+      return 'text-red-400'
     case 'warning':
-      return 'text-yellow-400';
+      return 'text-yellow-400'
     case 'info':
     default:
-      return 'text-blue-400';
+      return 'text-blue-400'
   }
-};
+}
 
 function reloadPage() {
-  window.location.reload();
+  window.location.reload()
 }
 </script>
 

--- a/components/targets/EraseUf2.vue
+++ b/components/targets/EraseUf2.vue
@@ -1,165 +1,192 @@
 <template>
-    <div class="relative w-full max-w-4xl max-h-full">
-        <div class="relative rounded-lg shadow bg-zinc-700">
-            <div class="flex items-center justify-between p-4 md:p-5 border-b rounded-t border-gray-600">
-                <h3 class="text-lg font-semibold text-white">
-                    {{ $t('flash.erase_flash') }} {{ deviceStore.$state.selectedTarget?.displayName }}
-                </h3>
-                <button type="button"
-                    class="text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm h-8 w-8 ms-auto inline-flex justify-center items-center hover:bg-gray-600 hover:text-white"
-                    data-modal-toggle="flash-modal"
-                    @click="closeModal">
-                    <X class="w-3 h-3" />
-                    <span class="sr-only">{{ $t('actions.close_dialog') }}</span>
-                </button>
+  <div class="relative w-full max-w-4xl max-h-full">
+    <div class="relative rounded-lg shadow bg-zinc-700">
+      <div class="flex items-center justify-between p-4 md:p-5 border-b rounded-t border-gray-600">
+        <h3 class="text-lg font-semibold text-white">
+          {{ $t('flash.erase_flash') }} {{ deviceStore.$state.selectedTarget?.displayName }}
+        </h3>
+        <button
+          type="button"
+          class="text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm h-8 w-8 ms-auto inline-flex justify-center items-center hover:bg-gray-600 hover:text-white"
+          data-modal-toggle="flash-modal"
+          @click="closeModal"
+        >
+          <X class="w-3 h-3" />
+          <span class="sr-only">{{ $t('actions.close_dialog') }}</span>
+        </button>
+      </div>
+      <div class="p-4 md:p-5">
+        <ol class="relative border-s border-gray-200 border-gray-600 ms-3.5 mb-4 md:mb-5">
+          <li class="mb-10 ms-8">
+            <span class="absolute flex items-center justify-center w-6 h-6 rounded-full -start-3 ring-8 bg-cyan-900 text-gray-100 ring-gray-900">
+              1
+            </span>
+            <h3 class="flex items-start mb-1 text-lg font-semibold text-white">
+              {{ $t('flash.uf2.enter_dfu_mode') }}
+            </h3>
+            <div
+              class="p-4 mb-4 my-2 text-sm rounded-lg bg-blue-50 bg-gray-800 text-blue-200"
+              role="alert"
+            >
+              <span class="font-medium">
+                <Info class="h-4 w-4 inline" />
+                {{ $t('flash.uf2.dfu_firmware_clause') }} &lt; {{ deviceStore.enterDfuVersion }}, {{ $t('flash.uf2.dfu_firmware_clause_2') }} {{ deviceStore.dfuStepAction }}
+                <br>
+                {{ $t('flash.erase_uf2.dfu_warning') }}
+              </span>
             </div>
-            <div class="p-4 md:p-5">
-                <ol class="relative border-s border-gray-200 border-gray-600 ms-3.5 mb-4 md:mb-5">
-                    <li class="mb-10 ms-8">
-                        <span class="absolute flex items-center justify-center w-6 h-6 rounded-full -start-3 ring-8 bg-cyan-900 text-gray-100 ring-gray-900">
-                            1
-                        </span>
-                        <h3 class="flex items-start mb-1 text-lg font-semibold text-white">
-                            {{ $t('flash.uf2.enter_dfu_mode') }}
-                        </h3>
-                        <div class="p-4 mb-4 my-2 text-sm rounded-lg bg-blue-50 bg-gray-800 text-blue-200" role="alert">
-                            <span class="font-medium">
-                                <Info class="h-4 w-4 inline" />
-                                {{ $t('flash.uf2.dfu_firmware_clause') }} &lt; {{ deviceStore.enterDfuVersion }}, {{ $t('flash.uf2.dfu_firmware_clause_2')}} {{ deviceStore.dfuStepAction }}
-                                <br />
-                                {{ $t('flash.erase_uf2.dfu_warning') }}
-                            </span>
-                        </div>
-                        <button type="button"
-                            class="inline-flex w-[250px] justify-center items-center py-2 px-3 text-sm font-medium focus:outline-none bg-meshtastic rounded-lg hover:bg-white focus:z-10 focus:ring-4 focus:ring-gray-200 text-black"
-                            @click="() => deviceStore.enterDfuMode($t)">
-                            <FolderDown class="h-4 w-4 text-black" />
-                            {{ $t('flash.uf2.enter_dfu') }}
-                        </button>
-                    </li>
-                    <li class="mb-10 ms-8">
-                        <span class="absolute flex items-center justify-center w-6 h-6 rounded-full -start-3 ring-8 bg-cyan-900 text-gray-100 ring-gray-900">
-                            2
-                        </span>
-                        <h3 class="flex items-start mb-1 text-lg font-semibold text-white">
-                            {{ $t('flash.uf2.ensure_drive_mounted') }}
-                        </h3>
-                        <span>
-                            {{ $t('flash.uf2.drive_name_info') }}
-                        </span>
-                        <div>
-                            <img v-if="deviceStore.isSelectedNrf" src="@/assets/img/dfu.png" :alt="$t('flash.uf2.dfu_drive')" />
-                            <img v-else src="@/assets/img/uf2_rp2040.png" :alt="$t('flash.uf2.dfu_drive')" />
-                        </div>
-                    </li>
-                    <li class="ms-8">
-                        <span class="absolute flex items-center justify-center w-6 h-6 rounded-full -start-3 ring-8 bg-cyan-900 text-gray-100 ring-gray-900">
-                            3
-                        </span>
-                        <h3 class="mb-1 text-lg font-semibold text-white">
-                            {{ $t('flash.uf2.download_copy_uf2') }}
-                        </h3>
-                        <div class="py-2">
-                            <span>
-                                {{ $t('flash.uf2.copy_instructions') }}
-                                {{ !deviceStore.isSelectedNrf ? $t('flash.erase_uf2.warning') : '' }}
-                            </span>
-                        </div>
-                        <a :href="uf2File" download="" 
-                            class="inline-flex w-[250px] justify-center items-center py-2 px-3 text-sm font-medium focus:outline-none bg-meshtastic rounded-lg hover:bg-white focus:z-10 focus:ring-4 focus:ring-gray-200 text-black">
-                            {{ $t('flash.uf2.download_uf2') }}
-                        </a>
-                    </li>
-                    <li class="ms-8 mt-4" v-if="deviceStore.isSelectedNrf">
-                        <span class="absolute flex items-center justify-center w-6 h-6 rounded-full -start-3 ring-8 bg-cyan-900 text-gray-100 ring-gray-900">
-                            4
-                        </span>
-                        <h3 class="mb-1 text-lg font-semibold text-white">
-                            {{ $t('buttons.serial_monitor') }}
-                        </h3>
-                        <div class="py-2">
-                            {{ $t('flash.erase_uf2.wait_for_drive') }}
-                        </div>
-                        <div>
-                        <button v-if="deviceStore.isSelectedNrf"
-                            class="text-black inline-flex w-[250px] justify-center bg-meshtastic hover:bg-gray-200 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center" 
-                            @click="openSerial">
-                            {{ $t('buttons.serial_monitor') }}
-                        </button>
-                        
-                        </div>
-                    </li>
-                    <li class="ms-8 mt-4" v-if="deviceStore.isSelectedNrf">
-                        <span class="absolute flex items-center justify-center w-6 h-6 rounded-full -start-3 ring-8 bg-cyan-900 text-gray-100 ring-gray-900">
-                            5
-                        </span>
-                        <h3 class="mb-1 text-lg font-semibold text-white">
-                            {{ $t('firmware.title') }}
-                        </h3>
-                        <div class="py-2">
-                            {{ $t('flash.erase_uf2.close_instructions') }}
-                        </div>
-                        <div>
-                            <button type="button"
-                            class="inline-flex w-[250px] justify-center items-center py-2 px-3 text-sm font-medium focus:outline-none bg-meshtastic rounded-lg hover:bg-white focus:z-10 focus:ring-4 focus:ring-gray-200 text-black"
-                            @click="closeModal">
-                            {{ $t('actions.continue') }}
-                        </button>
-                        </div>
-                    </li>
-                </ol>
-                <div id="terminal"></div>
+            <button
+              type="button"
+              class="inline-flex w-[250px] justify-center items-center py-2 px-3 text-sm font-medium focus:outline-none bg-meshtastic rounded-lg hover:bg-white focus:z-10 focus:ring-4 focus:ring-gray-200 text-black"
+              @click="() => deviceStore.enterDfuMode($t)"
+            >
+              <FolderDown class="h-4 w-4 text-black" />
+              {{ $t('flash.uf2.enter_dfu') }}
+            </button>
+          </li>
+          <li class="mb-10 ms-8">
+            <span class="absolute flex items-center justify-center w-6 h-6 rounded-full -start-3 ring-8 bg-cyan-900 text-gray-100 ring-gray-900">
+              2
+            </span>
+            <h3 class="flex items-start mb-1 text-lg font-semibold text-white">
+              {{ $t('flash.uf2.ensure_drive_mounted') }}
+            </h3>
+            <span>
+              {{ $t('flash.uf2.drive_name_info') }}
+            </span>
+            <div>
+              <img
+                v-if="deviceStore.isSelectedNrf"
+                src="@/assets/img/dfu.png"
+                :alt="$t('flash.uf2.dfu_drive')"
+              >
+              <img
+                v-else
+                src="@/assets/img/uf2_rp2040.png"
+                :alt="$t('flash.uf2.dfu_drive')"
+              >
             </div>
-        </div>
+          </li>
+          <li class="ms-8">
+            <span class="absolute flex items-center justify-center w-6 h-6 rounded-full -start-3 ring-8 bg-cyan-900 text-gray-100 ring-gray-900">
+              3
+            </span>
+            <h3 class="mb-1 text-lg font-semibold text-white">
+              {{ $t('flash.uf2.download_copy_uf2') }}
+            </h3>
+            <div class="py-2">
+              <span>
+                {{ $t('flash.uf2.copy_instructions') }}
+                {{ !deviceStore.isSelectedNrf ? $t('flash.erase_uf2.warning') : '' }}
+              </span>
+            </div>
+            <a
+              :href="uf2File"
+              download=""
+              class="inline-flex w-[250px] justify-center items-center py-2 px-3 text-sm font-medium focus:outline-none bg-meshtastic rounded-lg hover:bg-white focus:z-10 focus:ring-4 focus:ring-gray-200 text-black"
+            >
+              {{ $t('flash.uf2.download_uf2') }}
+            </a>
+          </li>
+          <li
+            v-if="deviceStore.isSelectedNrf"
+            class="ms-8 mt-4"
+          >
+            <span class="absolute flex items-center justify-center w-6 h-6 rounded-full -start-3 ring-8 bg-cyan-900 text-gray-100 ring-gray-900">
+              4
+            </span>
+            <h3 class="mb-1 text-lg font-semibold text-white">
+              {{ $t('buttons.serial_monitor') }}
+            </h3>
+            <div class="py-2">
+              {{ $t('flash.erase_uf2.wait_for_drive') }}
+            </div>
+            <div>
+              <button
+                v-if="deviceStore.isSelectedNrf"
+                class="text-black inline-flex w-[250px] justify-center bg-meshtastic hover:bg-gray-200 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center"
+                @click="openSerial"
+              >
+                {{ $t('buttons.serial_monitor') }}
+              </button>
+            </div>
+          </li>
+          <li
+            v-if="deviceStore.isSelectedNrf"
+            class="ms-8 mt-4"
+          >
+            <span class="absolute flex items-center justify-center w-6 h-6 rounded-full -start-3 ring-8 bg-cyan-900 text-gray-100 ring-gray-900">
+              5
+            </span>
+            <h3 class="mb-1 text-lg font-semibold text-white">
+              {{ $t('firmware.title') }}
+            </h3>
+            <div class="py-2">
+              {{ $t('flash.erase_uf2.close_instructions') }}
+            </div>
+            <div>
+              <button
+                type="button"
+                class="inline-flex w-[250px] justify-center items-center py-2 px-3 text-sm font-medium focus:outline-none bg-meshtastic rounded-lg hover:bg-white focus:z-10 focus:ring-4 focus:ring-gray-200 text-black"
+                @click="closeModal"
+              >
+                {{ $t('actions.continue') }}
+              </button>
+            </div>
+          </li>
+        </ol>
+        <div id="terminal" />
+      </div>
     </div>
+  </div>
 </template>
 
 <script lang="ts" setup>
 import {
   FolderDown,
   Info,
-} from 'lucide-vue-next';
-import { track } from '@vercel/analytics';
-import { computed } from 'vue';
+} from 'lucide-vue-next'
+import { track } from '@vercel/analytics'
+import { computed } from 'vue'
 
-import { useDeviceStore } from '../../stores/deviceStore';
-import { useFirmwareStore } from '../../stores/firmwareStore';
-import FlashHeader from './FlashHeader.vue';
-import ReleaseNotes from './ReleaseNotes.vue';
+import { useDeviceStore } from '../../stores/deviceStore'
+import { useFirmwareStore } from '../../stores/firmwareStore'
+import FlashHeader from './FlashHeader.vue'
+import ReleaseNotes from './ReleaseNotes.vue'
 
-const deviceStore = useDeviceStore();
-const firmwareStore = useFirmwareStore();
+const deviceStore = useDeviceStore()
+const firmwareStore = useFirmwareStore()
 
 const uf2File = computed(() => {
-    if (!deviceStore.isSelectedNrf) {
-        return '/uf2/pico_erase.uf2';
-    }
+  if (!deviceStore.isSelectedNrf) {
+    return '/uf2/pico_erase.uf2'
+  }
 
-    return deviceStore.isSoftDevice7point3 ? '/uf2/nrf_erase_sd7_3.uf2' : '/uf2/nrf_erase2.uf2';
-});
+  return deviceStore.isSoftDevice7point3 ? '/uf2/nrf_erase_sd7_3.uf2' : '/uf2/nrf_erase2.uf2'
+})
 
 const closeModal = () => {
-    document.getElementById('erase-modal')?.click(); // Flowbite bug
+  document.getElementById('erase-modal')?.click() // Flowbite bug
 }
 
 const openSerial = async () => {
-    const terminal = await openTerminal();
-    const port = await navigator.serial.requestPort({});
-    await port.open({ baudRate: 115200 });
-    // read from the serial port
-    const reader = port.readable!.getReader();
-    const writer = port.writable!.getWriter();
-    while (true) {
-        const { value, done } = await reader.read();
-        if (value) {
-            terminal.write(value);
-            writer.write(new Uint8Array([0x01, 0x01]));
-        }
-        if (done) {
-            console.log('[readLoop] DONE', done);
-            reader.releaseLock();
-            break;
-        }
+  const terminal = await openTerminal()
+  const port = await navigator.serial.requestPort({})
+  await port.open({ baudRate: 115200 })
+  // read from the serial port
+  const reader = port.readable!.getReader()
+  const writer = port.writable!.getWriter()
+  while (true) {
+    const { value, done } = await reader.read()
+    if (value) {
+      terminal.write(value)
+      writer.write(new Uint8Array([0x01, 0x01]))
     }
-};
+    if (done) {
+      console.log('[readLoop] DONE', done)
+      reader.releaseLock()
+      break
+    }
+  }
+}
 </script>

--- a/components/targets/Esp32.vue
+++ b/components/targets/Esp32.vue
@@ -1,268 +1,345 @@
 <template>
-    <div class="relative w-full max-w-full sm:max-w-4xl max-h-full px-2 sm:px-0">
-        <div class="relative rounded-lg shadow bg-zinc-700">
-            <FlashHeader />
-            <div class="p-3 sm:p-4 md:p-5">
-                <ReleaseNotes />
-                <ol v-if="firmwareStore.canShowFlash" class="relative border-s border-gray-200 border-gray-600 ms-2 sm:ms-3.5 mb-4 md:mb-5">
-                    <li class="mb-10 ms-6 sm:ms-8">
-                        <span class="absolute flex items-center justify-center w-6 h-6 rounded-full -start-3 ring-8 bg-cyan-900 text-gray-100 ring-gray-900">
-                            1
-                        </span>
-                        <h3 class="flex items-start mb-1 text-base sm:text-lg font-semibold text-white">
-                            {{ $t('flash.esp32.step_1_usb') }}
-                        </h3>
-                        <div class="p-3 sm:p-4 mb-4 my-2 text-xs sm:text-sm rounded-lg bg-gray-800 text-blue-200" role="alert">
-                            <span class="font-medium">
-                                <Info class="h-4 w-4 inline" />
-                                {{ $t('flash.esp32.s3_instructions') }}
-                                <br />
-                                {{ $t('flash.esp32.reset_alternative') }}
-                                <button type="button"
-                                    class="inline-flex items-center mt-1 mx-1 py-1 px-2 text-xs sm:text-sm font-medium focus:outline-none bg-meshtastic rounded-lg hover:bg-white focus:z-10 focus:ring-4 focus:ring-gray-200 text-black"
-                                    @click="deviceStore.baud1200()">
-                                    <Cpu class="h-4 w-4 text-black" />
-                                    {{ $t('flash.esp32.reset_button') }}
-                                </button>
-                            </span>
-                        </div>
-                    </li>
-                    <li class="mb-10 ms-6 sm:ms-8">
-                        <span class="absolute flex items-center justify-center w-6 h-6 rounded-full -start-3 ring-8 bg-cyan-900 text-gray-100 ring-gray-900">
-                            2
-                        </span>
-                        <h3 class="flex items-start mb-1 text-base sm:text-lg font-semibold text-white">
-                            {{ $t('flash.esp32.step_2_baud_rate') }}
-                        </h3>
-                        <div>
-                            <select class="block w-full mt-1 rounded-md border-gray-300 shadow-sm focus:border-blue-300 focus:ring focus:ring-blue-200 focus:ring-opacity-50" v-model="firmwareStore.$state.baudRate">
-                                <option value="115200">115200</option>
-                                <option value="230400">230400</option>
-                                <option value="460800">460800</option>
-                                <option value="921600">921600</option>
-                                <!-- TODO styling and wire this up -->
-                            </select>
-                            <span class="text-xs sm:text-sm mt-1">{{ $t('flash.esp32.slow_reliable') }}</span>
-                        </div>
-                    </li>
-                    <li class="ms-6 sm:ms-8">
-                        <span class="absolute flex items-center justify-center w-6 h-6 rounded-full -start-3 ring-8 bg-cyan-900 text-gray-100 ring-gray-900">
-                            3
-                        </span>
-                        <h3 class="mb-1 text-base sm:text-lg font-semibold text-white">
-                            {{ $t('flash.esp32.step_3_flash') }}
-                        </h3>
-                        <label class="relative inline-flex items-center me-2 sm:me-5 mb-2 cursor-pointer" v-if="canFullInstall()">
-                            <input type="checkbox" value="" class="sr-only peer" v-model="firmwareStore.$state.shouldCleanInstall">
-                            <div class="w-11 h-6 rounded-full peer peer-focus:ring-4 bg-gray-400 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all border-gray-600 peer-checked:bg-red-600"></div>
-                            <span class="ms-2 sm:ms-3 text-xs sm:text-sm font-medium text-gray-100">{{ $t('flash.esp32.full_erase') }}</span>
-                        </label>
-                        <!-- <label class="relative inline-flex items-center me-5 cursor-pointer" v-if="firmwareStore.$state.shouldCleanInstall && canBundleWebUI">
+  <div class="relative w-full max-w-full sm:max-w-4xl max-h-full px-2 sm:px-0">
+    <div class="relative rounded-lg shadow bg-zinc-700">
+      <FlashHeader />
+      <div class="p-3 sm:p-4 md:p-5">
+        <ReleaseNotes />
+        <ol
+          v-if="firmwareStore.canShowFlash"
+          class="relative border-s border-gray-200 border-gray-600 ms-2 sm:ms-3.5 mb-4 md:mb-5"
+        >
+          <li class="mb-10 ms-6 sm:ms-8">
+            <span class="absolute flex items-center justify-center w-6 h-6 rounded-full -start-3 ring-8 bg-cyan-900 text-gray-100 ring-gray-900">
+              1
+            </span>
+            <h3 class="flex items-start mb-1 text-base sm:text-lg font-semibold text-white">
+              {{ $t('flash.esp32.step_1_usb') }}
+            </h3>
+            <div
+              class="p-3 sm:p-4 mb-4 my-2 text-xs sm:text-sm rounded-lg bg-gray-800 text-blue-200"
+              role="alert"
+            >
+              <span class="font-medium">
+                <Info class="h-4 w-4 inline" />
+                {{ $t('flash.esp32.s3_instructions') }}
+                <br>
+                {{ $t('flash.esp32.reset_alternative') }}
+                <button
+                  type="button"
+                  class="inline-flex items-center mt-1 mx-1 py-1 px-2 text-xs sm:text-sm font-medium focus:outline-none bg-meshtastic rounded-lg hover:bg-white focus:z-10 focus:ring-4 focus:ring-gray-200 text-black"
+                  @click="deviceStore.baud1200()"
+                >
+                  <Cpu class="h-4 w-4 text-black" />
+                  {{ $t('flash.esp32.reset_button') }}
+                </button>
+              </span>
+            </div>
+          </li>
+          <li class="mb-10 ms-6 sm:ms-8">
+            <span class="absolute flex items-center justify-center w-6 h-6 rounded-full -start-3 ring-8 bg-cyan-900 text-gray-100 ring-gray-900">
+              2
+            </span>
+            <h3 class="flex items-start mb-1 text-base sm:text-lg font-semibold text-white">
+              {{ $t('flash.esp32.step_2_baud_rate') }}
+            </h3>
+            <div>
+              <select
+                v-model="firmwareStore.$state.baudRate"
+                class="block w-full mt-1 rounded-md border-gray-300 shadow-sm focus:border-blue-300 focus:ring focus:ring-blue-200 focus:ring-opacity-50"
+              >
+                <option value="115200">
+                  115200
+                </option>
+                <option value="230400">
+                  230400
+                </option>
+                <option value="460800">
+                  460800
+                </option>
+                <option value="921600">
+                  921600
+                </option>
+                <!-- TODO styling and wire this up -->
+              </select>
+              <span class="text-xs sm:text-sm mt-1">{{ $t('flash.esp32.slow_reliable') }}</span>
+            </div>
+          </li>
+          <li class="ms-6 sm:ms-8">
+            <span class="absolute flex items-center justify-center w-6 h-6 rounded-full -start-3 ring-8 bg-cyan-900 text-gray-100 ring-gray-900">
+              3
+            </span>
+            <h3 class="mb-1 text-base sm:text-lg font-semibold text-white">
+              {{ $t('flash.esp32.step_3_flash') }}
+            </h3>
+            <label
+              v-if="canFullInstall()"
+              class="relative inline-flex items-center me-2 sm:me-5 mb-2 cursor-pointer"
+            >
+              <input
+                v-model="firmwareStore.$state.shouldCleanInstall"
+                type="checkbox"
+                value=""
+                class="sr-only peer"
+              >
+              <div class="w-11 h-6 rounded-full peer peer-focus:ring-4 bg-gray-400 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all border-gray-600 peer-checked:bg-red-600" />
+              <span class="ms-2 sm:ms-3 text-xs sm:text-sm font-medium text-gray-100">{{ $t('flash.esp32.full_erase') }}</span>
+            </label>
+            <!-- <label class="relative inline-flex items-center me-5 cursor-pointer" v-if="firmwareStore.$state.shouldCleanInstall && canBundleWebUI">
                             <input type="checkbox" value="" class="sr-only peer" v-model="firmwareStore.$state.shouldBundleWebUI">
                             <div class="w-11 h-6 rounded-full peer peer-focus:ring-4 bg-gray-400 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all border-gray-600 peer-checked:bg-red-600"></div>
                             <span class="ms-3 text-sm font-medium text-gray-100">{{ $t('flash.esp32.bundle_webui') }}</span>
                         </label> -->
-                        <label class="relative inline-flex items-center me-2 sm:me-5 mb-2 cursor-pointer" v-if="canInstallMui">
-                            <input type="checkbox" value="" class="sr-only peer" v-model="firmwareStore.$state.shouldInstallMui">
-                            <div class="w-11 h-6 rounded-full peer peer-focus:ring-4 bg-gray-400 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all border-gray-600 peer-checked:bg-red-600"></div>
-                            <img src="/img/Meshtastic-UI-Long.svg" class="h-6 mx-1" alt="Meshtastic UI" />
-                        </label>
-                        <label class="relative inline-flex items-center me-2 sm:me-5 mb-2 cursor-pointer" v-if="canInstallInkHud">
-                            <input type="checkbox" value="" class="sr-only peer" v-model="firmwareStore.$state.shouldInstallInkHud">
-                            <div class="w-11 h-6 rounded-full peer peer-focus:ring-4 bg-gray-400 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all border-gray-600 peer-checked:bg-red-600"></div>
-                            <span class="ms-2 sm:ms-3 text-xs sm:text-sm font-medium text-gray-100">{{ $t('flash.esp32.install_inkhud') }}</span>
-                        </label>
-                        <div v-if="firmwareStore.$state.shouldCleanInstall" role="alert" class="flex flex-col p-3 sm:p-4 mb-4 mt-2 text-xs sm:text-sm text-red-800 rounded-lg bg-red-50 bg-gray-800 text-red-400">
-                            <div class="flex items-center">
-                                <Info class="flex-shrink-0 inline w-4 h-4 mr-1" />
-                                <span>
-                                    {{ $t('flash.esp32.backup_warning') }}
-                                    <span v-if="firmwareStore.$state.shouldBundleWebUI">{{ $t('flash.esp32.webui_space_warning') }}</span>
-                                </span>
-                            </div>
-                            <div class="flex items-center mt-2">
-                                <Link class="h-4 w-4 mr-1 text-red-400" />
-                                <a href="https://meshtastic.org/docs/configuration/radio/security/#security-keys---backup-and-restore" target="_blank" class="underline text-red-800 text-red-400">
-                                    {{ $t('flash.esp32.doc_guide') }}</a>
-                            </div>
-                        </div>
-                        <p>
-                            {{ $t('flash.esp32.process_warning') }}
-                        </p>
-                        <div>
-                            <div class="p-3 sm:p-4 mb-4 my-2 text-xs sm:text-sm rounded-lg bg-blue-50 bg-gray-800 text-blue-200" role="alert">
-                                <span class="font-medium">
-                                    <Info class="h-4 w-4 inline" />
-                                    {{ $t('flash.esp32.reset_after_flash') }}
-                                </span>
-                            </div>
-                        </div>
-                    </li>
-                </ol>
-                <div v-if="firmwareStore.canShowFlash">
-                    <button v-if="showFlashButton"
-                        class="text-black inline-flex w-full justify-center bg-meshtastic hover:bg-gray-200 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center" @click="flash">
-                        {{ firmwareStore.$state.shouldCleanInstall ? $t('flash.esp32.erase_and_install') : $t('flash.esp32.update') }}
-                    </button>
-                    <button v-if="firmwareStore.$state.flashPercentDone > 0 && !firmwareStore.$state.isFlashing"
-                        class="text-black inline-flex w-full justify-center bg-meshtastic hover:bg-gray-200 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center" @click="startOver">
-                        {{ $t('flash.esp32.start_over') }}
-                    </button>
-                    <div v-if="firmwareStore.$state.flashPercentDone > 0" class="mb-1 text-center font-medium text-white">{{ $t('flash.esp32.flashing_complete') }} {{ partition }} {{ firmwareStore.percentDone }} {{ $t('flash.esp32.complete') }}</div>
-                    <div class="w-fullrounded-full h-2.5 mb-4 bg-zinc-700" v-if="firmwareStore.$state.flashPercentDone > 0">
-                        <div class="bg-meshtastic h-2.5 rounded-full" :style=" { 'width': firmwareStore.percentDone }"></div>
-                    </div>
-                </div>
-                <div id="terminal"></div>
+            <label
+              v-if="canInstallMui"
+              class="relative inline-flex items-center me-2 sm:me-5 mb-2 cursor-pointer"
+            >
+              <input
+                v-model="firmwareStore.$state.shouldInstallMui"
+                type="checkbox"
+                value=""
+                class="sr-only peer"
+              >
+              <div class="w-11 h-6 rounded-full peer peer-focus:ring-4 bg-gray-400 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all border-gray-600 peer-checked:bg-red-600" />
+              <img
+                src="/img/Meshtastic-UI-Long.svg"
+                class="h-6 mx-1"
+                alt="Meshtastic UI"
+              >
+            </label>
+            <label
+              v-if="canInstallInkHud"
+              class="relative inline-flex items-center me-2 sm:me-5 mb-2 cursor-pointer"
+            >
+              <input
+                v-model="firmwareStore.$state.shouldInstallInkHud"
+                type="checkbox"
+                value=""
+                class="sr-only peer"
+              >
+              <div class="w-11 h-6 rounded-full peer peer-focus:ring-4 bg-gray-400 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all border-gray-600 peer-checked:bg-red-600" />
+              <span class="ms-2 sm:ms-3 text-xs sm:text-sm font-medium text-gray-100">{{ $t('flash.esp32.install_inkhud') }}</span>
+            </label>
+            <div
+              v-if="firmwareStore.$state.shouldCleanInstall"
+              role="alert"
+              class="flex flex-col p-3 sm:p-4 mb-4 mt-2 text-xs sm:text-sm text-red-800 rounded-lg bg-red-50 bg-gray-800 text-red-400"
+            >
+              <div class="flex items-center">
+                <Info class="flex-shrink-0 inline w-4 h-4 mr-1" />
+                <span>
+                  {{ $t('flash.esp32.backup_warning') }}
+                  <span v-if="firmwareStore.$state.shouldBundleWebUI">{{ $t('flash.esp32.webui_space_warning') }}</span>
+                </span>
+              </div>
+              <div class="flex items-center mt-2">
+                <Link class="h-4 w-4 mr-1 text-red-400" />
+                <a
+                  href="https://meshtastic.org/docs/configuration/radio/security/#security-keys---backup-and-restore"
+                  target="_blank"
+                  class="underline text-red-800 text-red-400"
+                >
+                  {{ $t('flash.esp32.doc_guide') }}</a>
+              </div>
             </div>
+            <p>
+              {{ $t('flash.esp32.process_warning') }}
+            </p>
+            <div>
+              <div
+                class="p-3 sm:p-4 mb-4 my-2 text-xs sm:text-sm rounded-lg bg-blue-50 bg-gray-800 text-blue-200"
+                role="alert"
+              >
+                <span class="font-medium">
+                  <Info class="h-4 w-4 inline" />
+                  {{ $t('flash.esp32.reset_after_flash') }}
+                </span>
+              </div>
+            </div>
+          </li>
+        </ol>
+        <div v-if="firmwareStore.canShowFlash">
+          <button
+            v-if="showFlashButton"
+            class="text-black inline-flex w-full justify-center bg-meshtastic hover:bg-gray-200 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center"
+            @click="flash"
+          >
+            {{ firmwareStore.$state.shouldCleanInstall ? $t('flash.esp32.erase_and_install') : $t('flash.esp32.update') }}
+          </button>
+          <button
+            v-if="firmwareStore.$state.flashPercentDone > 0 && !firmwareStore.$state.isFlashing"
+            class="text-black inline-flex w-full justify-center bg-meshtastic hover:bg-gray-200 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center"
+            @click="startOver"
+          >
+            {{ $t('flash.esp32.start_over') }}
+          </button>
+          <div
+            v-if="firmwareStore.$state.flashPercentDone > 0"
+            class="mb-1 text-center font-medium text-white"
+          >
+            {{ $t('flash.esp32.flashing_complete') }} {{ partition }} {{ firmwareStore.percentDone }} {{ $t('flash.esp32.complete') }}
+          </div>
+          <div
+            v-if="firmwareStore.$state.flashPercentDone > 0"
+            class="w-fullrounded-full h-2.5 mb-4 bg-zinc-700"
+          >
+            <div
+              class="bg-meshtastic h-2.5 rounded-full"
+              :style=" { width: firmwareStore.percentDone }"
+            />
+          </div>
         </div>
+        <div id="terminal" />
+      </div>
     </div>
+  </div>
 </template>
 
 <script lang="ts" setup>
-import '@/node_modules/xterm/css/xterm.css';
-import { useI18n } from 'vue-i18n';
-
-const { t } = useI18n();
+import '@/node_modules/xterm/css/xterm.css'
+import { useI18n } from 'vue-i18n'
 
 import {
   Cpu,
   Info,
   Link,
-} from 'lucide-vue-next';
+} from 'lucide-vue-next'
 import {
   BlobReader,
   ZipReader,
-} from '@zip.js/zip.js';
+} from '@zip.js/zip.js'
 
+import { useDeviceStore } from '../../stores/deviceStore'
+import { useFirmwareStore } from '../../stores/firmwareStore'
+import FlashHeader from './FlashHeader.vue'
+import ReleaseNotes from './ReleaseNotes.vue'
 
-import { useDeviceStore } from '../../stores/deviceStore';
-import { useFirmwareStore } from '../../stores/firmwareStore';
-import FlashHeader from './FlashHeader.vue';
-import ReleaseNotes from './ReleaseNotes.vue';
+const { t } = useI18n()
 
-const deviceStore = useDeviceStore();
-const firmwareStore = useFirmwareStore();
+const deviceStore = useDeviceStore()
+const firmwareStore = useFirmwareStore()
 
 const partition = computed(() => {
-    if (firmwareStore.$state.flashingIndex === 0) {
-        return t('flash.esp32.partition_app');
-    } 
-    if (firmwareStore.$state.flashingIndex === 1) {
-        return t('flash.esp32.partition_ota');
-    } 
-    if (firmwareStore.$state.flashingIndex === 2) {
-        return t('flash.esp32.partition_fs');
-    }
-    return ''
+  if (firmwareStore.$state.flashingIndex === 0) {
+    return t('flash.esp32.partition_app')
+  }
+  if (firmwareStore.$state.flashingIndex === 1) {
+    return t('flash.esp32.partition_ota')
+  }
+  if (firmwareStore.$state.flashingIndex === 2) {
+    return t('flash.esp32.partition_fs')
+  }
+  return ''
 })
 
 const showFlashButton = computed(() => {
-    return !firmwareStore.$state.isFlashing && firmwareStore.$state.flashPercentDone < 1;
+  return !firmwareStore.$state.isFlashing && firmwareStore.$state.flashPercentDone < 1
 })
 
 const startOver = () => {
-    firmwareStore.$state.isFlashing = false;
-    firmwareStore.$state.flashPercentDone = 0;
+  firmwareStore.$state.isFlashing = false
+  firmwareStore.$state.flashPercentDone = 0
 }
 
 const flash = () => {
-    firmwareStore.$state.partitionScheme = deviceStore.$state.selectedTarget.partitionScheme;
-    if (firmwareStore.$state.shouldCleanInstall) {  
-        cleanInstallEsp32();
-    } else {
-        updateEsp32();
-    }
+  firmwareStore.$state.partitionScheme = deviceStore.$state.selectedTarget.partitionScheme
+  if (firmwareStore.$state.shouldCleanInstall) {
+    cleanInstallEsp32()
+  }
+  else {
+    updateEsp32()
+  }
 }
 
 const canFullInstall = () => {
-    // Assume bin file if it's not a zip file and prevent full install if its not a full factory bin
-    if (firmwareStore.hasFirmwareFile && !firmwareStore.isZipFile && !firmwareStore.isFactoryBin)
-        return false;
-    return true;
+  // Assume bin file if it's not a zip file and prevent full install if its not a full factory bin
+  if (firmwareStore.hasFirmwareFile && !firmwareStore.isZipFile && !firmwareStore.isFactoryBin)
+    return false
+  return true
 }
-const canBundleWebUI = ref(false);
+const canBundleWebUI = ref(false)
 
 const isNewFirmware = computed(() => {
-    // Just check for *not* 2.5 firmware version for now
-    return !firmwareStore.firmwareVersion.includes('2.5');
-});
+  // Just check for *not* 2.5 firmware version for now
+  return !firmwareStore.firmwareVersion.includes('2.5')
+})
 
 const canInstallMui = computed(() => {
-    if (!isNewFirmware.value)
-        return false;
+  if (!isNewFirmware.value)
+    return false
     // Can't install MUI if we're installing the WebUI
-    return deviceStore.$state.selectedTarget.hasMui === true && !firmwareStore.shouldBundleWebUI;
-});
+  return deviceStore.$state.selectedTarget.hasMui === true && !firmwareStore.shouldBundleWebUI
+})
 
 const canInstallInkHud = computed(() => {
-    if (!isNewFirmware.value)
-        return false;
-    return deviceStore.$state.selectedTarget.hasInkHud === true;
-});
+  if (!isNewFirmware.value)
+    return false
+  return deviceStore.$state.selectedTarget.hasInkHud === true
+})
 
 watch(() => firmwareStore.$state.shouldInstallMui, () => {
-    canBundleWebUI.value = !firmwareStore.$state.shouldInstallMui;
-});
+  canBundleWebUI.value = !firmwareStore.$state.shouldInstallMui
+})
 
 watch(() => firmwareStore.$state.shouldCleanInstall, async () => {
-    if (firmwareStore.isZipFile && firmwareStore.$state.selectedFile) {
-        const reader = new BlobReader(firmwareStore.$state.selectedFile);
-        const zipReader = new ZipReader(reader);
-        const entries = await zipReader.getEntries();
-        const foundWebUI = entries.find(entry => entry.filename.startsWith('littlefswebui'));
-        canBundleWebUI.value = !!foundWebUI;
-    } else if (firmwareStore.selectedFirmware) {
-        canBundleWebUI.value = await checkIfRemoteFileExists(firmwareStore.getReleaseFileUrl(littleFsFileName.value)) && !firmwareStore.$state.shouldInstallMui;
-    }
-    else {
-        canBundleWebUI.value = false;
-    }
-});
+  if (firmwareStore.isZipFile && firmwareStore.$state.selectedFile) {
+    const reader = new BlobReader(firmwareStore.$state.selectedFile)
+    const zipReader = new ZipReader(reader)
+    const entries = await zipReader.getEntries()
+    const foundWebUI = entries.find(entry => entry.filename.startsWith('littlefswebui'))
+    canBundleWebUI.value = !!foundWebUI
+  }
+  else if (firmwareStore.selectedFirmware) {
+    canBundleWebUI.value = await checkIfRemoteFileExists(firmwareStore.getReleaseFileUrl(littleFsFileName.value)) && !firmwareStore.$state.shouldInstallMui
+  }
+  else {
+    canBundleWebUI.value = false
+  }
+})
 
 const targetPrefix = computed(() => {
-    let pioSuffix = "";
-    // Crowpanel ends with -tft, so don't add -tft suffix
-    if (firmwareStore.$state.shouldInstallMui && !deviceStore.$state.selectedTarget.platformioTarget.endsWith("-tft")) {
-        pioSuffix = "-tft";
-    } else if (firmwareStore.$state.shouldInstallInkHud) {
-        pioSuffix = "-inkhud";
-    }
-    return `${deviceStore.$state.selectedTarget.platformioTarget}${pioSuffix}-${firmwareStore.firmwareVersion}`;
-});
+  let pioSuffix = ''
+  // Crowpanel ends with -tft, so don't add -tft suffix
+  if (firmwareStore.$state.shouldInstallMui && !deviceStore.$state.selectedTarget.platformioTarget.endsWith('-tft')) {
+    pioSuffix = '-tft'
+  }
+  else if (firmwareStore.$state.shouldInstallInkHud) {
+    pioSuffix = '-inkhud'
+  }
+  return `${deviceStore.$state.selectedTarget.platformioTarget}${pioSuffix}-${firmwareStore.firmwareVersion}`
+})
 
 const cleanInstallEsp32 = () => {
-    const firmwareFile = `firmware-${targetPrefix.value}.bin`;
-    const otaFile = deviceStore.$state.selectedTarget.architecture === 'esp32-s3' ? 'bleota-s3.bin' : 'bleota.bin';
-    // Coerce the partition scheme to be the same as the selected target for all 2.6.2+ firmwares
-    if (deviceStore.$state.selectedTarget.partitionScheme && twoPointSixPointTwoOrGreater.value) {
-        firmwareStore.$state.partitionScheme = deviceStore.$state.selectedTarget.partitionScheme;
-    }
-    console.log(firmwareFile, otaFile, littleFsFileName.value);
-    firmwareStore.cleanInstallEspFlash(firmwareFile, otaFile, littleFsFileName.value, deviceStore.$state.selectedTarget);
+  const firmwareFile = `firmware-${targetPrefix.value}.bin`
+  const otaFile = deviceStore.$state.selectedTarget.architecture === 'esp32-s3' ? 'bleota-s3.bin' : 'bleota.bin'
+  // Coerce the partition scheme to be the same as the selected target for all 2.6.2+ firmwares
+  if (deviceStore.$state.selectedTarget.partitionScheme && twoPointSixPointTwoOrGreater.value) {
+    firmwareStore.$state.partitionScheme = deviceStore.$state.selectedTarget.partitionScheme
+  }
+  console.log(firmwareFile, otaFile, littleFsFileName.value)
+  firmwareStore.cleanInstallEspFlash(firmwareFile, otaFile, littleFsFileName.value, deviceStore.$state.selectedTarget)
 }
 
 const twoPointSixPointTwoOrGreater = computed(() => {
-    if (!firmwareStore.firmwareVersion) {
-        return false;
-    }
-    if (firmwareStore.firmwareVersion.includes('2.6') &&
-        !firmwareStore.firmwareVersion.includes('2.6.0') && // 2.6.1 is pre-partition scheme
-        !firmwareStore.firmwareVersion.includes('2.6.1')) { // 2.6.0 is pre-partition scheme
-        return true;
-    }
-});
+  if (!firmwareStore.firmwareVersion) {
+    return false
+  }
+  if (firmwareStore.firmwareVersion.includes('2.6')
+    && !firmwareStore.firmwareVersion.includes('2.6.0') // 2.6.1 is pre-partition scheme
+    && !firmwareStore.firmwareVersion.includes('2.6.1')) { // 2.6.0 is pre-partition scheme
+    return true
+  }
+})
 
 const littleFsFileName = computed(() => {
-    let prefix = firmwareStore.shouldBundleWebUI ? 'littlefswebui' : 'littlefs';
-    const littleFsInfix = isNewFirmware.value ? `${targetPrefix.value}` : firmwareStore.firmwareVersion;
-    return `${prefix}-${littleFsInfix}.bin`;
-});
+  const prefix = firmwareStore.shouldBundleWebUI ? 'littlefswebui' : 'littlefs'
+  const littleFsInfix = isNewFirmware.value ? `${targetPrefix.value}` : firmwareStore.firmwareVersion
+  return `${prefix}-${littleFsInfix}.bin`
+})
 
 const updateEsp32 = () => {
-    // Get firmware version from selectedFirmware or use regex wildcard to match otherwise
-    const firmwareFile = `firmware-${targetPrefix.value}-update.bin`;
-    console.log(firmwareFile);
-    firmwareStore.updateEspFlash(firmwareFile, deviceStore.$state.selectedTarget);
+  // Get firmware version from selectedFirmware or use regex wildcard to match otherwise
+  const firmwareFile = `firmware-${targetPrefix.value}-update.bin`
+  console.log(firmwareFile)
+  firmwareStore.updateEspFlash(firmwareFile, deviceStore.$state.selectedTarget)
 }
 </script>

--- a/components/targets/FlashHeader.vue
+++ b/components/targets/FlashHeader.vue
@@ -1,28 +1,32 @@
 <template>
-    <div v-if="firmwareStore.canShowFlash" class="flex items-center justify-between p-3 sm:p-4 md:p-5 border-b rounded-t border-gray-600">
-        <h3 class="text-base sm:text-lg font-semibold text-white">
-            {{ $t('flash.title') }} {{ deviceStore.$state.selectedTarget?.displayName }}
-        </h3>
-        <button type="button"
-            class="text-gray-400 bg-transparent hover:bg-gray-600 hover:text-white rounded-lg text-sm h-8 w-8 ms-auto inline-flex justify-center items-center"
-            data-modal-toggle="flash-modal"
-            @click="closeFlashModal">
-            <X class="w-3 h-3" />
-            <span class="sr-only">{{ $t('actions.close_dialog') }}</span>
-        </button>
-    </div>
+  <div
+    v-if="firmwareStore.canShowFlash"
+    class="flex items-center justify-between p-3 sm:p-4 md:p-5 border-b rounded-t border-gray-600"
+  >
+    <h3 class="text-base sm:text-lg font-semibold text-white">
+      {{ $t('flash.title') }} {{ deviceStore.$state.selectedTarget?.displayName }}
+    </h3>
+    <button
+      type="button"
+      class="text-gray-400 bg-transparent hover:bg-gray-600 hover:text-white rounded-lg text-sm h-8 w-8 ms-auto inline-flex justify-center items-center"
+      data-modal-toggle="flash-modal"
+      @click="closeFlashModal"
+    >
+      <X class="w-3 h-3" />
+      <span class="sr-only">{{ $t('actions.close_dialog') }}</span>
+    </button>
+  </div>
 </template>
 
 <script lang="ts" setup>
-import { useDeviceStore } from '../../stores/deviceStore';
-import { useFirmwareStore } from '../../stores/firmwareStore';
-import { X } from 'lucide-vue-next';
+import { useDeviceStore } from '../../stores/deviceStore'
+import { useFirmwareStore } from '../../stores/firmwareStore'
+import { X } from 'lucide-vue-next'
 
-const deviceStore = useDeviceStore();
-const firmwareStore = useFirmwareStore();
+const deviceStore = useDeviceStore()
+const firmwareStore = useFirmwareStore()
 
 const closeFlashModal = () => {
-    document.getElementById('flash-modal')?.click(); // Flowbite bug
+  document.getElementById('flash-modal')?.click() // Flowbite bug
 }
-
 </script>

--- a/components/targets/ReleaseNotes.vue
+++ b/components/targets/ReleaseNotes.vue
@@ -1,42 +1,50 @@
 <template>
-  <div v-show="releaseNotes && !firmwareStore.hasSeenReleaseNotes" class="mb-4">
+  <div
+    v-show="releaseNotes && !firmwareStore.hasSeenReleaseNotes"
+    class="mb-4"
+  >
     <h1>
       {{ firmwareStore.selectedFirmware?.title }}
     </h1>
-    <div v-if="releaseNotes" v-html="releaseNotes">
-    </div>
-    <button @click="firmwareStore.continueToFlash()" class="border border-meshtastic focus:ring-4 focus:outline-none font-medium rounded-lg text-small px-4 py-2 text-center me-2 mb-2 text-meshtastic hover:text-black hover:bg-white hover:border-transparent hover:shadow">
+    <div
+      v-if="releaseNotes"
+      v-html="releaseNotes"
+    />
+    <button
+      class="border border-meshtastic focus:ring-4 focus:outline-none font-medium rounded-lg text-small px-4 py-2 text-center me-2 mb-2 text-meshtastic hover:text-black hover:bg-white hover:border-transparent hover:shadow"
+      @click="firmwareStore.continueToFlash()"
+    >
       {{ $t('actions.continue') }}
     </button>
   </div>
 </template>
 
 <script lang="ts" setup>
-import { marked } from 'marked';
+import { marked } from 'marked'
 
-import { useFirmwareStore } from '../../stores/firmwareStore';
+import { useFirmwareStore } from '../../stores/firmwareStore'
 
-const firmwareStore = useFirmwareStore();
+const firmwareStore = useFirmwareStore()
 
-const releaseNotes = ref<string | undefined>(undefined);
+const releaseNotes = ref<string | undefined>(undefined)
 
 watch(() => firmwareStore.selectedFirmware, async () => {
-  const notes = firmwareStore.selectedFirmware?.release_notes || '';
+  const notes = firmwareStore.selectedFirmware?.release_notes || ''
   if (notes.length < 1) {
-    releaseNotes.value = undefined;
-    console.log('No release notes');
-  } else {
-    console.log('Parsing release notes markdown');
-    const output = await marked(notes);
+    releaseNotes.value = undefined
+    console.log('No release notes')
+  }
+  else {
+    console.log('Parsing release notes markdown')
+    const output = await marked(notes)
     releaseNotes.value = output
       .replaceAll('<p>', '<blockquote class="p-4 my-4 border-s-4 border-meshtastic bg-gray-800">')
-      .replaceAll('</p>','</blockquote>')
-      .replaceAll('<br>','')
+      .replaceAll('</p>', '</blockquote>')
+      .replaceAll('<br>', '')
       .replaceAll('[!CAUTION]', '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" /></svg>')
       .replaceAll('[!IMPORTANT]', '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" /></svg>')
       .replaceAll('[!WARNING]', '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" /></svg>')
-      .replaceAll('[!NOTE]', '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" /></svg>');  
+      .replaceAll('[!NOTE]', '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" /></svg>')
   }
- });
-
+})
 </script>

--- a/components/targets/Uf2.vue
+++ b/components/targets/Uf2.vue
@@ -1,134 +1,166 @@
 <template>
-    <div class="relative p-4 w-full max-w-4xl max-h-full">
-        <div class="relative rounded-lg shadow bg-zinc-700">
-            <FlashHeader />
-            <div class="p-4 md:p-5">
-                <ReleaseNotes />
-                <ol v-if="firmwareStore.canShowFlash" class="relative border-s border-gray-200 border-gray-600 ms-3.5 mb-4 md:mb-5">
-                    <li class="mb-10 ms-8">
-                        <span class="absolute flex items-center justify-center w-6 h-6 rounded-full -start-3 ring-8 bg-cyan-900 text-gray-100 ring-gray-900">
-                            1
-                        </span>
-                        <h3 class="flex items-start mb-1 text-lg font-semibold text-white">
-                            {{ $t('flash.uf2.enter_dfu_mode') }}
-                        </h3>
-                        <div class="p-4 mb-4 my-2 text-sm rounded-lg bg-blue-50 bg-gray-800 text-blue-200" role="alert">
-                            <span class="font-medium">
-                                <Info class="h-4 w-4 inline" />
-                                {{ $t('flash.uf2.dfu_firmware_clause') }} &lt; {{ deviceStore.enterDfuVersion }}, {{ $t('flash.uf2.dfu_firmware_clause_2') }} {{ deviceStore.dfuStepAction }}
-                            </span>
-                        </div>
-                        <button type="button"
-                            class="inline-flex items-center py-2 px-3 text-sm font-medium focus:outline-none bg-meshtastic rounded-lg hover:bg-white focus:z-10 focus:ring-4 focus:ring-gray-200 text-black"
-                            @click="() => deviceStore.enterDfuMode($t)">
-                            <FolderDown class="h-4 w-4 text-black" />
-                            {{ $t('flash.uf2.enter_dfu') }}
-                        </button>
-                    </li>
-                    <li class="mb-10 ms-8">
-                        <span class="absolute flex items-center justify-center w-6 h-6 rounded-full -start-3 ring-8 bg-cyan-900 text-gray-100 ring-gray-900">
-                            2
-                        </span>
-                        <h3 class="flex items-start mb-1 text-lg font-semibold text-white">
-                            {{ $t('flash.uf2.ensure_drive_mounted') }}
-                        </h3>
-                        <span>
-                            {{ $t('flash.uf2.drive_name_info') }}
-                        </span>
-                        <div>
-                            <img v-if="deviceStore.isSelectedNrf" src="@/assets/img/dfu.png" :alt="$t('flash.uf2.dfu_drive')" />
-                            <img v-else src="@/assets/img/uf2_rp2040.png" :alt="$t('flash.uf2.dfu_drive')" />
-                        </div>
-                    </li>
-                    <li class="ms-8">
-                        <span class="absolute flex items-center justify-center w-6 h-6 rounded-full -start-3 ring-8 bg-cyan-900 text-gray-100 ring-gray-900">
-                            3
-                        </span>
-                        <h3 class="mb-1 text-lg font-semibold text-white">
-                            {{ $t('flash.uf2.download_copy_uf2') }}
-                        </h3>
-                        <span>
-                            {{ $t('flash.uf2.copy_instructions') }}
-                        </span>
-                        <div class="p-4 mb-4 my-2 text-sm rounded-lg bg-blue-50 bg-gray-800 text-blue-200" role="alert">
-                            <span class="font-medium">
-                                <Info class="h-4 w-4 inline" />
-                                {{ $t('flash.uf2.auto_reboot_warning') }}
-                            </span>
-                        </div>
-                    </li>
-                    <li>
-                        <label class="relative inline-flex items-center me-5 ml-8 my-2 cursor-pointer" v-if="canInstallInkHud">
-                            <input type="checkbox" value="" class="sr-only peer" v-model="firmwareStore.shouldInstallInkHud">
-                            <div class="w-11 h-6 rounded-full peer peer-focus:ring-4 bg-gray-400 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all border-gray-600 peer-checked:bg-red-600"></div>
-                            <span class="ms-3 text-sm font-medium text-gray-100">{{ $t('flash.uf2.install_inkhud') }}</span>
-                        </label>
-                    </li>
-                </ol>
-
-                <div v-if="firmwareStore.canShowFlash">
-                    <a :href="downloadUf2FileUrl" v-if="firmwareStore.selectedFirmware?.id"
-                    class="text-black inline-flex w-full justify-center bg-meshtastic hover:bg-gray-200 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center">
-                    {{ $t('flash.uf2.download_uf2') }}
-                    </a>
-                    <button @click="downloadUf2FileFs" v-else
-                        class="text-black inline-flex w-full justify-center bg-meshtastic hover:bg-gray-200 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center">
-                        {{ $t('flash.uf2.download_uf2') }}
-                    </button>
-                </div>
+  <div class="relative p-4 w-full max-w-4xl max-h-full">
+    <div class="relative rounded-lg shadow bg-zinc-700">
+      <FlashHeader />
+      <div class="p-4 md:p-5">
+        <ReleaseNotes />
+        <ol
+          v-if="firmwareStore.canShowFlash"
+          class="relative border-s border-gray-200 border-gray-600 ms-3.5 mb-4 md:mb-5"
+        >
+          <li class="mb-10 ms-8">
+            <span class="absolute flex items-center justify-center w-6 h-6 rounded-full -start-3 ring-8 bg-cyan-900 text-gray-100 ring-gray-900">
+              1
+            </span>
+            <h3 class="flex items-start mb-1 text-lg font-semibold text-white">
+              {{ $t('flash.uf2.enter_dfu_mode') }}
+            </h3>
+            <div
+              class="p-4 mb-4 my-2 text-sm rounded-lg bg-blue-50 bg-gray-800 text-blue-200"
+              role="alert"
+            >
+              <span class="font-medium">
+                <Info class="h-4 w-4 inline" />
+                {{ $t('flash.uf2.dfu_firmware_clause') }} &lt; {{ deviceStore.enterDfuVersion }}, {{ $t('flash.uf2.dfu_firmware_clause_2') }} {{ deviceStore.dfuStepAction }}
+              </span>
             </div>
+            <button
+              type="button"
+              class="inline-flex items-center py-2 px-3 text-sm font-medium focus:outline-none bg-meshtastic rounded-lg hover:bg-white focus:z-10 focus:ring-4 focus:ring-gray-200 text-black"
+              @click="() => deviceStore.enterDfuMode($t)"
+            >
+              <FolderDown class="h-4 w-4 text-black" />
+              {{ $t('flash.uf2.enter_dfu') }}
+            </button>
+          </li>
+          <li class="mb-10 ms-8">
+            <span class="absolute flex items-center justify-center w-6 h-6 rounded-full -start-3 ring-8 bg-cyan-900 text-gray-100 ring-gray-900">
+              2
+            </span>
+            <h3 class="flex items-start mb-1 text-lg font-semibold text-white">
+              {{ $t('flash.uf2.ensure_drive_mounted') }}
+            </h3>
+            <span>
+              {{ $t('flash.uf2.drive_name_info') }}
+            </span>
+            <div>
+              <img
+                v-if="deviceStore.isSelectedNrf"
+                src="@/assets/img/dfu.png"
+                :alt="$t('flash.uf2.dfu_drive')"
+              >
+              <img
+                v-else
+                src="@/assets/img/uf2_rp2040.png"
+                :alt="$t('flash.uf2.dfu_drive')"
+              >
+            </div>
+          </li>
+          <li class="ms-8">
+            <span class="absolute flex items-center justify-center w-6 h-6 rounded-full -start-3 ring-8 bg-cyan-900 text-gray-100 ring-gray-900">
+              3
+            </span>
+            <h3 class="mb-1 text-lg font-semibold text-white">
+              {{ $t('flash.uf2.download_copy_uf2') }}
+            </h3>
+            <span>
+              {{ $t('flash.uf2.copy_instructions') }}
+            </span>
+            <div
+              class="p-4 mb-4 my-2 text-sm rounded-lg bg-blue-50 bg-gray-800 text-blue-200"
+              role="alert"
+            >
+              <span class="font-medium">
+                <Info class="h-4 w-4 inline" />
+                {{ $t('flash.uf2.auto_reboot_warning') }}
+              </span>
+            </div>
+          </li>
+          <li>
+            <label
+              v-if="canInstallInkHud"
+              class="relative inline-flex items-center me-5 ml-8 my-2 cursor-pointer"
+            >
+              <input
+                v-model="firmwareStore.shouldInstallInkHud"
+                type="checkbox"
+                value=""
+                class="sr-only peer"
+              >
+              <div class="w-11 h-6 rounded-full peer peer-focus:ring-4 bg-gray-400 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all border-gray-600 peer-checked:bg-red-600" />
+              <span class="ms-3 text-sm font-medium text-gray-100">{{ $t('flash.uf2.install_inkhud') }}</span>
+            </label>
+          </li>
+        </ol>
+
+        <div v-if="firmwareStore.canShowFlash">
+          <a
+            v-if="firmwareStore.selectedFirmware?.id"
+            :href="downloadUf2FileUrl"
+            class="text-black inline-flex w-full justify-center bg-meshtastic hover:bg-gray-200 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center"
+          >
+            {{ $t('flash.uf2.download_uf2') }}
+          </a>
+          <button
+            v-else
+            class="text-black inline-flex w-full justify-center bg-meshtastic hover:bg-gray-200 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center"
+            @click="downloadUf2FileFs"
+          >
+            {{ $t('flash.uf2.download_uf2') }}
+          </button>
         </div>
+      </div>
     </div>
+  </div>
 </template>
 
 <script lang="ts" setup>
 import {
   FolderDown,
   Info,
-} from 'lucide-vue-next';
-import { track } from '@vercel/analytics';
-import { computed } from 'vue';
+} from 'lucide-vue-next'
+import { track } from '@vercel/analytics'
+import { computed } from 'vue'
 
-import { useDeviceStore } from '../../stores/deviceStore';
-import { useFirmwareStore } from '../../stores/firmwareStore';
-import FlashHeader from './FlashHeader.vue';
-import ReleaseNotes from './ReleaseNotes.vue';
+import { useDeviceStore } from '../../stores/deviceStore'
+import { useFirmwareStore } from '../../stores/firmwareStore'
+import FlashHeader from './FlashHeader.vue'
+import ReleaseNotes from './ReleaseNotes.vue'
 
-const deviceStore = useDeviceStore();
-const firmwareStore = useFirmwareStore();
+const deviceStore = useDeviceStore()
+const firmwareStore = useFirmwareStore()
 
 const downloadUf2FileFs = () => {
-    let suffix = "";
-    if (firmwareStore.shouldInstallInkHud) {
-        suffix = "-inkhud";
-    }
-    const searchRegex = new RegExp(`firmware-${deviceStore.$state.selectedTarget.platformioTarget}${suffix}-.+.uf2`);
-    console.log(searchRegex);
-    firmwareStore.downloadUf2FileSystem(searchRegex);
+  let suffix = ''
+  if (firmwareStore.shouldInstallInkHud) {
+    suffix = '-inkhud'
+  }
+  const searchRegex = new RegExp(`firmware-${deviceStore.$state.selectedTarget.platformioTarget}${suffix}-.+.uf2`)
+  console.log(searchRegex)
+  firmwareStore.downloadUf2FileSystem(searchRegex)
 }
 
 const isNewFirmware = computed(() => {
-    // Just check for *not* 2.5 firmware version for now
-    return !firmwareStore.firmwareVersion.includes('2.5');
-});
+  // Just check for *not* 2.5 firmware version for now
+  return !firmwareStore.firmwareVersion.includes('2.5')
+})
 
 const canInstallInkHud = computed(() => {
-    if (!isNewFirmware.value)
-        return false;
-    return deviceStore.$state.selectedTarget.hasInkHud === true;
-});
-
+  if (!isNewFirmware.value)
+    return false
+  return deviceStore.$state.selectedTarget.hasInkHud === true
+})
 
 const downloadUf2FileUrl = computed(() => {
-    if (!firmwareStore.selectedFirmware?.id) return '';
-    const firmwareVersion = firmwareStore.selectedFirmware.id.replace('v', '')
-    let suffix = "";
-    if (firmwareStore.shouldInstallInkHud) {
-        suffix = "-inkhud";
-    }
-    const firmwareFile = `firmware-${deviceStore.$state.selectedTarget.platformioTarget}${suffix}-${firmwareVersion}.uf2`
-    firmwareStore.trackDownload(deviceStore.$state.selectedTarget, false);
-    console.log(firmwareFile);
-    return firmwareStore.getReleaseFileUrl(firmwareFile);
-});
+  if (!firmwareStore.selectedFirmware?.id) return ''
+  const firmwareVersion = firmwareStore.selectedFirmware.id.replace('v', '')
+  let suffix = ''
+  if (firmwareStore.shouldInstallInkHud) {
+    suffix = '-inkhud'
+  }
+  const firmwareFile = `firmware-${deviceStore.$state.selectedTarget.platformioTarget}${suffix}-${firmwareVersion}.uf2`
+  firmwareStore.trackDownload(deviceStore.$state.selectedTarget, false)
+  console.log(firmwareFile)
+  return firmwareStore.getReleaseFileUrl(firmwareFile)
+})
 </script>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,22 @@
+// @ts-check
+import withNuxt from './.nuxt/eslint.config.mjs'
+
+export default withNuxt(
+  {
+    rules: {
+      // Vue rules
+      'vue/multi-word-component-names': 'off',
+      'vue/no-v-html': 'warn',
+      'vue/attributes-order': 'warn',
+      'vue/first-attribute-linebreak': 'warn',
+      'vue/require-v-for-key': 'warn',
+      'vue/return-in-computed-property': 'warn',
+      // TypeScript rules - warn instead of error
+      '@typescript-eslint/no-unused-vars': 'warn',
+      '@typescript-eslint/no-explicit-any': 'warn',
+    },
+  },
+  {
+    ignores: ['types/resources.ts'],
+  },
+)

--- a/i18n.config.ts
+++ b/i18n.config.ts
@@ -6,5 +6,5 @@ export default defineI18nConfig(() => ({
   silentFallbackWarn: false,
   // Enable fallback for missing keys
   fallbackWarn: false,
-  missingWarn: false
+  missingWarn: false,
 }))

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,19 +1,33 @@
 // nuxt.config.ts
-import { defineNuxtConfig } from 'nuxt/config';
+import { defineNuxtConfig } from 'nuxt/config'
 
 export default defineNuxtConfig({
+
+  modules: ['@pinia/nuxt', '@vite-pwa/nuxt', '@nuxtjs/i18n', '@nuxt/eslint'],
+
+  ssr: false,
   devtools: { enabled: true },
 
   app: {
     head: {
       script: process.env.COOKIEYES_CLIENT_ID
         ? [
-          {
-            src: `https://cdn-cookieyes.com/client_data/${process.env.COOKIEYES_CLIENT_ID}/script.js`,
-            async: true,
-          },
-        ]
+            {
+              src: `https://cdn-cookieyes.com/client_data/${process.env.COOKIEYES_CLIENT_ID}/script.js`,
+              async: true,
+            },
+          ]
         : [],
+    },
+  },
+  css: ['~/assets/css/main.css'],
+
+  runtimeConfig: {
+    public: {
+      datadogApplicationId: process.env.DATADOG_APPLICATION_ID || '',
+      datadogClientToken: process.env.DATADOG_CLIENT_TOKEN || '',
+      datadogEnv: process.env.NODE_ENV || 'production',
+      cookieyesClientId: process.env.COOKIEYES_CLIENT_ID || '',
     },
   },
 
@@ -22,14 +36,43 @@ export default defineNuxtConfig({
     '/': { prerender: true },
   },
 
-  ssr: false,
-  css: ['~/assets/css/main.css'],
+  compatibilityDate: '2024-09-03',
 
-  modules: [
-    '@pinia/nuxt',
-    '@vite-pwa/nuxt',
-    '@nuxtjs/i18n',
-  ],
+  vite: {
+    plugins: [],
+    server: {
+      hmr: {
+        overlay: true, // Enable HMR overlay for errors
+      },
+      proxy: {
+        '^/api/.*': {
+          target: 'https://api.meshtastic.org/',
+          changeOrigin: true,
+          followRedirects: true,
+          rewrite: path => path.replace(/^\/api/, ''),
+          secure: false,
+          headers: {
+            Accept: 'application/octet-stream',
+            Origin: 'https://flash.meshtastic.org',
+            Referer: 'https://flash.meshtastic.org/',
+          },
+        },
+      },
+    },
+  },
+
+  postcss: {
+    plugins: {
+      tailwindcss: {},
+      autoprefixer: {},
+    },
+  },
+  eslint: {
+    config: {
+      stylistic: true,
+      typescript: true,
+    },
+  },
   i18n: {
     locales: [
       {
@@ -136,47 +179,4 @@ export default defineNuxtConfig({
   pwa: {
     /* PWA options */
   },
-
-  postcss: {
-    plugins: {
-      tailwindcss: {},
-      autoprefixer: {},
-    },
-  },
-
-  vite: {
-    plugins: [
-    ],
-    server: {
-      hmr: {
-        overlay: true, // Enable HMR overlay for errors
-      },
-      proxy: {
-        "^/api/.*": {
-          target:
-            "https://api.meshtastic.org/",
-          changeOrigin: true,
-          followRedirects: true,
-          rewrite: (path) => path.replace(/^\/api/, ""),
-          secure: false,
-          headers: {
-            Accept: "application/octet-stream",
-            Origin: 'https://flash.meshtastic.org',
-            Referer: 'https://flash.meshtastic.org/'
-          },
-        }
-      }
-    }
-  },
-
-  runtimeConfig: {
-    public: {
-      datadogApplicationId: process.env.DATADOG_APPLICATION_ID || '',
-      datadogClientToken: process.env.DATADOG_CLIENT_TOKEN || '',
-      datadogEnv: process.env.NODE_ENV || 'production',
-      cookieyesClientId: process.env.COOKIEYES_CLIENT_ID || '',
-    }
-  },
-
-  compatibilityDate: '2024-09-03',
-});
+})

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "nuxt dev",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
-    "postinstall": "nuxt prepare"
+    "postinstall": "nuxt prepare",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
   },
   "dependencies": {
     "@datadog/browser-logs": "^6.18.0",
@@ -36,12 +38,13 @@
   },
   "devDependencies": {
     "@nuxt/devtools": "^2.6.2",
+    "@nuxt/eslint": "^1.9.0",
     "@nuxtjs/tailwindcss": "^6.14.0",
     "@types/file-saver": "^2.0.7",
     "@types/w3c-web-serial": "^1.0.8",
     "@vite-pwa/nuxt": "^1.0.7",
     "autoprefixer": "^10.4.21",
-    "node-stdlib-browser": "^1.3.1",
+    "eslint": "^9.38.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.17"
   }

--- a/plugins/analytics.clients.ts
+++ b/plugins/analytics.clients.ts
@@ -1,5 +1,5 @@
-import { inject } from '@vercel/analytics';
+import { inject } from '@vercel/analytics'
 
 export default defineNuxtPlugin(() => {
-  inject();
-});
+  inject()
+})

--- a/plugins/datadog-rum.client.ts
+++ b/plugins/datadog-rum.client.ts
@@ -1,12 +1,12 @@
 // Datadog RUM and Logs initialization for Nuxt/Vue
-import { datadogRum } from '@datadog/browser-rum';
-import { datadogLogs } from '@datadog/browser-logs';
+import { datadogRum } from '@datadog/browser-rum'
+import { datadogLogs } from '@datadog/browser-logs'
 
 export default defineNuxtPlugin(() => {
   // Only initialize in browser environment
   if (import.meta.client) {
-    const config = useRuntimeConfig();
-    
+    const config = useRuntimeConfig()
+
     // Initialize Datadog RUM
     datadogRum.init({
       applicationId: config.public.datadogApplicationId || 'YOUR_APPLICATION_ID',
@@ -19,8 +19,8 @@ export default defineNuxtPlugin(() => {
       sessionSampleRate: 100,
       sessionReplaySampleRate: 20,
       defaultPrivacyLevel: 'allow',
-    });
-    
+    })
+
     // Initialize Datadog Logs (for precise counting, no sampling)
     datadogLogs.init({
       clientToken: config.public.datadogClientToken || 'YOUR_CLIENT_TOKEN',
@@ -31,11 +31,11 @@ export default defineNuxtPlugin(() => {
       // version: '1.0.0',
       forwardErrorsToLogs: true,
       sessionSampleRate: 100, // 100% for business metrics
-    });
-    
+    })
+
     // Start session replay recording
-    datadogRum.startSessionReplayRecording();
-    
-    console.log('Datadog RUM and Logs initialized');
+    datadogRum.startSessionReplayRecording()
+
+    console.log('Datadog RUM and Logs initialized')
   }
-});
+})

--- a/plugins/i18n-global.client.ts
+++ b/plugins/i18n-global.client.ts
@@ -1,9 +1,9 @@
 // Plugin to set up global i18n instance for Pinia stores
-import { setGlobalI18n } from '~/utils/i18n';
+import { setGlobalI18n } from '~/utils/i18n'
 
 export default defineNuxtPlugin(({ $i18n }) => {
   // Set the global i18n instance so it can be used in Pinia stores
-  console.log('Setting global i18n instance:', $i18n);
-  setGlobalI18n($i18n);
-  console.log('Global i18n instance set successfully');
-});
+  console.log('Setting global i18n instance:', $i18n)
+  setGlobalI18n($i18n)
+  console.log('Global i18n instance set successfully')
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: '@jsr/meshtastic__transport-web-serial@0.2.1(buffer@6.0.3)'
       '@nuxtjs/i18n':
         specifier: ^9.5.6
-        version: 9.5.6(@vue/compiler-dom@3.5.21)(eslint@9.25.0(jiti@2.5.1))(magicast@0.3.5)(rollup@4.50.2)(vue@3.5.21(typescript@5.7.3))
+        version: 9.5.6(@vue/compiler-dom@3.5.21)(eslint@9.38.0(jiti@2.5.1))(magicast@0.3.5)(rollup@4.50.2)(vue@3.5.21(typescript@5.7.3))
       '@pinia/nuxt':
         specifier: ^0.10.1
         version: 0.10.1(magicast@0.3.5)(pinia@3.0.3(typescript@5.7.3)(vue@3.5.21(typescript@5.7.3)))
@@ -34,7 +34,7 @@ importers:
         version: 12.8.2(typescript@5.7.3)
       '@vueuse/nuxt':
         specifier: ^13.7.0
-        version: 13.7.0(magicast@0.3.5)(nuxt@3.19.0(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@24.3.0)(@vue/compiler-sfc@3.5.21)(db0@0.3.2)(encoding@0.1.13)(eslint@9.25.0(jiti@2.5.1))(ioredis@5.7.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.50.2)(terser@5.44.0)(typescript@5.7.3)(vite@7.1.5(@types/node@24.3.0)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(yaml@2.8.1))(vue@3.5.21(typescript@5.7.3))
+        version: 13.7.0(magicast@0.3.5)(nuxt@3.19.0(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@24.3.0)(@vue/compiler-sfc@3.5.21)(db0@0.3.2)(encoding@0.1.13)(eslint@9.38.0(jiti@2.5.1))(ioredis@5.7.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.50.2)(terser@5.44.0)(typescript@5.7.3)(vite@7.1.5(@types/node@24.3.0)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(yaml@2.8.1))(vue@3.5.21(typescript@5.7.3))
       '@zip.js/zip.js':
         specifier: ^2.7.72
         version: 2.7.72
@@ -67,7 +67,7 @@ importers:
         version: 15.0.12
       nuxt:
         specifier: ^3.19.0
-        version: 3.19.0(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@24.3.0)(@vue/compiler-sfc@3.5.21)(db0@0.3.2)(encoding@0.1.13)(eslint@9.25.0(jiti@2.5.1))(ioredis@5.7.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.50.2)(terser@5.44.0)(typescript@5.7.3)(vite@7.1.5(@types/node@24.3.0)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(yaml@2.8.1)
+        version: 3.19.0(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@24.3.0)(@vue/compiler-sfc@3.5.21)(db0@0.3.2)(encoding@0.1.13)(eslint@9.38.0(jiti@2.5.1))(ioredis@5.7.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.50.2)(terser@5.44.0)(typescript@5.7.3)(vite@7.1.5(@types/node@24.3.0)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(yaml@2.8.1)
       pinia:
         specifier: ^3.0.3
         version: 3.0.3(typescript@5.7.3)(vue@3.5.21(typescript@5.7.3))
@@ -84,6 +84,9 @@ importers:
       '@nuxt/devtools':
         specifier: ^2.6.2
         version: 2.6.3(vite@7.1.5(@types/node@24.3.0)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.7.3))
+      '@nuxt/eslint':
+        specifier: ^1.9.0
+        version: 1.9.0(@typescript-eslint/utils@8.46.2(eslint@9.38.0(jiti@2.5.1))(typescript@5.7.3))(@vue/compiler-sfc@3.5.21)(eslint@9.38.0(jiti@2.5.1))(magicast@0.3.5)(typescript@5.7.3)(vite@7.1.5(@types/node@24.3.0)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))
       '@nuxtjs/tailwindcss':
         specifier: ^6.14.0
         version: 6.14.0(magicast@0.3.5)
@@ -99,9 +102,9 @@ importers:
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.6)
-      node-stdlib-browser:
-        specifier: ^1.3.1
-        version: 1.3.1
+      eslint:
+        specifier: ^9.38.0
+        version: 9.38.0(jiti@2.5.1)
       postcss:
         specifier: ^8.5.6
         version: 8.5.6
@@ -115,11 +118,20 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
+  '@antfu/install-pkg@1.1.0':
+    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
   '@apideck/better-ajv-errors@0.3.6':
     resolution: {integrity: sha512-P+ZygBLZtkp0qqOAJJVX4oX/sFo5JR3eBWwwuqHHhK0GIgQOKWrAfiAaWX0aArHkRWHMuggFEgAZNxVPwPZYaA==}
     engines: {node: '>=10'}
     peerDependencies:
       ajv: '>=8'
+
+  '@apidevtools/json-schema-ref-parser@14.2.1':
+    resolution: {integrity: sha512-HmdFw9CDYqM6B25pqGBpNeLCKvGPlIx1EbLrVL0zPvj50CJQUHyBNBw45Muk0kEIkogo1VZvOKHajdMuAzSxRg==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@types/json-schema': ^7.0.15
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -637,6 +649,12 @@ packages:
   '@bufbuild/protobuf@2.6.0':
     resolution: {integrity: sha512-6cuonJVNOIL7lTj5zgo/Rc2bKAo4/GvN+rKCrUj7GdEHRzCk8zKOfFwUsL9nAVk5rSIsRmlgcpLzTRysopEeeg==}
 
+  '@clack/core@0.5.0':
+    resolution: {integrity: sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==}
+
+  '@clack/prompts@0.11.0':
+    resolution: {integrity: sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==}
+
   '@cloudflare/kv-asset-handler@0.4.0':
     resolution: {integrity: sha512-+tv3z+SPp+gqTIcImN9o0hqE9xyfQjI1XD9pL6NuKjua9B1y7mNYv0S9cP+QEbA4ppVgGZEmKOvHX5G5Ei1CVA==}
     engines: {node: '>=18.0.0'}
@@ -683,6 +701,10 @@ packages:
 
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
+
+  '@es-joy/jsdoccomment@0.56.0':
+    resolution: {integrity: sha512-c6EW+aA1w2rjqOMjbL93nZlwxp6c1Ln06vTYs5FjRRhmJXK8V/OrSXdT+pUr4aRYgjCgu8/OkiZr0tzeVrRSbw==}
+    engines: {node: '>=20.11.0'}
 
   '@esbuild/aix-ppc64@0.25.10':
     resolution: {integrity: sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==}
@@ -840,6 +862,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@eslint-community/eslint-utils@4.7.0':
+    resolution: {integrity: sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
   '@eslint-community/eslint-utils@4.9.0':
     resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -850,32 +878,55 @@ packages:
     resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
-  '@eslint/config-array@0.20.1':
-    resolution: {integrity: sha512-OL0RJzC/CBzli0DrrR31qzj6d6i6Mm3HByuhflhl4LOBiWxN+3i6/t/ZQQNii4tjksXi8r2CRW1wMpWA2ULUEw==}
+  '@eslint/compat@1.4.0':
+    resolution: {integrity: sha512-DEzm5dKeDBPm3r08Ixli/0cmxr8LkRdwxMRUIJBlSCpAwSrvFEJpVBzV+66JhDxiaqKxnRzCXhtiMiczF7Hglg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.40 || 9
+    peerDependenciesMeta:
+      eslint:
+        optional: true
+
+  '@eslint/config-array@0.21.1':
+    resolution: {integrity: sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/config-helpers@0.2.3':
-    resolution: {integrity: sha512-u180qk2Um1le4yf0ruXH3PYFeEZeYC3p/4wCTKrr2U1CmGdzGi3KtY0nuPDH48UJxlKCC5RDzbcbh4X0XlqgHg==}
+  '@eslint/config-helpers@0.4.1':
+    resolution: {integrity: sha512-csZAzkNhsgwb0I/UAV6/RGFTbiakPCf0ZrGmrIxQpYvGZ00PhTkSnyKNolphgIvmnJeGw6rcGVEXfTzUnFuEvw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/core@0.13.0':
-    resolution: {integrity: sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==}
+  '@eslint/config-inspector@1.3.0':
+    resolution: {integrity: sha512-t+5Pra/8VX9Ue8V2p6skCeEMw9vm6HjwNF/n7l5nx78f3lUqLjzSTdMisFeo9AeYOj1hwEBiFYYGZ/Xn88cmHw==}
+    hasBin: true
+    peerDependencies:
+      eslint: ^8.50.0 || ^9.0.0
+
+  '@eslint/core@0.15.2':
+    resolution: {integrity: sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@0.16.0':
+    resolution: {integrity: sha512-nmC8/totwobIiFcGkDza3GIKfAw1+hLiYVrh3I1nIomQ8PEr5cxg34jnkmGawul/ep52wGRAcyeDCNtWKSOj4Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/eslintrc@3.3.1':
     resolution: {integrity: sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/js@9.25.0':
-    resolution: {integrity: sha512-iWhsUS8Wgxz9AXNfvfOPFSW4VfMXdVhp1hjkZVhXCrpgh/aLcc45rX6MPu+tIVUWDw0HfNwth7O28M1xDxNf9w==}
+  '@eslint/js@9.38.0':
+    resolution: {integrity: sha512-UZ1VpFvXf9J06YG9xQBdnzU+kthors6KjhMAl6f4gH4usHyh31rUf2DLGInT8RFYIReYXNSydgPY0V2LuWgl7A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/object-schema@2.1.6':
-    resolution: {integrity: sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==}
+  '@eslint/object-schema@2.1.7':
+    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/plugin-kit@0.2.8':
-    resolution: {integrity: sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==}
+  '@eslint/plugin-kit@0.3.5':
+    resolution: {integrity: sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.4.0':
+    resolution: {integrity: sha512-sB5uyeq+dwCWyPi31B2gQlVlo+j5brPlWx4yZBrEaRo/nhdDE8Xke1gsGgtiBdaBTxuTkceLVuVt/pclrasb0A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@fastify/busboy@3.2.0':
@@ -1081,13 +1132,25 @@ packages:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
 
+  '@nodelib/fs.scandir@4.0.1':
+    resolution: {integrity: sha512-vAkI715yhnmiPupY+dq+xenu5Tdf2TBQ66jLvBIcCddtz+5Q8LbMKaf9CIJJreez8fQ8fgaY+RaywQx8RJIWpw==}
+    engines: {node: '>=18.18.0'}
+
   '@nodelib/fs.stat@2.0.5':
     resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
     engines: {node: '>= 8'}
 
+  '@nodelib/fs.stat@4.0.0':
+    resolution: {integrity: sha512-ctr6bByzksKRCV0bavi8WoQevU6plSp2IkllIsEqaiKe2mwNNnaluhnRhcsgGZHrrHk57B3lf95MkLMO3STYcg==}
+    engines: {node: '>=18.18.0'}
+
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@3.0.1':
+    resolution: {integrity: sha512-nIh/M6Kh3ZtOmlY00DaUYB4xeeV6F3/ts1l29iwl3/cfyY/OuCfUx+v08zgx8TKPTifXRcjjqVQ4KB2zOYSbyw==}
+    engines: {node: '>=18.18.0'}
 
   '@nuxt/cli@3.28.0':
     resolution: {integrity: sha512-WQ751WxWLBIeH3TDFt/LWQ2znyAKxpR5+gpv80oerwnVQs4GKajAfR6dIgExXZkjaPUHEFv2lVD9vM+frbprzw==}
@@ -1111,6 +1174,32 @@ packages:
     hasBin: true
     peerDependencies:
       vite: '>=6.0'
+
+  '@nuxt/eslint-config@1.9.0':
+    resolution: {integrity: sha512-KLiYlX/MmWR9dhC0u7GSZQl6wyVLGAHme5aAL5fAUT1PLYgcFiJIUg1Z+b296LmwHGTa+oGPRBIk3yoDmX9/9Q==}
+    peerDependencies:
+      eslint: ^9.0.0
+      eslint-plugin-format: '*'
+    peerDependenciesMeta:
+      eslint-plugin-format:
+        optional: true
+
+  '@nuxt/eslint-plugin@1.9.0':
+    resolution: {integrity: sha512-DY4ZSavgFyKQxI/NCOpSCUHg3dpS2O4lAdic5UmvP2NWj1xwtvmA9UwEZQ2nW2/f/Km6N+Q53UsgFSIBjz8jDQ==}
+    peerDependencies:
+      eslint: ^9.0.0
+
+  '@nuxt/eslint@1.9.0':
+    resolution: {integrity: sha512-8Wm2fDD9za+vJOOhRS2jj+MzyjCNvDhS+04Y55q9W1Ai5hFjTZ1a94jlgSwaqI1B3Zt7y5fqFoEb4wKpZ3ycWg==}
+    peerDependencies:
+      eslint: ^9.0.0
+      eslint-webpack-plugin: ^4.1.0
+      vite-plugin-eslint2: ^5.0.0
+    peerDependenciesMeta:
+      eslint-webpack-plugin:
+        optional: true
+      vite-plugin-eslint2:
+        optional: true
 
   '@nuxt/kit@3.16.2':
     resolution: {integrity: sha512-K1SAUo2vweTfudKZzjKsZ5YJoxPLTspR5qz5+G61xtZreLpsdpDYfBseqsIAl5VFLJuszeRpWQ01jP9LfQ6Ksw==}
@@ -1873,6 +1962,12 @@ packages:
   '@speed-highlight/core@1.2.7':
     resolution: {integrity: sha512-0dxmVj4gxg3Jg879kvFS/msl4s9F3T9UXC1InxgOf7t5NvcPD97u/WTA5vL/IxWHMn7qSxBozqrnnE2wvl1m8g==}
 
+  '@stylistic/eslint-plugin@5.5.0':
+    resolution: {integrity: sha512-IeZF+8H0ns6prg4VrkhgL+yrvDXWDH2cKchrbh80ejG9dQgZWp10epHMbgRuQvgchLII/lfh6Xn3lu6+6L86Hw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: '>=9.0.0'
+
   '@surma/rollup-plugin-off-main-thread@2.2.3':
     resolution: {integrity: sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ==}
 
@@ -1913,14 +2008,39 @@ packages:
   '@types/web-bluetooth@0.0.21':
     resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
 
+  '@typescript-eslint/eslint-plugin@8.46.2':
+    resolution: {integrity: sha512-ZGBMToy857/NIPaaCucIUQgqueOiq7HeAKkhlvqVV4lm089zUFW6ikRySx2v+cAhKeUCPuWVHeimyk6Dw1iY3w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.46.2
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/parser@8.46.2':
+    resolution: {integrity: sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/project-service@8.38.0':
     resolution: {integrity: sha512-dbK7Jvqcb8c9QfH01YB6pORpqX1mn5gDZc9n63Ak/+jD67oWXn3Gs0M6vddAN+eDXBCS5EmNWzbSxsn9SzFWWg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <5.9.0'
 
+  '@typescript-eslint/project-service@8.46.2':
+    resolution: {integrity: sha512-PULOLZ9iqwI7hXcmL4fVfIsBi6AN9YxRc0frbvmg8f+4hQAjQ5GYNKK0DIArNo+rOKmR/iBYwkpBmnIwin4wBg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/scope-manager@8.38.0':
     resolution: {integrity: sha512-WJw3AVlFFcdT9Ri1xs/lg8LwDqgekWXWhH3iAF+1ZM+QPd7oxQ6jvtW/JPwzAScxitILUIFs0/AnQ/UWHzbATQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/scope-manager@8.46.2':
+    resolution: {integrity: sha512-LF4b/NmGvdWEHD2H4MsHD8ny6JpiVNDzrSZr3CsckEgCbAGZbYM4Cqxvi9L+WqDMT+51Ozy7lt2M+d0JLEuBqA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/tsconfig-utils@8.38.0':
@@ -1929,8 +2049,25 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <5.9.0'
 
+  '@typescript-eslint/tsconfig-utils@8.46.2':
+    resolution: {integrity: sha512-a7QH6fw4S57+F5y2FIxxSDyi5M4UfGF+Jl1bCGd7+L4KsaUY80GsiF/t0UoRFDHAguKlBaACWJRmdrc6Xfkkag==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/type-utils@8.46.2':
+    resolution: {integrity: sha512-HbPM4LbaAAt/DjxXaG9yiS9brOOz6fabal4uvUmaUYe6l3K1phQDMQKBRUrr06BQkxkvIZVVHttqiybM9nJsLA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/types@8.38.0':
     resolution: {integrity: sha512-wzkUfX3plUqij4YwWaJyqhiPE5UCRVlFpKn1oCRn2O1bJ592XxWJj8ROQ3JD5MYXLORW84063z3tZTb/cs4Tyw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/types@8.46.2':
+    resolution: {integrity: sha512-lNCWCbq7rpg7qDsQrd3D6NyWYu+gkTENkG5IKYhUIcxSb59SQC/hEQ+MrG4sTgBVghTonNWq42bA/d4yYumldQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@8.38.0':
@@ -1939,14 +2076,126 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <5.9.0'
 
+  '@typescript-eslint/typescript-estree@8.46.2':
+    resolution: {integrity: sha512-f7rW7LJ2b7Uh2EiQ+7sza6RDZnajbNbemn54Ob6fRwQbgcIn+GWfyuHDHRYgRoZu1P4AayVScrRW+YfbTvPQoQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/utils@8.46.2':
+    resolution: {integrity: sha512-sExxzucx0Tud5tE0XqR0lT0psBQvEpnpiul9XbGUB1QwpWJJAps1O/Z7hJxLGiZLBKMCutjTzDgmd1muEhBnVg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/visitor-keys@8.38.0':
     resolution: {integrity: sha512-pWrTcoFNWuwHlA9CvlfSsGWs14JxfN1TH25zM5L7o0pRLhsoZkDnTsXfQRJBEWJoV5DL0jf+Z+sxiud+K0mq1g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.46.2':
+    resolution: {integrity: sha512-tUFMXI4gxzzMXt4xpGJEsBsTox0XbNQ1y94EwlD/CuZwFcQP79xfQqMhau9HsRc/J0cAPA/HZt1dZPtGn9V/7w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@unhead/vue@2.0.14':
     resolution: {integrity: sha512-Ym9f+Kd2Afqek2FtUHvYvK+j2uZ2vbZ6Rr9NCnNGGBMdmafAuiZpT117YGyh0ARcueL6Znia0U8ySqPsnHOZIg==}
     peerDependencies:
       vue: '>=3.5.18'
+
+  '@unrs/resolver-binding-android-arm-eabi@1.11.1':
+    resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
+    cpu: [arm]
+    os: [android]
+
+  '@unrs/resolver-binding-android-arm64@1.11.1':
+    resolution: {integrity: sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==}
+    cpu: [arm64]
+    os: [android]
+
+  '@unrs/resolver-binding-darwin-arm64@1.11.1':
+    resolution: {integrity: sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@unrs/resolver-binding-darwin-x64@1.11.1':
+    resolution: {integrity: sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@unrs/resolver-binding-freebsd-x64@1.11.1':
+    resolution: {integrity: sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@unrs/resolver-binding-linux-arm-gnueabihf@1.11.1':
+    resolution: {integrity: sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-arm-musleabihf@1.11.1':
+    resolution: {integrity: sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-arm64-gnu@1.11.1':
+    resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
+    resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
+    resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
+    resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
+    resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
+    resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
+    resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
+    cpu: [x64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-x64-musl@1.11.1':
+    resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@unrs/resolver-binding-wasm32-wasi@1.11.1':
+    resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@unrs/resolver-binding-win32-arm64-msvc@1.11.1':
+    resolution: {integrity: sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@unrs/resolver-binding-win32-ia32-msvc@1.11.1':
+    resolution: {integrity: sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
+    resolution: {integrity: sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==}
+    cpu: [x64]
+    os: [win32]
 
   '@vercel/analytics@1.5.0':
     resolution: {integrity: sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==}
@@ -2234,6 +2483,10 @@ packages:
     resolution: {integrity: sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==}
     engines: {node: '>= 14'}
 
+  are-docs-informative@0.0.2:
+    resolution: {integrity: sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==}
+    engines: {node: '>=14'}
+
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
@@ -2247,12 +2500,6 @@ packages:
   arraybuffer.prototype.slice@1.0.4:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
-
-  asn1.js@4.10.1:
-    resolution: {integrity: sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==}
-
-  assert@2.1.0:
-    resolution: {integrity: sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==}
 
   ast-kit@1.4.2:
     resolution: {integrity: sha512-lvGehj1XsrIoQrD5CfPduIzQbcpuX2EPjlk/vDMDQF9U9HLRB6WwMTdighj5n52hdhh8xg9VgPTU7Q25MuJ/rw==}
@@ -2344,12 +2591,6 @@ packages:
   birpc@2.5.0:
     resolution: {integrity: sha512-VSWO/W6nNQdyP520F1mhf+Lc2f8pjGQOtoHHm7Ze8Go1kX7akpVIrtTa0fn+HB0QJEDVacl6aO08YE0PgXfdnQ==}
 
-  bn.js@4.12.2:
-    resolution: {integrity: sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==}
-
-  bn.js@5.2.2:
-    resolution: {integrity: sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==}
-
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
@@ -2366,32 +2607,6 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  brorand@1.1.0:
-    resolution: {integrity: sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==}
-
-  browser-resolve@2.0.0:
-    resolution: {integrity: sha512-7sWsQlYL2rGLy2IWm8WL8DCTJvYLc/qlOnsakDac87SOoCd16WLsaAMdCiAqsTNHIe+SXfaqyxyo6THoWqs8WQ==}
-
-  browserify-aes@1.2.0:
-    resolution: {integrity: sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==}
-
-  browserify-cipher@1.0.1:
-    resolution: {integrity: sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==}
-
-  browserify-des@1.0.2:
-    resolution: {integrity: sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==}
-
-  browserify-rsa@4.1.1:
-    resolution: {integrity: sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==}
-    engines: {node: '>= 0.10'}
-
-  browserify-sign@4.2.5:
-    resolution: {integrity: sha512-C2AUdAJg6rlM2W5QMp2Q4KGQMVBwR1lIimTsUnutJ8bMpW5B52pGpR2gEnNBNwijumDo5FojQ0L9JrXA8m4YEw==}
-    engines: {node: '>= 0.10'}
-
-  browserify-zlib@0.2.0:
-    resolution: {integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==}
-
   browserslist@4.26.2:
     resolution: {integrity: sha512-ECFzp6uFOSB+dcZ5BK/IBaGWssbSYBHvuMeMt3MMFyhI0Z8SqGgEkBLARgpRH3hutIgPVsALcMwbDrJqPxQ65A==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -2404,21 +2619,22 @@ packages:
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
-  buffer-xor@1.0.3:
-    resolution: {integrity: sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==}
-
-  buffer@5.7.1:
-    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
-
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
-  builtin-status-codes@3.0.0:
-    resolution: {integrity: sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==}
+  builtin-modules@5.0.0:
+    resolution: {integrity: sha512-bkXY9WsVpY7CvMhKSR6pZilZu9Ln5WDrKVBUXf2S443etkmEO4V58heTecXcUIsNsi4Rx8JUO4NfX1IcQl4deg==}
+    engines: {node: '>=18.20'}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
+
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
 
   c12@3.0.2:
     resolution: {integrity: sha512-6Tzk1/TNeI3WBPpK0j/Ss4+gPj3PUJYbWl/MWDJBThFvwNGNkXtd7Cz8BJtD4aRwoGHtzQD0SnxamgUiBH0/Nw==}
@@ -2477,6 +2693,9 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  change-case@5.4.4:
+    resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
+
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
@@ -2489,15 +2708,19 @@ packages:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
 
-  cipher-base@1.0.7:
-    resolution: {integrity: sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==}
-    engines: {node: '>= 0.10'}
+  ci-info@4.3.1:
+    resolution: {integrity: sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==}
+    engines: {node: '>=8'}
 
   citty@0.1.6:
     resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
 
   classnames@2.5.1:
     resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
+
+  clean-regexp@1.0.0:
+    resolution: {integrity: sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==}
+    engines: {node: '>=4'}
 
   clipboardy@4.0.0:
     resolution: {integrity: sha512-5mOlNS0mhX0707P2I0aZ2V/cmHUEO/fL7VFLqszkhUsxt7RwnmrInf/eEQKlf5GzvYeHIjT+Ov1HRfNmymlG0w==}
@@ -2540,6 +2763,10 @@ packages:
     resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
     engines: {node: '>= 6'}
 
+  comment-parser@1.4.1:
+    resolution: {integrity: sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==}
+    engines: {node: '>= 12.0.0'}
+
   common-tags@1.8.2:
     resolution: {integrity: sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==}
     engines: {node: '>=4.0.0'}
@@ -2569,12 +2796,6 @@ packages:
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
-
-  console-browserify@1.2.0:
-    resolution: {integrity: sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==}
-
-  constants-browserify@1.0.0:
-    resolution: {integrity: sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==}
 
   content-disposition@0.5.4:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
@@ -2629,18 +2850,6 @@ packages:
       buffer:
         optional: true
 
-  create-ecdh@4.0.4:
-    resolution: {integrity: sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==}
-
-  create-hash@1.2.0:
-    resolution: {integrity: sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==}
-
-  create-hmac@1.1.7:
-    resolution: {integrity: sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==}
-
-  create-require@1.1.1:
-    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
-
   croner@9.1.0:
     resolution: {integrity: sha512-p9nwwR4qyT5W996vBZhdvBCnMhicY5ytZkR4D1Xj0wuTDEiMnjwR57Q3RXYY/s0EpX6Ay3vgIcfaR+ewGHsi+g==}
     engines: {node: '>=18.0'}
@@ -2654,10 +2863,6 @@ packages:
 
   crossws@0.3.5:
     resolution: {integrity: sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==}
-
-  crypto-browserify@3.12.1:
-    resolution: {integrity: sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==}
-    engines: {node: '>= 0.10'}
 
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
@@ -2767,15 +2972,6 @@ packages:
       supports-color:
         optional: true
 
-  debug@4.4.0:
-    resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -2840,9 +3036,6 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
-  des.js@1.1.0:
-    resolution: {integrity: sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==}
-
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
 
@@ -2869,18 +3062,11 @@ packages:
     resolution: {integrity: sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==}
     engines: {node: '>=0.3.1'}
 
-  diffie-hellman@5.0.3:
-    resolution: {integrity: sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==}
-
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
-
-  domain-browser@4.22.0:
-    resolution: {integrity: sha512-IGBwjF7tNk3cwypFNH/7bfzBcgSCbaMOD3GsaY1AU/JRrnHnYgEM0+9kQt52iZxjNsjBtJYtao146V+f8jFZNw==}
-    engines: {node: '>=10'}
 
   domelementtype@2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
@@ -2928,9 +3114,6 @@ packages:
 
   electron-to-chromium@1.5.221:
     resolution: {integrity: sha512-/1hFJ39wkW01ogqSyYoA4goOXOtMRy6B+yvA1u42nnsEGtHzIzmk93aPISumVQeblj47JUHLC9coCjUxb1EvtQ==}
-
-  elliptic@6.6.1:
-    resolution: {integrity: sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -3006,6 +3189,10 @@ packages:
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
+  escape-string-regexp@1.0.5:
+    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
+    engines: {node: '>=0.8.0'}
+
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
@@ -3019,9 +3206,97 @@ packages:
     engines: {node: '>=6.0'}
     hasBin: true
 
+  eslint-config-flat-gitignore@2.1.0:
+    resolution: {integrity: sha512-cJzNJ7L+psWp5mXM7jBX+fjHtBvvh06RBlcweMhKD8jWqQw0G78hOW5tpVALGHGFPsBV+ot2H+pdDGJy6CV8pA==}
+    peerDependencies:
+      eslint: ^9.5.0
+
+  eslint-flat-config-utils@2.1.4:
+    resolution: {integrity: sha512-bEnmU5gqzS+4O+id9vrbP43vByjF+8KOs+QuuV4OlqAuXmnRW2zfI/Rza1fQvdihQ5h4DUo0NqFAiViD4mSrzQ==}
+
+  eslint-import-context@0.1.9:
+    resolution: {integrity: sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      unrs-resolver: ^1.0.0
+    peerDependenciesMeta:
+      unrs-resolver:
+        optional: true
+
+  eslint-merge-processors@2.0.0:
+    resolution: {integrity: sha512-sUuhSf3IrJdGooquEUB5TNpGNpBoQccbnaLHsb1XkBLUPPqCNivCpY05ZcpCOiV9uHwO2yxXEWVczVclzMxYlA==}
+    peerDependencies:
+      eslint: '*'
+
+  eslint-plugin-import-lite@0.3.0:
+    resolution: {integrity: sha512-dkNBAL6jcoCsXZsQ/Tt2yXmMDoNt5NaBh/U7yvccjiK8cai6Ay+MK77bMykmqQA2bTF6lngaLCDij6MTO3KkvA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: '>=9.0.0'
+      typescript: '>=4.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  eslint-plugin-import-x@4.16.1:
+    resolution: {integrity: sha512-vPZZsiOKaBAIATpFE2uMI4w5IRwdv/FpQ+qZZMR4E+PeOcM4OeoEbqxRMnywdxP19TyB/3h6QBB0EWon7letSQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/utils': ^8.0.0
+      eslint: ^8.57.0 || ^9.0.0
+      eslint-import-resolver-node: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/utils':
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+
+  eslint-plugin-jsdoc@54.7.0:
+    resolution: {integrity: sha512-u5Na4he2+6kY1rWqxzbQaAwJL3/tDCuT5ElDRc5UJ9stOeQeQ5L1JJ1kRRu7ldYMlOHMCJLsY8Mg/Tu3ExdZiQ==}
+    engines: {node: '>=20.11.0'}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
+
+  eslint-plugin-regexp@2.10.0:
+    resolution: {integrity: sha512-ovzQT8ESVn5oOe5a7gIDPD5v9bCSjIFJu57sVPDqgPRXicQzOnYfFN21WoQBQF18vrhT5o7UMKFwJQVVjyJ0ng==}
+    engines: {node: ^18 || >=20}
+    peerDependencies:
+      eslint: '>=8.44.0'
+
+  eslint-plugin-unicorn@60.0.0:
+    resolution: {integrity: sha512-QUzTefvP8stfSXsqKQ+vBQSEsXIlAiCduS/V1Em+FKgL9c21U/IIm20/e3MFy1jyCf14tHAhqC1sX8OTy6VUCg==}
+    engines: {node: ^20.10.0 || >=21.0.0}
+    peerDependencies:
+      eslint: '>=9.29.0'
+
+  eslint-plugin-vue@10.5.1:
+    resolution: {integrity: sha512-SbR9ZBUFKgvWAbq3RrdCtWaW0IKm6wwUiApxf3BVTNfqUIo4IQQmreMg2iHFJJ6C/0wss3LXURBJ1OwS/MhFcQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@stylistic/eslint-plugin': ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
+      '@typescript-eslint/parser': ^7.0.0 || ^8.0.0
+      eslint: ^8.57.0 || ^9.0.0
+      vue-eslint-parser: ^10.0.0
+    peerDependenciesMeta:
+      '@stylistic/eslint-plugin':
+        optional: true
+      '@typescript-eslint/parser':
+        optional: true
+
+  eslint-processor-vue-blocks@2.0.0:
+    resolution: {integrity: sha512-u4W0CJwGoWY3bjXAuFpc/b6eK3NQEI8MoeW7ritKj3G3z/WtHrKjkqf+wk8mPEy5rlMGS+k6AZYOw2XBoN/02Q==}
+    peerDependencies:
+      '@vue/compiler-sfc': ^3.3.0
+      eslint: '>=9.0.0'
+
   eslint-scope@8.4.0:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-typegen@2.3.0:
+    resolution: {integrity: sha512-azYgAvhlz1AyTpeLfVSKcrNJInuIsRrcUrOcHmEl8T9oMKesePVUPrF8gRgE6azV8CAlFzxJDTyaXAAbA/BYiA==}
+    peerDependencies:
+      eslint: ^9.0.0
 
   eslint-visitor-keys@3.4.3:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
@@ -3031,8 +3306,8 @@ packages:
     resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  eslint@9.25.0:
-    resolution: {integrity: sha512-MsBdObhM4cEwkzCiraDv7A6txFXEqtNXOb877TsSp2FCkBNl8JfVQrmiuDqC1IkejT6JLPzYBXx/xAiYhyzgGA==}
+  eslint@9.38.0:
+    resolution: {integrity: sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
     peerDependencies:
@@ -3093,9 +3368,6 @@ packages:
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
-
-  evp_bytestokey@1.0.3:
-    resolution: {integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==}
 
   execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
@@ -3165,6 +3437,10 @@ packages:
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
+
+  find-up-simple@1.0.1:
+    resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
+    engines: {node: '>=18'}
 
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -3288,6 +3564,9 @@ packages:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
 
+  get-tsconfig@4.12.0:
+    resolution: {integrity: sha512-LScr2aNr2FbjAjZh2C6X6BxRx1/x+aTDExct/xyq2XKbYOiG5c0aK7pMsSuyc0brz3ibr/lbQiHD9jzt4lccJw==}
+
   giget@2.0.0:
     resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
     hasBin: true
@@ -3322,6 +3601,10 @@ packages:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
 
+  globals@16.4.0:
+    resolution: {integrity: sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==}
+    engines: {node: '>=18'}
+
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
@@ -3336,6 +3619,9 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  graphemer@1.4.0:
+    resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
   gzip-size@7.0.0:
     resolution: {integrity: sha512-O1Ld7Dr+nqPnmGpdhzLmMTQ4vAsD+rHwMm1NLUmoUFFymBOMKxCCrtDxqdBRYXdeEPEi3SyoR4TizJLQrnKBNA==}
@@ -3374,17 +3660,6 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
-  hash-base@3.0.5:
-    resolution: {integrity: sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg==}
-    engines: {node: '>= 0.10'}
-
-  hash-base@3.1.2:
-    resolution: {integrity: sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==}
-    engines: {node: '>= 0.8'}
-
-  hash.js@1.1.7:
-    resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
-
   hasown@2.0.0:
     resolution: {integrity: sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==}
     engines: {node: '>= 0.4'}
@@ -3396,9 +3671,6 @@ packages:
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
-
-  hmac-drbg@1.0.1:
-    resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
 
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
@@ -3422,9 +3694,6 @@ packages:
   http-shutdown@1.2.2:
     resolution: {integrity: sha512-S9wWkJ/VSY9/k4qcjG318bqJNruzE4HySUhFYknwmu6LBP97KLLfwNf+n4V1BHurvFNkSKLFnK/RsuUnRTf9Vw==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
-
-  https-browserify@1.0.0:
-    resolution: {integrity: sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -3472,6 +3741,10 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  indent-string@5.0.0:
+    resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
+    engines: {node: '>=12'}
+
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
@@ -3497,10 +3770,6 @@ packages:
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
 
-  is-arguments@1.2.0:
-    resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
-    engines: {node: '>= 0.4'}
-
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
     engines: {node: '>= 0.4'}
@@ -3520,6 +3789,10 @@ packages:
   is-boolean-object@1.2.2:
     resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
     engines: {node: '>= 0.4'}
+
+  is-builtin-module@5.0.0:
+    resolution: {integrity: sha512-f4RqJKBUe5rQkJ2eJEJBXSticB3hGbN9j0yxxMQFqIW89Jp9WYFtzfTcRlstDKVUTRzSOTLKRfO9vIztenwtxA==}
+    engines: {node: '>=18.20'}
 
   is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
@@ -3585,10 +3858,6 @@ packages:
 
   is-module@1.0.0:
     resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
-
-  is-nan@1.3.2:
-    resolution: {integrity: sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==}
-    engines: {node: '>= 0.4'}
 
   is-negative-zero@2.0.3:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
@@ -3693,10 +3962,6 @@ packages:
     resolution: {integrity: sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==}
     engines: {node: '>=16'}
 
-  isomorphic-timers-promises@1.0.1:
-    resolution: {integrity: sha512-u4sej9B1LPSxTGKB/HiuzvEQnXH0ECYkSVQU39koSwmFAxhlEAFl9RdTvLv4TOTQUgBS5O3O5fwUxk6byBZ+IQ==}
-    engines: {node: '>=10'}
-
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
@@ -3723,6 +3988,14 @@ packages:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
 
+  jsdoc-type-pratt-parser@4.8.0:
+    resolution: {integrity: sha512-iZ8Bdb84lWRuGHamRXFyML07r21pcwBrLkHEuHgEY5UbCouBwv7ECknDRKzsQIXMiqpPymqtIf8TC/shYKB5rw==}
+    engines: {node: '>=12.0.0'}
+
+  jsdoc-type-pratt-parser@5.1.1:
+    resolution: {integrity: sha512-DYYlVP1fe4QBMh2xTIs20/YeTz2GYVbWAEZweHSZD+qQ/Cx2d5RShuhhsdk64eTjNq0FeVnteP/qVOgaywSRbg==}
+    engines: {node: '>=12.0.0'}
+
   jsesc@3.0.2:
     resolution: {integrity: sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==}
     engines: {node: '>=6'}
@@ -3735,6 +4008,9 @@ packages:
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-to-typescript-lite@15.0.0:
+    resolution: {integrity: sha512-5mMORSQm9oTLyjM4mWnyNBi2T042Fhg1/0gCIB6X8U/LVpM2A+Nmj2yEyArqVouDmFThDxpEXcnTgSrjkGJRFA==}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -3837,6 +4113,10 @@ packages:
     resolution: {integrity: sha512-I8oW2+QL5KJo8zXNWX046M134WchxsXC7SawLPvRQpogCbkyQIaFxPE89A2HiwR7vAK2Dm2ERBAmyjTYGYEpBg==}
     hasBin: true
 
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   local-pkg@1.1.1:
     resolution: {integrity: sha512-WunYko2W1NcdfAFpuLUoucsgULmgDBRkdxHxWQ7mK0cQqwPiy8E1enjuRBrhLtZkB5iScJ1XIPdhVEFK8aOLSg==}
     engines: {node: '>=14'}
@@ -3923,9 +4203,6 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
-  md5.js@1.3.5:
-    resolution: {integrity: sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==}
-
   mdn-data@2.0.28:
     resolution: {integrity: sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==}
 
@@ -3957,10 +4234,6 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
-
-  miller-rabin@4.0.1:
-    resolution: {integrity: sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==}
-    hasBin: true
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -3995,12 +4268,6 @@ packages:
   mini-svg-data-uri@1.4.4:
     resolution: {integrity: sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==}
     hasBin: true
-
-  minimalistic-assert@1.0.1:
-    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
-
-  minimalistic-crypto-utils@1.0.1:
-    resolution: {integrity: sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -4066,6 +4333,11 @@ packages:
   nanotar@0.2.0:
     resolution: {integrity: sha512-9ca1h0Xjvo9bEkE4UOxgAzLV0jHKe6LMaxo37ND2DAhhAtd0j8pR1Wxz+/goMrZO8AEZTWCmyaOsFI/W5AdpCQ==}
 
+  napi-postinstall@0.3.4:
+    resolution: {integrity: sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+    hasBin: true
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -4128,10 +4400,6 @@ packages:
   node-releases@2.0.21:
     resolution: {integrity: sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==}
 
-  node-stdlib-browser@1.3.1:
-    resolution: {integrity: sha512-X75ZN8DCLftGM5iKwoYLA3rjnrAEs97MkzvSd4q2746Tgpg8b8XWiBGiBG4ZpgcAqBgtgPHTiAc8ZMCvZuikDw==}
-    engines: {node: '>=10'}
-
   nopt@8.1.0:
     resolution: {integrity: sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -4186,10 +4454,6 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
-  object-is@1.1.6:
-    resolution: {integrity: sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==}
-    engines: {node: '>= 0.4'}
-
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
@@ -4237,9 +4501,6 @@ packages:
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
-
-  os-browserify@0.3.0:
-    resolution: {integrity: sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==}
 
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
@@ -4306,16 +4567,18 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
-  parse-asn1@5.1.9:
-    resolution: {integrity: sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg==}
-    engines: {node: '>= 0.10'}
-
   parse-gitignore@2.0.0:
     resolution: {integrity: sha512-RmVuCHWsfu0QPNW+mraxh/xjQVw/lhUCUru8Zni3Ctq3AoMhpDTq0OVdKS6iesd6Kqb7viCV3isAL43dciOSog==}
     engines: {node: '>=14'}
 
+  parse-imports-exports@0.2.4:
+    resolution: {integrity: sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==}
+
   parse-path@7.1.0:
     resolution: {integrity: sha512-EuCycjZtfPcjWk7KTksnJ5xPMvWGA/6i4zrLYhRG0hGvC3GPU/jGUj3Cy+ZR0v30duV3e23R95T1lE2+lsndSw==}
+
+  parse-statements@1.0.11:
+    resolution: {integrity: sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==}
 
   parse-url@9.2.0:
     resolution: {integrity: sha512-bCgsFI+GeGWPAvAiUv63ZorMeif3/U0zaXABGJbOWt5OH2KCaPHF6S+0ok4aqM9RuIPGyZdx9tR9l13PsW4AYQ==}
@@ -4368,10 +4631,6 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
-  pbkdf2@3.1.5:
-    resolution: {integrity: sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==}
-    engines: {node: '>= 0.10'}
-
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
 
@@ -4406,10 +4665,6 @@ packages:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
 
-  pkg-dir@5.0.0:
-    resolution: {integrity: sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==}
-    engines: {node: '>=10'}
-
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
@@ -4418,6 +4673,10 @@ packages:
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+
+  pluralize@8.0.0:
+    resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
+    engines: {node: '>=4'}
 
   portfinder@1.0.37:
     resolution: {integrity: sha512-yuGIEjDAYnnOex9ddMnKZEMFE0CcGo6zbfzDklkmT1m5z734ss6JMzN9rNB3+RR7iS+F10D4/BVIaXOyh8PQKw==}
@@ -4670,12 +4929,6 @@ packages:
   protocols@2.0.2:
     resolution: {integrity: sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ==}
 
-  public-encrypt@4.0.3:
-    resolution: {integrity: sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==}
-
-  punycode@1.4.1:
-    resolution: {integrity: sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==}
-
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -4690,10 +4943,6 @@ packages:
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
-  querystring-es3@0.2.1:
-    resolution: {integrity: sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==}
-    engines: {node: '>=0.4.x'}
-
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -4702,9 +4951,6 @@ packages:
 
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
-
-  randomfill@1.0.4:
-    resolution: {integrity: sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==}
 
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
@@ -4718,10 +4964,6 @@ packages:
 
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
-
-  readable-stream@3.6.2:
-    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
-    engines: {node: '>= 6'}
 
   readable-stream@4.7.0:
     resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
@@ -4746,6 +4988,10 @@ packages:
     resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
     engines: {node: '>=4'}
 
+  refa@0.12.1:
+    resolution: {integrity: sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
@@ -4756,6 +5002,10 @@ packages:
 
   regenerate@1.4.2:
     resolution: {integrity: sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==}
+
+  regexp-ast-analysis@0.7.1:
+    resolution: {integrity: sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
   regexp-tree@0.1.27:
     resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
@@ -4801,6 +5051,9 @@ packages:
     resolution: {integrity: sha512-i1xevIst/Qa+nA9olDxLWnLk8YZbi8R/7JPbCMcgyWaFR6bKWaexgJgEB5oc2PKMjYdrHynyz0NY+if+H98t1w==}
     engines: {node: '>= 0.8'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   resolve@1.22.10:
     resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
     engines: {node: '>= 0.4'}
@@ -4816,10 +5069,6 @@ packages:
 
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
-
-  ripemd160@2.0.3:
-    resolution: {integrity: sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==}
-    engines: {node: '>= 0.8'}
 
   rollup-plugin-visualizer@6.0.3:
     resolution: {integrity: sha512-ZU41GwrkDcCpVoffviuM9Clwjy5fcUxlz0oMoTXTYsK+tcIFzbdacnrr2n8TXcHxbGKKXtOdjxM2HUS4HjkwIw==}
@@ -4875,6 +5124,10 @@ packages:
   sax@1.4.1:
     resolution: {integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==}
 
+  scslre@0.3.0:
+    resolution: {integrity: sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==}
+    engines: {node: ^14.0.0 || >=16.0.0}
+
   scule@1.3.0:
     resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
 
@@ -4921,11 +5174,6 @@ packages:
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
-
-  sha.js@2.4.12:
-    resolution: {integrity: sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==}
-    engines: {node: '>= 0.10'}
-    hasBin: true
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -5000,9 +5248,22 @@ packages:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
     deprecated: Please use @jridgewell/sourcemap-codec instead
 
+  spdx-exceptions@2.5.0:
+    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
+
+  spdx-expression-parse@4.0.0:
+    resolution: {integrity: sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==}
+
+  spdx-license-ids@3.0.22:
+    resolution: {integrity: sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==}
+
   speakingurl@14.0.1:
     resolution: {integrity: sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==}
     engines: {node: '>=0.10.0'}
+
+  stable-hash-x@0.2.0:
+    resolution: {integrity: sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==}
+    engines: {node: '>=12.0.0'}
 
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
@@ -5033,12 +5294,6 @@ packages:
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
-
-  stream-browserify@3.0.0:
-    resolution: {integrity: sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==}
-
-  stream-http@3.2.0:
-    resolution: {integrity: sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A==}
 
   streamx@2.22.1:
     resolution: {integrity: sha512-znKXEBxfatz2GBNK02kRnCXjV+AA4kjZIUxeWSr3UGirZMJfTE9uiwKHobnbgxWyL/JWro8tTq+vOqAK1/qbSA==}
@@ -5091,6 +5346,10 @@ packages:
 
   strip-final-newline@3.0.0:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
+    engines: {node: '>=12'}
+
+  strip-indent@4.1.1:
+    resolution: {integrity: sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==}
     engines: {node: '>=12'}
 
   strip-json-comments@3.1.1:
@@ -5188,10 +5447,6 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
-  timers-browserify@2.0.12:
-    resolution: {integrity: sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==}
-    engines: {node: '>=0.6.0'}
-
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
@@ -5205,10 +5460,6 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
-
-  to-buffer@1.2.2:
-    resolution: {integrity: sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==}
-    engines: {node: '>= 0.4'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -5254,9 +5505,6 @@ packages:
   tsscmp@1.0.6:
     resolution: {integrity: sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==}
     engines: {node: '>=0.6.x'}
-
-  tty-browserify@0.0.1:
-    resolution: {integrity: sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -5399,6 +5647,9 @@ packages:
     resolution: {integrity: sha512-6NCPkv1ClwH+/BGE9QeoTIl09nuiAt0gS28nn1PvYXsGKRwM2TCbFA2QiilmehPDTXIe684k4rZI1yl3A1PCUw==}
     engines: {node: '>=18.12.0'}
 
+  unrs-resolver@1.11.1:
+    resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
+
   unstorage@1.17.1:
     resolution: {integrity: sha512-KKGwRTT0iVBCErKemkJCLs7JdxNVfqTPc/85ae1XES0+bsHbc/sFBfVi5kJp156cc51BHinIH2l3k0EZ24vOBQ==}
     peerDependencies:
@@ -5488,18 +5739,11 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
-  url@0.11.4:
-    resolution: {integrity: sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==}
-    engines: {node: '>= 0.4'}
-
   urlpattern-polyfill@10.1.0:
     resolution: {integrity: sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-
-  util@0.12.5:
-    resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
 
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
@@ -5626,9 +5870,6 @@ packages:
       yaml:
         optional: true
 
-  vm-browserify@1.1.2:
-    resolution: {integrity: sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==}
-
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
@@ -5637,6 +5878,12 @@ packages:
 
   vue-devtools-stub@0.1.0:
     resolution: {integrity: sha512-RutnB7X8c5hjq39NceArgXg28WZtZpGc3+J16ljMiYnFhKvd8hITxSWQSQ5bvldxMDU6gG5mkxl1MTQLXckVSQ==}
+
+  vue-eslint-parser@10.2.0:
+    resolution: {integrity: sha512-CydUvFOQKD928UzZhTp4pr2vWz1L+H99t7Pkln2QSPdvmURT0MoC4wUccfCnuEaihNsu9aYYyk+bep8rlfkUXw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
 
   vue-i18n@10.0.7:
     resolution: {integrity: sha512-bKsk0PYwP9gdYF4nqSAT0kDpnLu1gZzlxFl885VH4mHVhEnqP16+/mAU05r1U6NIrc0fGDWP89tZ8GzeJZpe+w==}
@@ -5791,9 +6038,9 @@ packages:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
 
-  xtend@4.0.2:
-    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
-    engines: {node: '>=0.4'}
+  xml-name-validator@4.0.0:
+    resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
+    engines: {node: '>=12'}
 
   xterm@5.3.0:
     resolution: {integrity: sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==}
@@ -5858,12 +6105,22 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
+  '@antfu/install-pkg@1.1.0':
+    dependencies:
+      package-manager-detector: 1.3.0
+      tinyexec: 1.0.1
+
   '@apideck/better-ajv-errors@0.3.6(ajv@8.17.1)':
     dependencies:
       ajv: 8.17.1
       json-schema: 0.4.0
       jsonpointer: 5.0.1
       leven: 3.1.0
+
+  '@apidevtools/json-schema-ref-parser@14.2.1(@types/json-schema@7.0.15)':
+    dependencies:
+      '@types/json-schema': 7.0.15
+      js-yaml: 4.1.0
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -6542,6 +6799,17 @@ snapshots:
 
   '@bufbuild/protobuf@2.6.0': {}
 
+  '@clack/core@0.5.0':
+    dependencies:
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+
+  '@clack/prompts@0.11.0':
+    dependencies:
+      '@clack/core': 0.5.0
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+
   '@cloudflare/kv-asset-handler@0.4.0':
     dependencies:
       mime: 3.0.0
@@ -6588,6 +6856,14 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@es-joy/jsdoccomment@0.56.0':
+    dependencies:
+      '@types/estree': 1.0.8
+      '@typescript-eslint/types': 8.46.2
+      comment-parser: 1.4.1
+      esquery: 1.6.0
+      jsdoc-type-pratt-parser: 5.1.1
 
   '@esbuild/aix-ppc64@0.25.10':
     optional: true
@@ -6667,24 +6943,64 @@ snapshots:
   '@esbuild/win32-x64@0.25.10':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.0(eslint@9.25.0(jiti@2.5.1))':
+  '@eslint-community/eslint-utils@4.7.0(eslint@9.38.0(jiti@2.5.1))':
     dependencies:
-      eslint: 9.25.0(jiti@2.5.1)
+      eslint: 9.38.0(jiti@2.5.1)
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/eslint-utils@4.9.0(eslint@9.38.0(jiti@2.5.1))':
+    dependencies:
+      eslint: 9.38.0(jiti@2.5.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.1': {}
 
-  '@eslint/config-array@0.20.1':
+  '@eslint/compat@1.4.0(eslint@9.38.0(jiti@2.5.1))':
     dependencies:
-      '@eslint/object-schema': 2.1.6
+      '@eslint/core': 0.16.0
+    optionalDependencies:
+      eslint: 9.38.0(jiti@2.5.1)
+
+  '@eslint/config-array@0.21.1':
+    dependencies:
+      '@eslint/object-schema': 2.1.7
       debug: 4.4.3
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/config-helpers@0.2.3': {}
+  '@eslint/config-helpers@0.4.1':
+    dependencies:
+      '@eslint/core': 0.16.0
 
-  '@eslint/core@0.13.0':
+  '@eslint/config-inspector@1.3.0(eslint@9.38.0(jiti@2.5.1))':
+    dependencies:
+      '@nodelib/fs.walk': 3.0.1
+      ansis: 4.1.0
+      bundle-require: 5.1.0(esbuild@0.25.10)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      debug: 4.4.3
+      esbuild: 0.25.10
+      eslint: 9.38.0(jiti@2.5.1)
+      find-up: 7.0.0
+      get-port-please: 3.2.0
+      h3: 1.15.4
+      mlly: 1.8.0
+      mrmime: 2.0.1
+      open: 10.2.0
+      tinyglobby: 0.2.15
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@eslint/core@0.15.2':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/core@0.16.0':
     dependencies:
       '@types/json-schema': 7.0.15
 
@@ -6702,13 +7018,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/js@9.25.0': {}
+  '@eslint/js@9.38.0': {}
 
-  '@eslint/object-schema@2.1.6': {}
+  '@eslint/object-schema@2.1.7': {}
 
-  '@eslint/plugin-kit@0.2.8':
+  '@eslint/plugin-kit@0.3.5':
     dependencies:
-      '@eslint/core': 0.13.0
+      '@eslint/core': 0.15.2
+      levn: 0.4.1
+
+  '@eslint/plugin-kit@0.4.0':
+    dependencies:
+      '@eslint/core': 0.16.0
       levn: 0.4.1
 
   '@fastify/busboy@3.2.0':
@@ -6778,9 +7099,9 @@ snapshots:
 
   '@intlify/shared@11.1.10': {}
 
-  '@intlify/unplugin-vue-i18n@6.0.8(@vue/compiler-dom@3.5.21)(eslint@9.25.0(jiti@2.5.1))(rollup@4.50.2)(typescript@5.7.3)(vue-i18n@10.0.7(vue@3.5.21(typescript@5.7.3)))(vue@3.5.21(typescript@5.7.3))':
+  '@intlify/unplugin-vue-i18n@6.0.8(@vue/compiler-dom@3.5.21)(eslint@9.38.0(jiti@2.5.1))(rollup@4.50.2)(typescript@5.7.3)(vue-i18n@10.0.7(vue@3.5.21(typescript@5.7.3)))(vue@3.5.21(typescript@5.7.3))':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.25.0(jiti@2.5.1))
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.38.0(jiti@2.5.1))
       '@intlify/bundle-utils': 10.0.1(vue-i18n@10.0.7(vue@3.5.21(typescript@5.7.3)))
       '@intlify/shared': 11.1.10
       '@intlify/vue-i18n-extensions': 8.0.0(@intlify/shared@11.1.10)(@vue/compiler-dom@3.5.21)(vue-i18n@10.0.7(vue@3.5.21(typescript@5.7.3)))(vue@3.5.21(typescript@5.7.3))
@@ -6892,7 +7213,7 @@ snapshots:
 
   '@koa/router@12.0.2':
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.3
       http-errors: 2.0.0
       koa-compose: 4.1.0
       methods: 1.1.2
@@ -6973,11 +7294,23 @@ snapshots:
       '@nodelib/fs.stat': 2.0.5
       run-parallel: 1.2.0
 
+  '@nodelib/fs.scandir@4.0.1':
+    dependencies:
+      '@nodelib/fs.stat': 4.0.0
+      run-parallel: 1.2.0
+
   '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.stat@4.0.0': {}
 
   '@nodelib/fs.walk@1.2.8':
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.15.0
+
+  '@nodelib/fs.walk@3.0.1':
+    dependencies:
+      '@nodelib/fs.scandir': 4.0.1
       fastq: 1.15.0
 
   '@nuxt/cli@3.28.0(magicast@0.3.5)':
@@ -7072,6 +7405,74 @@ snapshots:
       - supports-color
       - utf-8-validate
       - vue
+
+  '@nuxt/eslint-config@1.9.0(@typescript-eslint/utils@8.46.2(eslint@9.38.0(jiti@2.5.1))(typescript@5.7.3))(@vue/compiler-sfc@3.5.21)(eslint@9.38.0(jiti@2.5.1))(typescript@5.7.3)':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@clack/prompts': 0.11.0
+      '@eslint/js': 9.38.0
+      '@nuxt/eslint-plugin': 1.9.0(eslint@9.38.0(jiti@2.5.1))(typescript@5.7.3)
+      '@stylistic/eslint-plugin': 5.5.0(eslint@9.38.0(jiti@2.5.1))
+      '@typescript-eslint/eslint-plugin': 8.46.2(@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.5.1))(typescript@5.7.3))(eslint@9.38.0(jiti@2.5.1))(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.46.2(eslint@9.38.0(jiti@2.5.1))(typescript@5.7.3)
+      eslint: 9.38.0(jiti@2.5.1)
+      eslint-config-flat-gitignore: 2.1.0(eslint@9.38.0(jiti@2.5.1))
+      eslint-flat-config-utils: 2.1.4
+      eslint-merge-processors: 2.0.0(eslint@9.38.0(jiti@2.5.1))
+      eslint-plugin-import-lite: 0.3.0(eslint@9.38.0(jiti@2.5.1))(typescript@5.7.3)
+      eslint-plugin-import-x: 4.16.1(@typescript-eslint/utils@8.46.2(eslint@9.38.0(jiti@2.5.1))(typescript@5.7.3))(eslint@9.38.0(jiti@2.5.1))
+      eslint-plugin-jsdoc: 54.7.0(eslint@9.38.0(jiti@2.5.1))
+      eslint-plugin-regexp: 2.10.0(eslint@9.38.0(jiti@2.5.1))
+      eslint-plugin-unicorn: 60.0.0(eslint@9.38.0(jiti@2.5.1))
+      eslint-plugin-vue: 10.5.1(@stylistic/eslint-plugin@5.5.0(eslint@9.38.0(jiti@2.5.1)))(@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.5.1))(typescript@5.7.3))(eslint@9.38.0(jiti@2.5.1))(vue-eslint-parser@10.2.0(eslint@9.38.0(jiti@2.5.1)))
+      eslint-processor-vue-blocks: 2.0.0(@vue/compiler-sfc@3.5.21)(eslint@9.38.0(jiti@2.5.1))
+      globals: 16.4.0
+      local-pkg: 1.1.2
+      pathe: 2.0.3
+      vue-eslint-parser: 10.2.0(eslint@9.38.0(jiti@2.5.1))
+    transitivePeerDependencies:
+      - '@typescript-eslint/utils'
+      - '@vue/compiler-sfc'
+      - eslint-import-resolver-node
+      - supports-color
+      - typescript
+
+  '@nuxt/eslint-plugin@1.9.0(eslint@9.38.0(jiti@2.5.1))(typescript@5.7.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.46.2
+      '@typescript-eslint/utils': 8.46.2(eslint@9.38.0(jiti@2.5.1))(typescript@5.7.3)
+      eslint: 9.38.0(jiti@2.5.1)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@nuxt/eslint@1.9.0(@typescript-eslint/utils@8.46.2(eslint@9.38.0(jiti@2.5.1))(typescript@5.7.3))(@vue/compiler-sfc@3.5.21)(eslint@9.38.0(jiti@2.5.1))(magicast@0.3.5)(typescript@5.7.3)(vite@7.1.5(@types/node@24.3.0)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))':
+    dependencies:
+      '@eslint/config-inspector': 1.3.0(eslint@9.38.0(jiti@2.5.1))
+      '@nuxt/devtools-kit': 2.6.3(magicast@0.3.5)(vite@7.1.5(@types/node@24.3.0)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))
+      '@nuxt/eslint-config': 1.9.0(@typescript-eslint/utils@8.46.2(eslint@9.38.0(jiti@2.5.1))(typescript@5.7.3))(@vue/compiler-sfc@3.5.21)(eslint@9.38.0(jiti@2.5.1))(typescript@5.7.3)
+      '@nuxt/eslint-plugin': 1.9.0(eslint@9.38.0(jiti@2.5.1))(typescript@5.7.3)
+      '@nuxt/kit': 4.0.3(magicast@0.3.5)
+      chokidar: 4.0.3
+      eslint: 9.38.0(jiti@2.5.1)
+      eslint-flat-config-utils: 2.1.4
+      eslint-typegen: 2.3.0(eslint@9.38.0(jiti@2.5.1))
+      find-up: 7.0.0
+      get-port-please: 3.2.0
+      mlly: 1.8.0
+      pathe: 2.0.3
+      unimport: 5.2.0
+    transitivePeerDependencies:
+      - '@typescript-eslint/utils'
+      - '@vue/compiler-sfc'
+      - bufferutil
+      - eslint-import-resolver-node
+      - eslint-plugin-format
+      - magicast
+      - supports-color
+      - typescript
+      - utf-8-validate
+      - vite
 
   '@nuxt/kit@3.16.2(magicast@0.3.5)':
     dependencies:
@@ -7180,7 +7581,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/vite-builder@3.19.0(@types/node@24.3.0)(eslint@9.25.0(jiti@2.5.1))(magicast@0.3.5)(optionator@0.9.4)(rollup@4.50.2)(terser@5.44.0)(typescript@5.7.3)(vue@3.5.21(typescript@5.7.3))(yaml@2.8.1)':
+  '@nuxt/vite-builder@3.19.0(@types/node@24.3.0)(eslint@9.38.0(jiti@2.5.1))(magicast@0.3.5)(optionator@0.9.4)(rollup@4.50.2)(terser@5.44.0)(typescript@5.7.3)(vue@3.5.21(typescript@5.7.3))(yaml@2.8.1)':
     dependencies:
       '@nuxt/kit': 3.19.0(magicast@0.3.5)
       '@rollup/plugin-replace': 6.0.2(rollup@4.50.2)
@@ -7212,7 +7613,7 @@ snapshots:
       unenv: 2.0.0-rc.21
       vite: 7.1.5(@types/node@24.3.0)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
       vite-node: 3.2.4(@types/node@24.3.0)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
-      vite-plugin-checker: 0.10.3(eslint@9.25.0(jiti@2.5.1))(optionator@0.9.4)(typescript@5.7.3)(vite@7.1.5(@types/node@24.3.0)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))
+      vite-plugin-checker: 0.10.3(eslint@9.38.0(jiti@2.5.1))(optionator@0.9.4)(typescript@5.7.3)(vite@7.1.5(@types/node@24.3.0)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))
       vue: 3.5.21(typescript@5.7.3)
       vue-bundle-renderer: 2.1.2
     transitivePeerDependencies:
@@ -7240,11 +7641,11 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@nuxtjs/i18n@9.5.6(@vue/compiler-dom@3.5.21)(eslint@9.25.0(jiti@2.5.1))(magicast@0.3.5)(rollup@4.50.2)(vue@3.5.21(typescript@5.7.3))':
+  '@nuxtjs/i18n@9.5.6(@vue/compiler-dom@3.5.21)(eslint@9.38.0(jiti@2.5.1))(magicast@0.3.5)(rollup@4.50.2)(vue@3.5.21(typescript@5.7.3))':
     dependencies:
       '@intlify/h3': 0.6.1
       '@intlify/shared': 10.0.7
-      '@intlify/unplugin-vue-i18n': 6.0.8(@vue/compiler-dom@3.5.21)(eslint@9.25.0(jiti@2.5.1))(rollup@4.50.2)(typescript@5.7.3)(vue-i18n@10.0.7(vue@3.5.21(typescript@5.7.3)))(vue@3.5.21(typescript@5.7.3))
+      '@intlify/unplugin-vue-i18n': 6.0.8(@vue/compiler-dom@3.5.21)(eslint@9.38.0(jiti@2.5.1))(rollup@4.50.2)(typescript@5.7.3)(vue-i18n@10.0.7(vue@3.5.21(typescript@5.7.3)))(vue@3.5.21(typescript@5.7.3))
       '@intlify/utils': 0.13.0
       '@miyaneee/rollup-plugin-json5': 1.2.0(rollup@4.50.2)
       '@nuxt/kit': 3.19.0(magicast@0.3.5)
@@ -7805,6 +8206,16 @@ snapshots:
 
   '@speed-highlight/core@1.2.7': {}
 
+  '@stylistic/eslint-plugin@5.5.0(eslint@9.38.0(jiti@2.5.1))':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.38.0(jiti@2.5.1))
+      '@typescript-eslint/types': 8.46.2
+      eslint: 9.38.0(jiti@2.5.1)
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      estraverse: 5.3.0
+      picomatch: 4.0.3
+
   '@surma/rollup-plugin-off-main-thread@2.2.3':
     dependencies:
       ejs: 3.1.10
@@ -7844,10 +8255,48 @@ snapshots:
 
   '@types/web-bluetooth@0.0.21': {}
 
+  '@typescript-eslint/eslint-plugin@8.46.2(@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.5.1))(typescript@5.7.3))(eslint@9.38.0(jiti@2.5.1))(typescript@5.7.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.1
+      '@typescript-eslint/parser': 8.46.2(eslint@9.38.0(jiti@2.5.1))(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.46.2
+      '@typescript-eslint/type-utils': 8.46.2(eslint@9.38.0(jiti@2.5.1))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.46.2(eslint@9.38.0(jiti@2.5.1))(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.46.2
+      eslint: 9.38.0(jiti@2.5.1)
+      graphemer: 1.4.0
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.1.0(typescript@5.7.3)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.5.1))(typescript@5.7.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.46.2
+      '@typescript-eslint/types': 8.46.2
+      '@typescript-eslint/typescript-estree': 8.46.2(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.46.2
+      debug: 4.4.3
+      eslint: 9.38.0(jiti@2.5.1)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/project-service@8.38.0(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.38.0(typescript@5.7.3)
-      '@typescript-eslint/types': 8.38.0
+      '@typescript-eslint/types': 8.46.2
+      debug: 4.4.3
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.46.2(typescript@5.7.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.46.2(typescript@5.7.3)
+      '@typescript-eslint/types': 8.46.2
       debug: 4.4.3
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -7858,11 +8307,34 @@ snapshots:
       '@typescript-eslint/types': 8.38.0
       '@typescript-eslint/visitor-keys': 8.38.0
 
+  '@typescript-eslint/scope-manager@8.46.2':
+    dependencies:
+      '@typescript-eslint/types': 8.46.2
+      '@typescript-eslint/visitor-keys': 8.46.2
+
   '@typescript-eslint/tsconfig-utils@8.38.0(typescript@5.7.3)':
     dependencies:
       typescript: 5.7.3
 
+  '@typescript-eslint/tsconfig-utils@8.46.2(typescript@5.7.3)':
+    dependencies:
+      typescript: 5.7.3
+
+  '@typescript-eslint/type-utils@8.46.2(eslint@9.38.0(jiti@2.5.1))(typescript@5.7.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.46.2
+      '@typescript-eslint/typescript-estree': 8.46.2(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.46.2(eslint@9.38.0(jiti@2.5.1))(typescript@5.7.3)
+      debug: 4.4.3
+      eslint: 9.38.0(jiti@2.5.1)
+      ts-api-utils: 2.1.0(typescript@5.7.3)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/types@8.38.0': {}
+
+  '@typescript-eslint/types@8.46.2': {}
 
   '@typescript-eslint/typescript-estree@8.38.0(typescript@5.7.3)':
     dependencies:
@@ -7880,9 +8352,41 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@8.46.2(typescript@5.7.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.46.2(typescript@5.7.3)
+      '@typescript-eslint/tsconfig-utils': 8.46.2(typescript@5.7.3)
+      '@typescript-eslint/types': 8.46.2
+      '@typescript-eslint/visitor-keys': 8.46.2
+      debug: 4.4.3
+      fast-glob: 3.3.3
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.7.2
+      ts-api-utils: 2.1.0(typescript@5.7.3)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.46.2(eslint@9.38.0(jiti@2.5.1))(typescript@5.7.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.38.0(jiti@2.5.1))
+      '@typescript-eslint/scope-manager': 8.46.2
+      '@typescript-eslint/types': 8.46.2
+      '@typescript-eslint/typescript-estree': 8.46.2(typescript@5.7.3)
+      eslint: 9.38.0(jiti@2.5.1)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/visitor-keys@8.38.0':
     dependencies:
       '@typescript-eslint/types': 8.38.0
+      eslint-visitor-keys: 4.2.1
+
+  '@typescript-eslint/visitor-keys@8.46.2':
+    dependencies:
+      '@typescript-eslint/types': 8.46.2
       eslint-visitor-keys: 4.2.1
 
   '@unhead/vue@2.0.14(vue@3.5.21(typescript@5.7.3))':
@@ -7890,6 +8394,65 @@ snapshots:
       hookable: 5.5.3
       unhead: 2.0.14
       vue: 3.5.21(typescript@5.7.3)
+
+  '@unrs/resolver-binding-android-arm-eabi@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-android-arm64@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-darwin-arm64@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-darwin-x64@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-freebsd-x64@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm-gnueabihf@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm-musleabihf@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm64-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-x64-musl@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-wasm32-wasi@1.11.1':
+    dependencies:
+      '@napi-rs/wasm-runtime': 0.2.12
+    optional: true
+
+  '@unrs/resolver-binding-win32-arm64-msvc@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-win32-ia32-msvc@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
+    optional: true
 
   '@vercel/analytics@1.5.0(vue-router@4.5.1(vue@3.5.21(typescript@5.7.3)))(vue@3.5.21(typescript@5.7.3))':
     optionalDependencies:
@@ -8137,13 +8700,13 @@ snapshots:
 
   '@vueuse/metadata@13.7.0': {}
 
-  '@vueuse/nuxt@13.7.0(magicast@0.3.5)(nuxt@3.19.0(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@24.3.0)(@vue/compiler-sfc@3.5.21)(db0@0.3.2)(encoding@0.1.13)(eslint@9.25.0(jiti@2.5.1))(ioredis@5.7.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.50.2)(terser@5.44.0)(typescript@5.7.3)(vite@7.1.5(@types/node@24.3.0)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(yaml@2.8.1))(vue@3.5.21(typescript@5.7.3))':
+  '@vueuse/nuxt@13.7.0(magicast@0.3.5)(nuxt@3.19.0(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@24.3.0)(@vue/compiler-sfc@3.5.21)(db0@0.3.2)(encoding@0.1.13)(eslint@9.38.0(jiti@2.5.1))(ioredis@5.7.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.50.2)(terser@5.44.0)(typescript@5.7.3)(vite@7.1.5(@types/node@24.3.0)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(yaml@2.8.1))(vue@3.5.21(typescript@5.7.3))':
     dependencies:
       '@nuxt/kit': 4.0.3(magicast@0.3.5)
       '@vueuse/core': 13.7.0(vue@3.5.21(typescript@5.7.3))
       '@vueuse/metadata': 13.7.0
       local-pkg: 1.1.1
-      nuxt: 3.19.0(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@24.3.0)(@vue/compiler-sfc@3.5.21)(db0@0.3.2)(encoding@0.1.13)(eslint@9.25.0(jiti@2.5.1))(ioredis@5.7.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.50.2)(terser@5.44.0)(typescript@5.7.3)(vite@7.1.5(@types/node@24.3.0)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(yaml@2.8.1)
+      nuxt: 3.19.0(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@24.3.0)(@vue/compiler-sfc@3.5.21)(db0@0.3.2)(encoding@0.1.13)(eslint@9.38.0(jiti@2.5.1))(ioredis@5.7.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.50.2)(terser@5.44.0)(typescript@5.7.3)(vite@7.1.5(@types/node@24.3.0)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(yaml@2.8.1)
       vue: 3.5.21(typescript@5.7.3)
     transitivePeerDependencies:
       - magicast
@@ -8279,6 +8842,8 @@ snapshots:
     transitivePeerDependencies:
       - react-native-b4a
 
+  are-docs-informative@0.0.2: {}
+
   arg@5.0.2: {}
 
   argparse@2.0.1: {}
@@ -8297,20 +8862,6 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
-
-  asn1.js@4.10.1:
-    dependencies:
-      bn.js: 4.12.2
-      inherits: 2.0.4
-      minimalistic-assert: 1.0.1
-
-  assert@2.1.0:
-    dependencies:
-      call-bind: 1.0.8
-      is-nan: 1.3.2
-      object-is: 1.1.6
-      object.assign: 4.1.7
-      util: 0.12.5
 
   ast-kit@1.4.2:
     dependencies:
@@ -8399,10 +8950,6 @@ snapshots:
 
   birpc@2.5.0: {}
 
-  bn.js@4.12.2: {}
-
-  bn.js@5.2.2: {}
-
   boolbase@1.0.0: {}
 
   brace-expansion@1.1.11:
@@ -8422,56 +8969,6 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  brorand@1.1.0: {}
-
-  browser-resolve@2.0.0:
-    dependencies:
-      resolve: 1.22.10
-
-  browserify-aes@1.2.0:
-    dependencies:
-      buffer-xor: 1.0.3
-      cipher-base: 1.0.7
-      create-hash: 1.2.0
-      evp_bytestokey: 1.0.3
-      inherits: 2.0.4
-      safe-buffer: 5.2.1
-
-  browserify-cipher@1.0.1:
-    dependencies:
-      browserify-aes: 1.2.0
-      browserify-des: 1.0.2
-      evp_bytestokey: 1.0.3
-
-  browserify-des@1.0.2:
-    dependencies:
-      cipher-base: 1.0.7
-      des.js: 1.1.0
-      inherits: 2.0.4
-      safe-buffer: 5.2.1
-
-  browserify-rsa@4.1.1:
-    dependencies:
-      bn.js: 5.2.2
-      randombytes: 2.1.0
-      safe-buffer: 5.2.1
-
-  browserify-sign@4.2.5:
-    dependencies:
-      bn.js: 5.2.2
-      browserify-rsa: 4.1.1
-      create-hash: 1.2.0
-      create-hmac: 1.1.7
-      elliptic: 6.6.1
-      inherits: 2.0.4
-      parse-asn1: 5.1.9
-      readable-stream: 2.3.8
-      safe-buffer: 5.2.1
-
-  browserify-zlib@0.2.0:
-    dependencies:
-      pako: 1.0.11
-
   browserslist@4.26.2:
     dependencies:
       baseline-browser-mapping: 2.8.5
@@ -8484,23 +8981,21 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
-  buffer-xor@1.0.3: {}
-
-  buffer@5.7.1:
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
-
   buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  builtin-status-codes@3.0.0: {}
+  builtin-modules@5.0.0: {}
 
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.0.0
+
+  bundle-require@5.1.0(esbuild@0.25.10):
+    dependencies:
+      esbuild: 0.25.10
+      load-tsconfig: 0.2.5
 
   c12@3.0.2(magicast@0.3.5):
     dependencies:
@@ -8581,6 +9076,8 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  change-case@5.4.4: {}
+
   chokidar@3.6.0:
     dependencies:
       anymatch: 3.1.3
@@ -8599,17 +9096,17 @@ snapshots:
 
   chownr@3.0.0: {}
 
-  cipher-base@1.0.7:
-    dependencies:
-      inherits: 2.0.4
-      safe-buffer: 5.2.1
-      to-buffer: 1.2.2
+  ci-info@4.3.1: {}
 
   citty@0.1.6:
     dependencies:
       consola: 3.4.2
 
   classnames@2.5.1: {}
+
+  clean-regexp@1.0.0:
+    dependencies:
+      escape-string-regexp: 1.0.5
 
   clipboardy@4.0.0:
     dependencies:
@@ -8643,6 +9140,8 @@ snapshots:
 
   commander@6.2.1: {}
 
+  comment-parser@1.4.1: {}
+
   common-tags@1.8.2: {}
 
   commondir@1.0.1: {}
@@ -8666,10 +9165,6 @@ snapshots:
   confbox@0.2.2: {}
 
   consola@3.4.2: {}
-
-  console-browserify@1.2.0: {}
-
-  constants-browserify@1.0.0: {}
 
   content-disposition@0.5.4:
     dependencies:
@@ -8711,30 +9206,6 @@ snapshots:
     optionalDependencies:
       buffer: 6.0.3
 
-  create-ecdh@4.0.4:
-    dependencies:
-      bn.js: 4.12.2
-      elliptic: 6.6.1
-
-  create-hash@1.2.0:
-    dependencies:
-      cipher-base: 1.0.7
-      inherits: 2.0.4
-      md5.js: 1.3.5
-      ripemd160: 2.0.3
-      sha.js: 2.4.12
-
-  create-hmac@1.1.7:
-    dependencies:
-      cipher-base: 1.0.7
-      create-hash: 1.2.0
-      inherits: 2.0.4
-      ripemd160: 2.0.3
-      safe-buffer: 5.2.1
-      sha.js: 2.4.12
-
-  create-require@1.1.1: {}
-
   croner@9.1.0: {}
 
   cross-spawn@7.0.6:
@@ -8750,21 +9221,6 @@ snapshots:
   crossws@0.3.5:
     dependencies:
       uncrypto: 0.1.3
-
-  crypto-browserify@3.12.1:
-    dependencies:
-      browserify-cipher: 1.0.1
-      browserify-sign: 4.2.5
-      create-ecdh: 4.0.4
-      create-hash: 1.2.0
-      create-hmac: 1.1.7
-      diffie-hellman: 5.0.3
-      hash-base: 3.0.5
-      inherits: 2.0.4
-      pbkdf2: 3.1.5
-      public-encrypt: 4.0.3
-      randombytes: 2.1.0
-      randomfill: 1.0.4
 
   crypto-js@4.2.0: {}
 
@@ -8875,10 +9331,6 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  debug@4.4.0:
-    dependencies:
-      ms: 2.1.3
-
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -8927,11 +9379,6 @@ snapshots:
 
   depd@2.0.0: {}
 
-  des.js@1.1.0:
-    dependencies:
-      inherits: 2.0.4
-      minimalistic-assert: 1.0.1
-
   destr@2.0.5: {}
 
   destroy@1.2.0: {}
@@ -8946,12 +9393,6 @@ snapshots:
 
   diff@8.0.2: {}
 
-  diffie-hellman@5.0.3:
-    dependencies:
-      bn.js: 4.12.2
-      miller-rabin: 4.0.1
-      randombytes: 2.1.0
-
   dlv@1.1.3: {}
 
   dom-serializer@2.0.0:
@@ -8959,8 +9400,6 @@ snapshots:
       domelementtype: 2.3.0
       domhandler: 5.0.3
       entities: 4.5.0
-
-  domain-browser@4.22.0: {}
 
   domelementtype@2.3.0: {}
 
@@ -9001,16 +9440,6 @@ snapshots:
       jake: 10.9.4
 
   electron-to-chromium@1.5.221: {}
-
-  elliptic@6.6.1:
-    dependencies:
-      bn.js: 4.12.2
-      brorand: 1.1.0
-      hash.js: 1.1.7
-      hmac-drbg: 1.0.1
-      inherits: 2.0.4
-      minimalistic-assert: 1.0.1
-      minimalistic-crypto-utils: 1.0.1
 
   emoji-regex@8.0.0: {}
 
@@ -9152,6 +9581,8 @@ snapshots:
 
   escape-html@1.0.3: {}
 
+  escape-string-regexp@1.0.5: {}
+
   escape-string-regexp@4.0.0: {}
 
   escape-string-regexp@5.0.0: {}
@@ -9164,30 +9595,148 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
+  eslint-config-flat-gitignore@2.1.0(eslint@9.38.0(jiti@2.5.1)):
+    dependencies:
+      '@eslint/compat': 1.4.0(eslint@9.38.0(jiti@2.5.1))
+      eslint: 9.38.0(jiti@2.5.1)
+
+  eslint-flat-config-utils@2.1.4:
+    dependencies:
+      pathe: 2.0.3
+
+  eslint-import-context@0.1.9(unrs-resolver@1.11.1):
+    dependencies:
+      get-tsconfig: 4.12.0
+      stable-hash-x: 0.2.0
+    optionalDependencies:
+      unrs-resolver: 1.11.1
+
+  eslint-merge-processors@2.0.0(eslint@9.38.0(jiti@2.5.1)):
+    dependencies:
+      eslint: 9.38.0(jiti@2.5.1)
+
+  eslint-plugin-import-lite@0.3.0(eslint@9.38.0(jiti@2.5.1))(typescript@5.7.3):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.38.0(jiti@2.5.1))
+      '@typescript-eslint/types': 8.38.0
+      eslint: 9.38.0(jiti@2.5.1)
+    optionalDependencies:
+      typescript: 5.7.3
+
+  eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.46.2(eslint@9.38.0(jiti@2.5.1))(typescript@5.7.3))(eslint@9.38.0(jiti@2.5.1)):
+    dependencies:
+      '@typescript-eslint/types': 8.38.0
+      comment-parser: 1.4.1
+      debug: 4.4.3
+      eslint: 9.38.0(jiti@2.5.1)
+      eslint-import-context: 0.1.9(unrs-resolver@1.11.1)
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.7.2
+      stable-hash-x: 0.2.0
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      '@typescript-eslint/utils': 8.46.2(eslint@9.38.0(jiti@2.5.1))(typescript@5.7.3)
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-jsdoc@54.7.0(eslint@9.38.0(jiti@2.5.1)):
+    dependencies:
+      '@es-joy/jsdoccomment': 0.56.0
+      are-docs-informative: 0.0.2
+      comment-parser: 1.4.1
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint: 9.38.0(jiti@2.5.1)
+      espree: 10.4.0
+      esquery: 1.6.0
+      parse-imports-exports: 0.2.4
+      semver: 7.7.2
+      spdx-expression-parse: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-regexp@2.10.0(eslint@9.38.0(jiti@2.5.1)):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.38.0(jiti@2.5.1))
+      '@eslint-community/regexpp': 4.12.1
+      comment-parser: 1.4.1
+      eslint: 9.38.0(jiti@2.5.1)
+      jsdoc-type-pratt-parser: 4.8.0
+      refa: 0.12.1
+      regexp-ast-analysis: 0.7.1
+      scslre: 0.3.0
+
+  eslint-plugin-unicorn@60.0.0(eslint@9.38.0(jiti@2.5.1)):
+    dependencies:
+      '@babel/helper-validator-identifier': 7.27.1
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.38.0(jiti@2.5.1))
+      '@eslint/plugin-kit': 0.3.5
+      change-case: 5.4.4
+      ci-info: 4.3.1
+      clean-regexp: 1.0.0
+      core-js-compat: 3.45.1
+      eslint: 9.38.0(jiti@2.5.1)
+      esquery: 1.6.0
+      find-up-simple: 1.0.1
+      globals: 16.4.0
+      indent-string: 5.0.0
+      is-builtin-module: 5.0.0
+      jsesc: 3.1.0
+      pluralize: 8.0.0
+      regexp-tree: 0.1.27
+      regjsparser: 0.12.0
+      semver: 7.7.2
+      strip-indent: 4.1.1
+
+  eslint-plugin-vue@10.5.1(@stylistic/eslint-plugin@5.5.0(eslint@9.38.0(jiti@2.5.1)))(@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.5.1))(typescript@5.7.3))(eslint@9.38.0(jiti@2.5.1))(vue-eslint-parser@10.2.0(eslint@9.38.0(jiti@2.5.1))):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.38.0(jiti@2.5.1))
+      eslint: 9.38.0(jiti@2.5.1)
+      natural-compare: 1.4.0
+      nth-check: 2.1.1
+      postcss-selector-parser: 6.1.2
+      semver: 7.7.2
+      vue-eslint-parser: 10.2.0(eslint@9.38.0(jiti@2.5.1))
+      xml-name-validator: 4.0.0
+    optionalDependencies:
+      '@stylistic/eslint-plugin': 5.5.0(eslint@9.38.0(jiti@2.5.1))
+      '@typescript-eslint/parser': 8.46.2(eslint@9.38.0(jiti@2.5.1))(typescript@5.7.3)
+
+  eslint-processor-vue-blocks@2.0.0(@vue/compiler-sfc@3.5.21)(eslint@9.38.0(jiti@2.5.1)):
+    dependencies:
+      '@vue/compiler-sfc': 3.5.21
+      eslint: 9.38.0(jiti@2.5.1)
+
   eslint-scope@8.4.0:
     dependencies:
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
+  eslint-typegen@2.3.0(eslint@9.38.0(jiti@2.5.1)):
+    dependencies:
+      eslint: 9.38.0(jiti@2.5.1)
+      json-schema-to-typescript-lite: 15.0.0
+      ohash: 2.0.11
+
   eslint-visitor-keys@3.4.3: {}
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.25.0(jiti@2.5.1):
+  eslint@9.38.0(jiti@2.5.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.25.0(jiti@2.5.1))
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.38.0(jiti@2.5.1))
       '@eslint-community/regexpp': 4.12.1
-      '@eslint/config-array': 0.20.1
-      '@eslint/config-helpers': 0.2.3
-      '@eslint/core': 0.13.0
+      '@eslint/config-array': 0.21.1
+      '@eslint/config-helpers': 0.4.1
+      '@eslint/core': 0.16.0
       '@eslint/eslintrc': 3.3.1
-      '@eslint/js': 9.25.0
-      '@eslint/plugin-kit': 0.2.8
+      '@eslint/js': 9.38.0
+      '@eslint/plugin-kit': 0.4.0
       '@humanfs/node': 0.16.7
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
       '@types/estree': 1.0.8
-      '@types/json-schema': 7.0.15
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
@@ -9260,11 +9809,6 @@ snapshots:
   event-target-shim@5.0.1: {}
 
   events@3.3.0: {}
-
-  evp_bytestokey@1.0.3:
-    dependencies:
-      md5.js: 1.3.5
-      safe-buffer: 5.2.1
 
   execa@8.0.1:
     dependencies:
@@ -9345,6 +9889,8 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  find-up-simple@1.0.1: {}
+
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
@@ -9355,7 +9901,6 @@ snapshots:
       locate-path: 7.2.0
       path-exists: 5.0.0
       unicorn-magic: 0.1.0
-    optional: true
 
   flat-cache@4.0.1:
     dependencies:
@@ -9500,6 +10045,10 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
 
+  get-tsconfig@4.12.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   giget@2.0.0:
     dependencies:
       citty: 0.1.6
@@ -9550,6 +10099,8 @@ snapshots:
 
   globals@14.0.0: {}
 
+  globals@16.4.0: {}
+
   globalthis@1.0.4:
     dependencies:
       define-properties: 1.2.1
@@ -9567,6 +10118,8 @@ snapshots:
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
+
+  graphemer@1.4.0: {}
 
   gzip-size@7.0.0:
     dependencies:
@@ -9616,23 +10169,6 @@ snapshots:
     dependencies:
       has-symbols: 1.0.3
 
-  hash-base@3.0.5:
-    dependencies:
-      inherits: 2.0.4
-      safe-buffer: 5.2.1
-
-  hash-base@3.1.2:
-    dependencies:
-      inherits: 2.0.4
-      readable-stream: 2.3.8
-      safe-buffer: 5.2.1
-      to-buffer: 1.2.2
-
-  hash.js@1.1.7:
-    dependencies:
-      inherits: 2.0.4
-      minimalistic-assert: 1.0.1
-
   hasown@2.0.0:
     dependencies:
       function-bind: 1.1.2
@@ -9642,12 +10178,6 @@ snapshots:
       function-bind: 1.1.2
 
   he@1.2.0: {}
-
-  hmac-drbg@1.0.1:
-    dependencies:
-      hash.js: 1.1.7
-      minimalistic-assert: 1.0.1
-      minimalistic-crypto-utils: 1.0.1
 
   hookable@5.5.3: {}
 
@@ -9680,8 +10210,6 @@ snapshots:
       toidentifier: 1.0.1
 
   http-shutdown@1.2.2: {}
-
-  https-browserify@1.0.0: {}
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -9726,6 +10254,8 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  indent-string@5.0.0: {}
+
   inflight@1.0.6:
     dependencies:
       once: 1.4.0
@@ -9759,11 +10289,6 @@ snapshots:
 
   iron-webcrypto@1.2.1: {}
 
-  is-arguments@1.2.0:
-    dependencies:
-      call-bound: 1.0.4
-      has-tostringtag: 1.0.2
-
   is-array-buffer@3.0.5:
     dependencies:
       call-bind: 1.0.8
@@ -9790,6 +10315,10 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
+
+  is-builtin-module@5.0.0:
+    dependencies:
+      builtin-modules: 5.0.0
 
   is-callable@1.2.7: {}
 
@@ -9847,11 +10376,6 @@ snapshots:
   is-map@2.0.3: {}
 
   is-module@1.0.0: {}
-
-  is-nan@1.3.2:
-    dependencies:
-      call-bind: 1.0.8
-      define-properties: 1.2.1
 
   is-negative-zero@2.0.3: {}
 
@@ -9941,8 +10465,6 @@ snapshots:
 
   isexe@3.1.1: {}
 
-  isomorphic-timers-promises@1.0.1: {}
-
   jackspeak@3.4.3:
     dependencies:
       '@isaacs/cliui': 8.0.2
@@ -9967,11 +10489,20 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsdoc-type-pratt-parser@4.8.0: {}
+
+  jsdoc-type-pratt-parser@5.1.1: {}
+
   jsesc@3.0.2: {}
 
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
+
+  json-schema-to-typescript-lite@15.0.0:
+    dependencies:
+      '@apidevtools/json-schema-ref-parser': 14.2.1(@types/json-schema@7.0.15)
+      '@types/json-schema': 7.0.15
 
   json-schema-traverse@0.4.1: {}
 
@@ -10050,7 +10581,7 @@ snapshots:
       content-disposition: 0.5.4
       content-type: 1.0.5
       cookies: 0.9.1
-      debug: 4.4.0
+      debug: 4.4.3
       delegates: 1.0.0
       depd: 2.0.0
       destroy: 1.2.0
@@ -10116,6 +10647,8 @@ snapshots:
       untun: 0.1.3
       uqr: 0.1.2
 
+  load-tsconfig@0.2.5: {}
+
   local-pkg@1.1.1:
     dependencies:
       mlly: 1.8.0
@@ -10135,7 +10668,6 @@ snapshots:
   locate-path@7.2.0:
     dependencies:
       p-locate: 6.0.0
-    optional: true
 
   lodash-es@4.17.21: {}
 
@@ -10203,12 +10735,6 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  md5.js@1.3.5:
-    dependencies:
-      hash-base: 3.0.5
-      inherits: 2.0.4
-      safe-buffer: 5.2.1
-
   mdn-data@2.0.28: {}
 
   mdn-data@2.12.2: {}
@@ -10234,11 +10760,6 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
-  miller-rabin@4.0.1:
-    dependencies:
-      bn.js: 4.12.2
-      brorand: 1.1.0
-
   mime-db@1.52.0: {}
 
   mime-db@1.54.0: {}
@@ -10258,10 +10779,6 @@ snapshots:
   mimic-fn@4.0.0: {}
 
   mini-svg-data-uri@1.4.4: {}
-
-  minimalistic-assert@1.0.1: {}
-
-  minimalistic-crypto-utils@1.0.1: {}
 
   minimatch@3.1.2:
     dependencies:
@@ -10313,6 +10830,8 @@ snapshots:
   nanoid@5.1.5: {}
 
   nanotar@0.2.0: {}
+
+  napi-postinstall@0.3.4: {}
 
   natural-compare@1.4.0: {}
 
@@ -10459,36 +10978,6 @@ snapshots:
 
   node-releases@2.0.21: {}
 
-  node-stdlib-browser@1.3.1:
-    dependencies:
-      assert: 2.1.0
-      browser-resolve: 2.0.0
-      browserify-zlib: 0.2.0
-      buffer: 5.7.1
-      console-browserify: 1.2.0
-      constants-browserify: 1.0.0
-      create-require: 1.1.1
-      crypto-browserify: 3.12.1
-      domain-browser: 4.22.0
-      events: 3.3.0
-      https-browserify: 1.0.0
-      isomorphic-timers-promises: 1.0.1
-      os-browserify: 0.3.0
-      path-browserify: 1.0.1
-      pkg-dir: 5.0.0
-      process: 0.11.10
-      punycode: 1.4.1
-      querystring-es3: 0.2.1
-      readable-stream: 3.6.2
-      stream-browserify: 3.0.0
-      stream-http: 3.2.0
-      string_decoder: 1.3.0
-      timers-browserify: 2.0.12
-      tty-browserify: 0.0.1
-      url: 0.11.4
-      util: 0.12.5
-      vm-browserify: 1.1.2
-
   nopt@8.1.0:
     dependencies:
       abbrev: 3.0.1
@@ -10510,7 +10999,7 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt@3.19.0(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@24.3.0)(@vue/compiler-sfc@3.5.21)(db0@0.3.2)(encoding@0.1.13)(eslint@9.25.0(jiti@2.5.1))(ioredis@5.7.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.50.2)(terser@5.44.0)(typescript@5.7.3)(vite@7.1.5(@types/node@24.3.0)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(yaml@2.8.1):
+  nuxt@3.19.0(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@24.3.0)(@vue/compiler-sfc@3.5.21)(db0@0.3.2)(encoding@0.1.13)(eslint@9.38.0(jiti@2.5.1))(ioredis@5.7.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.50.2)(terser@5.44.0)(typescript@5.7.3)(vite@7.1.5(@types/node@24.3.0)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(yaml@2.8.1):
     dependencies:
       '@nuxt/cli': 3.28.0(magicast@0.3.5)
       '@nuxt/devalue': 2.0.2
@@ -10518,7 +11007,7 @@ snapshots:
       '@nuxt/kit': 3.19.0(magicast@0.3.5)
       '@nuxt/schema': 3.19.0
       '@nuxt/telemetry': 2.6.6(magicast@0.3.5)
-      '@nuxt/vite-builder': 3.19.0(@types/node@24.3.0)(eslint@9.25.0(jiti@2.5.1))(magicast@0.3.5)(optionator@0.9.4)(rollup@4.50.2)(terser@5.44.0)(typescript@5.7.3)(vue@3.5.21(typescript@5.7.3))(yaml@2.8.1)
+      '@nuxt/vite-builder': 3.19.0(@types/node@24.3.0)(eslint@9.38.0(jiti@2.5.1))(magicast@0.3.5)(optionator@0.9.4)(rollup@4.50.2)(terser@5.44.0)(typescript@5.7.3)(vue@3.5.21(typescript@5.7.3))(yaml@2.8.1)
       '@unhead/vue': 2.0.14(vue@3.5.21(typescript@5.7.3))
       '@vue/shared': 3.5.21
       c12: 3.3.0(magicast@0.3.5)
@@ -10649,11 +11138,6 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
-  object-is@1.1.6:
-    dependencies:
-      call-bind: 1.0.8
-      define-properties: 1.2.1
-
   object-keys@1.1.1: {}
 
   object.assign@4.1.7:
@@ -10715,8 +11199,6 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
-
-  os-browserify@0.3.0: {}
 
   own-keys@1.0.1:
     dependencies:
@@ -10812,7 +11294,6 @@ snapshots:
   p-limit@4.0.0:
     dependencies:
       yocto-queue: 1.2.1
-    optional: true
 
   p-locate@5.0.0:
     dependencies:
@@ -10821,7 +11302,6 @@ snapshots:
   p-locate@6.0.0:
     dependencies:
       p-limit: 4.0.0
-    optional: true
 
   p-timeout@6.1.4:
     optional: true
@@ -10843,20 +11323,18 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
-  parse-asn1@5.1.9:
-    dependencies:
-      asn1.js: 4.10.1
-      browserify-aes: 1.2.0
-      evp_bytestokey: 1.0.3
-      pbkdf2: 3.1.5
-      safe-buffer: 5.2.1
-
   parse-gitignore@2.0.0:
     optional: true
+
+  parse-imports-exports@0.2.4:
+    dependencies:
+      parse-statements: 1.0.11
 
   parse-path@7.1.0:
     dependencies:
       protocols: 2.0.2
+
+  parse-statements@1.0.11: {}
 
   parse-url@9.2.0:
     dependencies:
@@ -10869,8 +11347,7 @@ snapshots:
 
   path-exists@4.0.0: {}
 
-  path-exists@5.0.0:
-    optional: true
+  path-exists@5.0.0: {}
 
   path-is-absolute@1.0.1: {}
 
@@ -10893,15 +11370,6 @@ snapshots:
 
   pathe@2.0.3: {}
 
-  pbkdf2@3.1.5:
-    dependencies:
-      create-hash: 1.2.0
-      create-hmac: 1.1.7
-      ripemd160: 2.0.3
-      safe-buffer: 5.2.1
-      sha.js: 2.4.12
-      to-buffer: 1.2.2
-
   perfect-debounce@1.0.0: {}
 
   perfect-debounce@2.0.0: {}
@@ -10923,10 +11391,6 @@ snapshots:
 
   pirates@4.0.6: {}
 
-  pkg-dir@5.0.0:
-    dependencies:
-      find-up: 5.0.0
-
   pkg-types@1.3.1:
     dependencies:
       confbox: 0.1.8
@@ -10945,10 +11409,12 @@ snapshots:
       exsolve: 1.0.7
       pathe: 2.0.3
 
+  pluralize@8.0.0: {}
+
   portfinder@1.0.37:
     dependencies:
       async: 3.2.6
-      debug: 4.4.0
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -11171,28 +11637,16 @@ snapshots:
 
   protocols@2.0.2: {}
 
-  public-encrypt@4.0.3:
-    dependencies:
-      bn.js: 4.12.2
-      browserify-rsa: 4.1.1
-      create-hash: 1.2.0
-      parse-asn1: 5.1.9
-      randombytes: 2.1.0
-      safe-buffer: 5.2.1
-
-  punycode@1.4.1: {}
-
   punycode@2.3.1: {}
 
   qs@6.14.0:
     dependencies:
       side-channel: 1.1.0
+    optional: true
 
   quansync@0.2.10: {}
 
   quansync@0.2.11: {}
-
-  querystring-es3@0.2.1: {}
 
   queue-microtask@1.2.3: {}
 
@@ -11200,11 +11654,6 @@ snapshots:
 
   randombytes@2.1.0:
     dependencies:
-      safe-buffer: 5.2.1
-
-  randomfill@1.0.4:
-    dependencies:
-      randombytes: 2.1.0
       safe-buffer: 5.2.1
 
   range-parser@1.2.1: {}
@@ -11226,12 +11675,6 @@ snapshots:
       process-nextick-args: 2.0.1
       safe-buffer: 5.1.2
       string_decoder: 1.1.1
-      util-deprecate: 1.0.2
-
-  readable-stream@3.6.2:
-    dependencies:
-      inherits: 2.0.4
-      string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
   readable-stream@4.7.0:
@@ -11258,6 +11701,10 @@ snapshots:
     dependencies:
       redis-errors: 1.2.0
 
+  refa@0.12.1:
+    dependencies:
+      '@eslint-community/regexpp': 4.12.1
+
   reflect.getprototypeof@1.0.10:
     dependencies:
       call-bind: 1.0.8
@@ -11274,6 +11721,11 @@ snapshots:
       regenerate: 1.4.2
 
   regenerate@1.4.2: {}
+
+  regexp-ast-analysis@0.7.1:
+    dependencies:
+      '@eslint-community/regexpp': 4.12.1
+      refa: 0.12.1
 
   regexp-tree@0.1.27: {}
 
@@ -11320,6 +11772,8 @@ snapshots:
       http-errors: 1.6.3
       path-is-absolute: 1.0.1
 
+  resolve-pkg-maps@1.0.0: {}
+
   resolve@1.22.10:
     dependencies:
       is-core-module: 2.16.1
@@ -11335,11 +11789,6 @@ snapshots:
   reusify@1.0.4: {}
 
   rfdc@1.4.1: {}
-
-  ripemd160@2.0.3:
-    dependencies:
-      hash-base: 3.1.2
-      inherits: 2.0.4
 
   rollup-plugin-visualizer@6.0.3(rollup@4.50.2):
     dependencies:
@@ -11415,6 +11864,12 @@ snapshots:
 
   sax@1.4.1: {}
 
+  scslre@0.3.0:
+    dependencies:
+      '@eslint-community/regexpp': 4.12.1
+      refa: 0.12.1
+      regexp-ast-analysis: 0.7.1
+
   scule@1.3.0: {}
 
   semver@6.3.1: {}
@@ -11481,12 +11936,6 @@ snapshots:
   setprototypeof@1.1.0: {}
 
   setprototypeof@1.2.0: {}
-
-  sha.js@2.4.12:
-    dependencies:
-      inherits: 2.0.4
-      safe-buffer: 5.2.1
-      to-buffer: 1.2.2
 
   shebang-command@2.0.0:
     dependencies:
@@ -11563,7 +12012,18 @@ snapshots:
 
   sourcemap-codec@1.4.8: {}
 
+  spdx-exceptions@2.5.0: {}
+
+  spdx-expression-parse@4.0.0:
+    dependencies:
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.22
+
+  spdx-license-ids@3.0.22: {}
+
   speakingurl@14.0.1: {}
+
+  stable-hash-x@0.2.0: {}
 
   standard-as-callback@2.1.0: {}
 
@@ -11585,18 +12045,6 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
-
-  stream-browserify@3.0.0:
-    dependencies:
-      inherits: 2.0.4
-      readable-stream: 3.6.2
-
-  stream-http@3.2.0:
-    dependencies:
-      builtin-status-codes: 3.0.0
-      inherits: 2.0.4
-      readable-stream: 3.6.2
-      xtend: 4.0.2
 
   streamx@2.22.1:
     dependencies:
@@ -11683,6 +12131,8 @@ snapshots:
   strip-comments@2.0.1: {}
 
   strip-final-newline@3.0.0: {}
+
+  strip-indent@4.1.1: {}
 
   strip-json-comments@3.1.1: {}
 
@@ -11824,10 +12274,6 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
-  timers-browserify@2.0.12:
-    dependencies:
-      setimmediate: 1.0.5
-
   tiny-invariant@1.3.3: {}
 
   tinyexec@1.0.1: {}
@@ -11841,12 +12287,6 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
-
-  to-buffer@1.2.2:
-    dependencies:
-      isarray: 2.0.5
-      safe-buffer: 5.2.1
-      typed-array-buffer: 1.0.3
 
   to-regex-range@5.0.1:
     dependencies:
@@ -11878,8 +12318,6 @@ snapshots:
   tslog@4.9.3: {}
 
   tsscmp@1.0.6: {}
-
-  tty-browserify@0.0.1: {}
 
   type-check@0.4.0:
     dependencies:
@@ -11979,8 +12417,7 @@ snapshots:
 
   unicode-property-aliases-ecmascript@2.2.0: {}
 
-  unicorn-magic@0.1.0:
-    optional: true
+  unicorn-magic@0.1.0: {}
 
   unicorn-magic@0.3.0: {}
 
@@ -12093,6 +12530,30 @@ snapshots:
       picomatch: 4.0.3
       webpack-virtual-modules: 0.6.2
 
+  unrs-resolver@1.11.1:
+    dependencies:
+      napi-postinstall: 0.3.4
+    optionalDependencies:
+      '@unrs/resolver-binding-android-arm-eabi': 1.11.1
+      '@unrs/resolver-binding-android-arm64': 1.11.1
+      '@unrs/resolver-binding-darwin-arm64': 1.11.1
+      '@unrs/resolver-binding-darwin-x64': 1.11.1
+      '@unrs/resolver-binding-freebsd-x64': 1.11.1
+      '@unrs/resolver-binding-linux-arm-gnueabihf': 1.11.1
+      '@unrs/resolver-binding-linux-arm-musleabihf': 1.11.1
+      '@unrs/resolver-binding-linux-arm64-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-arm64-musl': 1.11.1
+      '@unrs/resolver-binding-linux-ppc64-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-riscv64-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-riscv64-musl': 1.11.1
+      '@unrs/resolver-binding-linux-s390x-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-x64-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-x64-musl': 1.11.1
+      '@unrs/resolver-binding-wasm32-wasi': 1.11.1
+      '@unrs/resolver-binding-win32-arm64-msvc': 1.11.1
+      '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
+      '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
+
   unstorage@1.17.1(@netlify/blobs@9.1.2)(db0@0.3.2)(ioredis@5.7.0):
     dependencies:
       anymatch: 3.1.3
@@ -12145,23 +12606,10 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  url@0.11.4:
-    dependencies:
-      punycode: 1.4.1
-      qs: 6.14.0
-
   urlpattern-polyfill@10.1.0:
     optional: true
 
   util-deprecate@1.0.2: {}
-
-  util@0.12.5:
-    dependencies:
-      inherits: 2.0.4
-      is-arguments: 1.2.0
-      is-generator-function: 1.1.0
-      is-typed-array: 1.1.15
-      which-typed-array: 1.1.19
 
   uuid@11.1.0:
     optional: true
@@ -12199,7 +12647,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-checker@0.10.3(eslint@9.25.0(jiti@2.5.1))(optionator@0.9.4)(typescript@5.7.3)(vite@7.1.5(@types/node@24.3.0)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)):
+  vite-plugin-checker@0.10.3(eslint@9.38.0(jiti@2.5.1))(optionator@0.9.4)(typescript@5.7.3)(vite@7.1.5(@types/node@24.3.0)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)):
     dependencies:
       '@babel/code-frame': 7.27.1
       chokidar: 4.0.3
@@ -12212,7 +12660,7 @@ snapshots:
       vite: 7.1.5(@types/node@24.3.0)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
       vscode-uri: 3.1.0
     optionalDependencies:
-      eslint: 9.25.0(jiti@2.5.1)
+      eslint: 9.38.0(jiti@2.5.1)
       optionator: 0.9.4
       typescript: 5.7.3
 
@@ -12269,8 +12717,6 @@ snapshots:
       terser: 5.44.0
       yaml: 2.8.1
 
-  vm-browserify@1.1.2: {}
-
   vscode-uri@3.1.0: {}
 
   vue-bundle-renderer@2.1.2:
@@ -12278,6 +12724,18 @@ snapshots:
       ufo: 1.6.1
 
   vue-devtools-stub@0.1.0: {}
+
+  vue-eslint-parser@10.2.0(eslint@9.38.0(jiti@2.5.1)):
+    dependencies:
+      debug: 4.4.3
+      eslint: 9.38.0(jiti@2.5.1)
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.6.0
+      semver: 7.7.2
+    transitivePeerDependencies:
+      - supports-color
 
   vue-i18n@10.0.7(vue@3.5.21(typescript@5.7.3)):
     dependencies:
@@ -12515,7 +12973,7 @@ snapshots:
     dependencies:
       is-wsl: 3.1.0
 
-  xtend@4.0.2: {}
+  xml-name-validator@4.0.0: {}
 
   xterm@5.3.0: {}
 
@@ -12550,8 +13008,7 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  yocto-queue@1.2.1:
-    optional: true
+  yocto-queue@1.2.1: {}
 
   youch-core@0.3.3:
     dependencies:

--- a/stores/deviceStore.ts
+++ b/stores/deviceStore.ts
@@ -1,35 +1,35 @@
-import { mande } from 'mande';
-import { defineStore } from 'pinia';
+import { mande } from 'mande'
+import { defineStore } from 'pinia'
 import {
   vendorCobrandingTag,
-} from '~/types/resources';
+} from '~/types/resources'
 
-import { MeshDevice } from '@meshtastic/core';
-import { TransportWebSerial } from '@meshtastic/transport-web-serial';
+import { MeshDevice } from '@meshtastic/core'
+import { TransportWebSerial } from '@meshtastic/transport-web-serial'
 
 // biome-ignore lint/style/useImportType: WUT?
-import { type DeviceHardware } from '../types/api';
-import { createUrl } from './store';
-import { useFirmwareStore } from './firmwareStore';
-import { useToastStore } from './toastStore';
+import type { DeviceHardware } from '../types/api'
+import { createUrl } from './store'
+import { useFirmwareStore } from './firmwareStore'
+import { useToastStore } from './toastStore'
 
 // Ensure Web Serial API types are available
 declare global {
   interface Navigator {
-    serial: any;
+    serial: any
   }
   interface SerialPort {
-    readable: ReadableStream;
-    writable: WritableStream;
-    open(options: any): Promise<void>;
-    close(): Promise<void>;
-    forget(): Promise<void>;
+    readable: ReadableStream
+    writable: WritableStream
+    open(options: any): Promise<void>
+    close(): Promise<void>
+    forget(): Promise<void>
   }
 }
 
-const firmwareApi = mande(createUrl("api/resource/deviceHardware"));
+const firmwareApi = mande(createUrl('api/resource/deviceHardware'))
 
-export const useDeviceStore = defineStore("device", {
+export const useDeviceStore = defineStore('device', {
   state: () => {
     return {
       selectedDevice: <DeviceHardware | undefined>undefined,
@@ -41,345 +41,361 @@ export const useDeviceStore = defineStore("device", {
       readerClosed: <Promise<any> | undefined>undefined,
       writerClosed: <Promise<any> | undefined>undefined,
       port: <SerialPort | undefined>undefined,
-    };
+    }
   },
   getters: {
     filteredDevices(): DeviceHardware[] {
       if (this.tag) {
-        return this.targets.filter(t => t.tags?.includes(this.tag ?? '') || t.architecture === this.tag);
+        return this.targets.filter(t => t.tags?.includes(this.tag ?? '') || t.architecture === this.tag)
       }
       return this.targets
     },
     sortedDevices(): DeviceHardware[] {
       return this.filteredDevices
         .filter(t => t.supportLevel === 1).sort((a, b) => {
-            const hwModelComparison = a.hwModel - b.hwModel;
-            if (hwModelComparison !== 0) return hwModelComparison;
-            return (a.images?.length ?? 0) - (b.images?.length ?? 0);
-          })
+          const hwModelComparison = a.hwModel - b.hwModel
+          if (hwModelComparison !== 0) return hwModelComparison
+          return (a.images?.length ?? 0) - (b.images?.length ?? 0)
+        })
         .concat(this.filteredDevices.filter(t => t.supportLevel === 2)
           .sort((a, b) => {
-            const hwModelComparison = a.hwModel - b.hwModel;
-            if (hwModelComparison !== 0) return hwModelComparison;
-            return (a.images?.length ?? 0) - (b.images?.length ?? 0);
+            const hwModelComparison = a.hwModel - b.hwModel
+            if (hwModelComparison !== 0) return hwModelComparison
+            return (a.images?.length ?? 0) - (b.images?.length ?? 0)
           }))
         .concat(this.filteredDevices.filter(t => (t.supportLevel ?? 3) === 3)
-          .sort((a, b) => a.hwModel - b.hwModel));
+          .sort((a, b) => a.hwModel - b.hwModel))
     },
     allTags(): string[] {
-      return this.targets.flatMap(t => t.tags ?? []).filter((v, i, a) => a.indexOf(v) === i);
+      return this.targets.flatMap(t => t.tags ?? []).filter((v, i, a) => a.indexOf(v) === i)
     },
     allArchs(): string[] {
-      return this.targets.map(t => t.architecture).filter((v, i, a) => a.indexOf(v) === i);
+      return this.targets.map(t => t.architecture).filter((v, i, a) => a.indexOf(v) === i)
     },
-    selectedArchitecture: (state) => state.selectedTarget?.architecture || "",
+    selectedArchitecture: state => state.selectedTarget?.architecture || '',
     isSelectedNrf(): boolean {
-      return this.selectedArchitecture.startsWith("nrf52");
+      return this.selectedArchitecture.startsWith('nrf52')
     },
     isSoftDevice7point3(): boolean {
-      const sd73Devices = ["WIO_WM1110", "TRACKER_T1000_E", "XIAO_NRF52_KIT", "SEEED_SOLAR_NODE", "SEEED_WIO_TRACKER_L1" , "SEEED_WIO_TRACKER_L1_EINK"];
-      return sd73Devices.includes(this.selectedTarget?.hwModelSlug || '');
+      const sd73Devices = ['WIO_WM1110', 'TRACKER_T1000_E', 'XIAO_NRF52_KIT', 'SEEED_SOLAR_NODE', 'SEEED_WIO_TRACKER_L1', 'SEEED_WIO_TRACKER_L1_EINK']
+      return sd73Devices.includes(this.selectedTarget?.hwModelSlug || '')
     },
     enterDfuVersion(): string {
       if (this.isSelectedNrf) {
-        return "2.2.17";
+        return '2.2.17'
       }
-      return "2.2.18";
+      return '2.2.18'
     },
     dfuStepAction(): string {
-      const { t } = useI18n();
+      const { t } = useI18n()
 
       if (this.isSelectedNrf) {
-        return t('flash.dfu_action_doubleclick');
+        return t('flash.dfu_action_doubleclick')
       }
-      return t('flash.dfu_action_bootsel');
+      return t('flash.dfu_action_bootsel')
     },
   },
   actions: {
     async fetchList() {
       try {
         // First try to fetch from the API
-        const targets = await firmwareApi.get<DeviceHardware[]>();
-        this.setTargetsList(targets);
-      } catch (ex) {
-        console.error(ex);
+        const targets = await firmwareApi.get<DeviceHardware[]>()
+        this.setTargetsList(targets)
+      }
+      catch (ex) {
+        console.error(ex)
         // Fallback to offline list from the JSON file
         try {
-          const response = await fetch('/data/hardware-list.json');
+          const response = await fetch('/data/hardware-list.json')
           if (response.ok) {
-            const offlineHardwareList = await response.json();
-            this.setTargetsList(offlineHardwareList);
-          } else {
-            console.error('Failed to load hardware list from JSON file');
+            const offlineHardwareList = await response.json()
+            this.setTargetsList(offlineHardwareList)
           }
-        } catch (error) {
-          console.error('Error loading hardware list from JSON file:', error);
+          else {
+            console.error('Failed to load hardware list from JSON file')
+          }
+        }
+        catch (error) {
+          console.error('Error loading hardware list from JSON file:', error)
         }
       }
     },
     setTargetsList(targets: DeviceHardware[]) {
       if (vendorCobrandingTag.length > 0) {
         this.targets = targets.filter(
-          (t: DeviceHardware) => t.activelySupported && t.tags?.includes(vendorCobrandingTag)
-        );
+          (t: DeviceHardware) => t.activelySupported && t.tags?.includes(vendorCobrandingTag),
+        )
       }
       else {
         this.targets = targets.filter(
-          (t: DeviceHardware) => t.activelySupported
-        );
+          (t: DeviceHardware) => t.activelySupported,
+        )
       }
     },
     async setSelectedTarget(target: DeviceHardware) {
-      this.selectedTarget = target;
-      document.getElementById('device-modal')?.click();
-      const firmwareStore = useFirmwareStore();
+      this.selectedTarget = target
+      document.getElementById('device-modal')?.click()
+      const firmwareStore = useFirmwareStore()
 
-      await new Promise((_) => setTimeout(_, 250));
+      await new Promise(_ => setTimeout(_, 250))
       if (!firmwareStore.hasFirmwareFile && !firmwareStore.hasOnlineFirmware && firmwareStore.stable.length > 0) {
-        firmwareStore.setSelectedFirmware(firmwareStore.stable[0]);
+        firmwareStore.setSelectedFirmware(firmwareStore.stable[0])
       }
 
       // Auto-select MUI for devices that support it
       if (target.hasMui === true) {
-        firmwareStore.$state.shouldInstallMui = true;
+        firmwareStore.$state.shouldInstallMui = true
       }
-      
+
       // Update Datadog RUM context with hardware model and platformio target
       if (import.meta.client) {
         try {
-          const { datadogRum } = await import('@datadog/browser-rum');
-          datadogRum.setGlobalContextProperty('hwModel', target.hwModel);
-          datadogRum.setGlobalContextProperty('platformioTarget', target.platformioTarget);
-        } catch (error) {
+          const { datadogRum } = await import('@datadog/browser-rum')
+          datadogRum.setGlobalContextProperty('hwModel', target.hwModel)
+          datadogRum.setGlobalContextProperty('platformioTarget', target.platformioTarget)
+        }
+        catch (error) {
           // Datadog RUM not available, silently continue
         }
       }
     },
     setSelectedTag(tag: string) {
-      if (tag === "all") {
-        this.tag = undefined;
-        return;
+      if (tag === 'all') {
+        this.tag = undefined
+        return
       }
       if (tag === this.tag) {
-        this.tag = undefined;
-      } else {
-        this.tag = tag;
+        this.tag = undefined
+      }
+      else {
+        this.tag = tag
       }
     },
     async openDeviceConnection(shouldConfigure: boolean = true): Promise<MeshDevice> {
       // Request serial port from user
-      this.port = await navigator.serial.requestPort();
+      this.port = await navigator.serial.requestPort()
 
       // Create transport and device using the new API
-      const transport = await TransportWebSerial.createFromPort(this.port!, 115200);
-      const id = Math.floor(Math.random() * 1e9);
-      const device = new MeshDevice(transport, id);
+      const transport = await TransportWebSerial.createFromPort(this.port!, 115200)
+      const id = Math.floor(Math.random() * 1e9)
+      const device = new MeshDevice(transport, id)
 
       // Configure the device connection
       if (shouldConfigure) {
-        await device.configure();
+        await device.configure()
       }
 
-      return device;
+      return device
     },
     async cleanupDevice(device: MeshDevice) {
-      console.log('Starting device cleanup...');
+      console.log('Starting device cleanup...')
 
       if (this.port && device?.transport?.fromDevice) {
         try {
-          await device.transport.fromDevice.cancel(); // Cancel any ongoing reads
-          } catch (error) {
-            console.warn('Error cancelling fromDevice reader:', error);
+          await device.transport.fromDevice.cancel() // Cancel any ongoing reads
+        }
+        catch (error) {
+          console.warn('Error cancelling fromDevice reader:', error)
+        }
+        try {
+          await device.transport.toDevice.close() // Close the toDevice stream
+        }
+        catch (error) {
+          console.warn('Error closing toDevice writer:', error)
+        }
+        try {
+          const reader = device.transport.fromDevice.getReader()
+
+          const textEncoder = new TextEncoderStream()
+          const writer = textEncoder.writable.getWriter()
+          const writableStreamClosed = textEncoder.readable.pipeTo(this.port.writable!)
+
+          await reader.cancel()
+
+          await writer.close()
+          await writableStreamClosed
+
+          // this is the secret sauce!
+          await this.port?.forget()
+        }
+        catch (error: any) {
+          console.log('Disconnect failed:', error?.message || error)
+          if (this.port) {
+            await this.port.forget()
           }
-          try {
-            await device.transport.toDevice.close(); // Close the toDevice stream
-          } catch (error) {
-            console.warn('Error closing toDevice writer:', error);
-          }
-          try {
-            const reader = device.transport.fromDevice.getReader();
-            
-            const textEncoder = new TextEncoderStream();
-            const writer = textEncoder.writable.getWriter();
-            const writableStreamClosed = textEncoder.readable.pipeTo(this.port.writable!);
-            
-            await reader.cancel();
-            
-            await writer.close();
-            await writableStreamClosed;
-            
-            // this is the secret sauce!
-            await this.port?.forget();
-            
-          } catch (error: any) {
-            console.log('Disconnect failed:', error?.message || error);
-            if (this.port) {
-              await this.port.forget();
-            }
-          }
-        } 
-        
+        }
+      }
+
       // Clear any store state
-      this.abortController = undefined;
-      this.readerClosed = undefined;
-      this.writerClosed = undefined;
+      this.abortController = undefined
+      this.readerClosed = undefined
+      this.writerClosed = undefined
     },
     async enterDfuMode(tFunc?: (key: string) => string) {
-      const toastStore = useToastStore();
-      let device: MeshDevice | null = null;
-      
-      this.isConnecting = true;
+      const toastStore = useToastStore()
+      const device: MeshDevice | null = null
+
+      this.isConnecting = true
       try {
         // Configure the device so transport streams are properly set up
-// Promise.race for connection timeout
-        const connectionPromise = this.openDeviceConnection(false);
+        // Promise.race for connection timeout
+        const connectionPromise = this.openDeviceConnection(false)
         const timeoutPromise = new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error('timeout')), 5000)
-        );
-        let device: MeshDevice;
+          setTimeout(() => reject(new Error('timeout')), 5000),
+        )
+        let device: MeshDevice
         try {
-          device = await Promise.race([connectionPromise, timeoutPromise]);
-        } catch (error) {
+          device = await Promise.race([connectionPromise, timeoutPromise])
+        }
+        catch (error) {
           if ((error as Error).message === 'timeout') {
-            const errorTitle = tFunc?.('dfu.error_connection_title') || 'Device Connection Failed';
-            const errorMessage = tFunc?.('dfu.error_connection') || 'Failed to connect to device. Please disconnect and reconnect the device, then try again. If the problem persists, reload the page.';
-            toastStore.error(errorTitle, errorMessage);
-            throw error;
-          } else {
-            throw error;
+            const errorTitle = tFunc?.('dfu.error_connection_title') || 'Device Connection Failed'
+            const errorMessage = tFunc?.('dfu.error_connection') || 'Failed to connect to device. Please disconnect and reconnect the device, then try again. If the problem persists, reload the page.'
+            toastStore.error(errorTitle, errorMessage)
+            throw error
+          }
+          else {
+            throw error
           }
         }
         device.events.onMyNodeInfo.subscribe((info) => {
-          console.log("Received MyNodeInfo event:", info);
+          console.log('Received MyNodeInfo event:', info)
           // Handle the event as needed
-          device?.enterDfuMode();
-        });
+          device?.enterDfuMode()
+        })
         try {
-          await device.configure();
-        } catch (error) {
-          console.error('Error configuring device:', error);
-          const errorTitle = tFunc?.('dfu.error_title') || 'DFU Mode Failed';
-          const errorMessage = tFunc?.('dfu.error_message') || 'Failed to enter DFU mode. Please disconnect and reconnect the device, then try again.';
-          toastStore.error(errorTitle, errorMessage);
-          throw error;
+          await device.configure()
         }
-        await device.enterDfuMode();
+        catch (error) {
+          console.error('Error configuring device:', error)
+          const errorTitle = tFunc?.('dfu.error_title') || 'DFU Mode Failed'
+          const errorMessage = tFunc?.('dfu.error_message') || 'Failed to enter DFU mode. Please disconnect and reconnect the device, then try again.'
+          toastStore.error(errorTitle, errorMessage)
+          throw error
+        }
+        await device.enterDfuMode()
 
         // Show success message
-        const successTitle = tFunc?.('dfu.success_title') || 'DFU Mode';
-        const successMessage = tFunc?.('dfu.success_message') || 'Device successfully entered DFU mode';
-        toastStore.success(successTitle, successMessage);
+        const successTitle = tFunc?.('dfu.success_title') || 'DFU Mode'
+        const successMessage = tFunc?.('dfu.success_message') || 'Device successfully entered DFU mode'
+        toastStore.success(successTitle, successMessage)
+      }
+      catch (error: any) {
+        console.error('Error entering DFU mode:', error)
 
-      } catch (error: any) {
-        console.error('Error entering DFU mode:', error);
-        
-        const errorTitle = tFunc?.('dfu.error_connection_title') || 'Device Connection Failed';
-        const errorMessage = tFunc?.('dfu.error_connection') || 'Failed to connect to device. Please disconnect and reconnect the device, then try again. If the problem persists, reload the page.';
+        const errorTitle = tFunc?.('dfu.error_connection_title') || 'Device Connection Failed'
+        const errorMessage = tFunc?.('dfu.error_connection') || 'Failed to connect to device. Please disconnect and reconnect the device, then try again. If the problem persists, reload the page.'
 
-        toastStore.error(errorTitle, errorMessage);
-        throw error;
-      } finally {
+        toastStore.error(errorTitle, errorMessage)
+        throw error
+      }
+      finally {
         // Always attempt to clean up the device connection
         if (device) {
-          await this.cleanupDevice(device);
+          await this.cleanupDevice(device)
         }
-        this.isConnecting = false;
+        this.isConnecting = false
       }
     },
     async baud1200() {
-      this.port = await navigator.serial.requestPort();
-      await this.port?.open({ baudRate: 1200 });
+      this.port = await navigator.serial.requestPort()
+      await this.port?.open({ baudRate: 1200 })
       // Give the device a moment to recognize the 1200 baud connection
-      await new Promise((resolve) => setTimeout(resolve, 500));
-      await this.port?.close();
+      await new Promise(resolve => setTimeout(resolve, 500))
+      await this.port?.close()
     },
     async autoSelectHardware(tFunc?: (key: string) => string) {
-      const toastStore = useToastStore();
-      this.isConnecting = true;
+      const toastStore = useToastStore()
+      this.isConnecting = true
       try {
         // Promise.race for connection timeout
-        const connectionPromise = this.openDeviceConnection(false);
+        const connectionPromise = this.openDeviceConnection(false)
         const timeoutPromise = new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error('timeout')), 5000)
-        );
-        let device: MeshDevice;
+          setTimeout(() => reject(new Error('timeout')), 5000),
+        )
+        let device: MeshDevice
         try {
-          device = await Promise.race([connectionPromise, timeoutPromise]);
-        } catch (error) {
+          device = await Promise.race([connectionPromise, timeoutPromise])
+        }
+        catch (error) {
           if ((error as Error).message === 'timeout') {
-            const errorTitle = tFunc?.('dfu.error_connection_title') || 'Device Connection Failed';
-            const errorMessage = tFunc?.('dfu.error_connection') || 'Failed to connect to device. Please disconnect and reconnect the device, then try again. If the problem persists, reload the page.';
-            toastStore.error(errorTitle, errorMessage);
-            throw error;
-          } else {
-            throw error;
+            const errorTitle = tFunc?.('dfu.error_connection_title') || 'Device Connection Failed'
+            const errorMessage = tFunc?.('dfu.error_connection') || 'Failed to connect to device. Please disconnect and reconnect the device, then try again. If the problem persists, reload the page.'
+            toastStore.error(errorTitle, errorMessage)
+            throw error
+          }
+          else {
+            throw error
           }
         }
         device.events.onDeviceMetadataPacket.subscribe(async (packet: any) => {
-          console.log("Received device metadata packet:", packet);
+          console.log('Received device metadata packet:', packet)
           // Try to find the device by pio env name first, then hw model if that fails
-          let targetDevice: DeviceHardware | undefined = undefined;
+          let targetDevice: DeviceHardware | undefined = undefined
           if (packet?.data?.platformioTarget?.length > 0) {
             targetDevice = this.targets.find(
               (target: DeviceHardware) => target.platformioTarget === packet?.data?.platformioTarget,
-            );
+            )
           }
           if (!targetDevice) {
             targetDevice = this.targets.find(
               (target: DeviceHardware) => target.hwModel === packet?.data?.hwModel,
-            );
+            )
           }
           if (targetDevice) {
-            console.log("Found device onDeviceMetadataPacket", targetDevice);
-            this.setSelectedTarget(targetDevice);
+            console.log('Found device onDeviceMetadataPacket', targetDevice)
+            this.setSelectedTarget(targetDevice)
             if (targetDevice.architecture.startsWith('nrf')) {
               toastStore.success(
-                  tFunc?.('dfu.success_title') || 'DFU Mode',
-                  tFunc?.('dfu.success_message') || 'Device successfully entered DFU mode'
-                );  
-              await device?.enterDfuMode();
+                tFunc?.('dfu.success_title') || 'DFU Mode',
+                tFunc?.('dfu.success_message') || 'Device successfully entered DFU mode',
+              )
+              await device?.enterDfuMode()
             }
-            await this.cleanupDevice(device);
-            
-            return 0;
+            await this.cleanupDevice(device)
+
+            return 0
           }
-        });
-        
-        const configurePromise = device.configure();
+        })
+
+        const configurePromise = device.configure()
         try {
-          await Promise.race([configurePromise, timeoutPromise]);
-        } catch (error) {
+          await Promise.race([configurePromise, timeoutPromise])
+        }
+        catch (error) {
           if ((error as Error).message === 'timeout') {
             if (this.selectedTarget) {
-              await this.cleanupDevice(device);
-              return;
+              await this.cleanupDevice(device)
+              return
             }
-            const errorTitle = tFunc?.('dfu.error_unresponsive_title') || 'Device Unresponsive';
-            const errorMessage = tFunc?.('dfu.error_unresponsive') || 'The device is not responding. Please ensure it is properly connected and not in DFU mode.';
-            toastStore.error(errorTitle, errorMessage);
-            throw error;
-          } else {
-            throw error;
+            const errorTitle = tFunc?.('dfu.error_unresponsive_title') || 'Device Unresponsive'
+            const errorMessage = tFunc?.('dfu.error_unresponsive') || 'The device is not responding. Please ensure it is properly connected and not in DFU mode.'
+            toastStore.error(errorTitle, errorMessage)
+            throw error
+          }
+          else {
+            throw error
           }
         }
 
-
         // Wait for device metadata, then clean up
-        await new Promise((resolve) => setTimeout(resolve, 5000));
+        await new Promise(resolve => setTimeout(resolve, 5000))
 
-        await this.cleanupDevice(device);
+        await this.cleanupDevice(device)
 
-        return -1;
-      } catch (error) {
-        console.error('Error in autoSelectHardware:', error);
-        const errorTitle = tFunc?.('dfu.error_connection_title') || 'Device Connection Failed';
-        const errorMessage = tFunc?.('dfu.error_connection') || 'Failed to connect to device. Please disconnect and reconnect the device, then try again. If the problem persists, reload the page.';
+        return -1
+      }
+      catch (error) {
+        console.error('Error in autoSelectHardware:', error)
+        const errorTitle = tFunc?.('dfu.error_connection_title') || 'Device Connection Failed'
+        const errorMessage = tFunc?.('dfu.error_connection') || 'Failed to connect to device. Please disconnect and reconnect the device, then try again. If the problem persists, reload the page.'
 
-        toastStore.error(errorTitle, errorMessage);
-        throw error;
-      } finally {
-        this.isConnecting = false;
+        toastStore.error(errorTitle, errorMessage)
+        throw error
+      }
+      finally {
+        this.isConnecting = false
       }
     },
   },
-});
+})

--- a/stores/firmwareStore.ts
+++ b/stores/firmwareStore.ts
@@ -3,34 +3,34 @@ import {
   type FlashOptions,
   type LoaderOptions,
   Transport,
-} from 'esptool-js';
-import { saveAs } from 'file-saver';
-import { mande } from 'mande';
-import { defineStore } from 'pinia';
-import type { Terminal } from 'xterm';
-import { supportsNew8MBPartitionTable } from '~/utils/versionUtils';
+} from 'esptool-js'
+import { saveAs } from 'file-saver'
+import { mande } from 'mande'
+import { defineStore } from 'pinia'
+import type { Terminal } from 'xterm'
+import { supportsNew8MBPartitionTable } from '~/utils/versionUtils'
 import {
   currentPrerelease,
   showPrerelease,
-} from '~/types/resources';
+} from '~/types/resources'
 
-import { track } from '@vercel/analytics';
-import { useSessionStorage } from '@vueuse/core';
+import { track } from '@vercel/analytics'
+import { useSessionStorage } from '@vueuse/core'
 import {
   BlobReader,
   BlobWriter,
   ZipReader,
-} from '@zip.js/zip.js';
+} from '@zip.js/zip.js'
 
 import {
   type DeviceHardware,
   type FirmwareReleases,
   type FirmwareResource,
   getCorsFriendyReleaseUrl,
-} from '../types/api';
-import { createUrl } from './store';
+} from '../types/api'
+import { createUrl } from './store'
 
-const previews = showPrerelease ? [currentPrerelease] : [];
+const previews = showPrerelease ? [currentPrerelease] : []
 
 const firmwareApi = mande(createUrl('api/github/firmware/list'))
 
@@ -49,7 +49,7 @@ export const useFirmwareStore = defineStore('firmware', {
       shouldBundleWebUI: false,
       shouldInstallMui: false,
       shouldInstallInkHud: false,
-      partitionScheme: <String | undefined>{},
+      partitionScheme: <string | undefined>{},
       flashPercentDone: 0,
       isFlashing: false,
       flashingIndex: 0,
@@ -61,21 +61,21 @@ export const useFirmwareStore = defineStore('firmware', {
     }
   },
   getters: {
-    hasOnlineFirmware: (state) => (state.selectedFirmware?.id || '').length > 0,
-    hasFirmwareFile: (state) => (state.selectedFile?.name || '').length > 0,
-    percentDone: (state) => `${state.flashPercentDone}%`,
-    firmwareVersion: (state) => state.selectedFirmware?.id ? state.selectedFirmware.id.replace('v', '') : '.+',
-    canShowFlash: (state) => state.selectedFirmware?.id ? state.hasSeenReleaseNotes : true, 
-    isZipFile: (state) => state.selectedFile?.name.endsWith('.zip'),
-    isFactoryBin: (state) => state.selectedFile?.name.endsWith('.factory.bin'),
+    hasOnlineFirmware: state => (state.selectedFirmware?.id || '').length > 0,
+    hasFirmwareFile: state => (state.selectedFile?.name || '').length > 0,
+    percentDone: state => `${state.flashPercentDone}%`,
+    firmwareVersion: state => state.selectedFirmware?.id ? state.selectedFirmware.id.replace('v', '') : '.+',
+    canShowFlash: state => state.selectedFirmware?.id ? state.hasSeenReleaseNotes : true,
+    isZipFile: state => state.selectedFile?.name.endsWith('.zip'),
+    isFactoryBin: state => state.selectedFile?.name.endsWith('.factory.bin'),
   },
   actions: {
     clearState() {
-      this.shouldCleanInstall = false;
-      this.shouldBundleWebUI = false;
-      this.shouldInstallMui = false;
-      this.shouldInstallInkHud = false;
-      this.partitionScheme = undefined;
+      this.shouldCleanInstall = false
+      this.shouldBundleWebUI = false
+      this.shouldInstallMui = false
+      this.shouldInstallInkHud = false
+      this.partitionScheme = undefined
     },
     continueToFlash() {
       this.hasSeenReleaseNotes = true
@@ -84,88 +84,90 @@ export const useFirmwareStore = defineStore('firmware', {
       firmwareApi.get<FirmwareReleases>()
         .then((response: FirmwareReleases) => {
           // Only grab the latest 4 releases
-          this.stable = response.releases.stable.slice(0, 4);
-          this.alpha = response.releases.alpha.filter(f => !f.title.includes('Preview')).slice(0, 4);
+          this.stable = response.releases.stable.slice(0, 4)
+          this.alpha = response.releases.alpha.filter(f => !f.title.includes('Preview')).slice(0, 4)
           this.previews = [
             ...response.releases.alpha
               .filter(f => f.title.includes('Preview') && !f.title.includes('2.6.0')) // Exclude 2.6.0 preview
               .slice(0, 4),
-            ...previews
-          ];
-          this.pullRequests = response.pullRequests.slice(0, 4);
+            ...previews,
+          ]
+          this.pullRequests = response.pullRequests.slice(0, 4)
         })
         .catch((error) => {
-          console.error('Error fetching firmware list:', error);
-          this.couldntFetchFirmwareApi = true;
-        });
+          console.error('Error fetching firmware list:', error)
+          this.couldntFetchFirmwareApi = true
+        })
     },
     async setSelectedFirmware(firmware: FirmwareResource) {
-      this.selectedFirmware = firmware;
-      this.selectedFile = undefined;
-      this.hasSeenReleaseNotes = false;
+      this.selectedFirmware = firmware
+      this.selectedFile = undefined
+      this.hasSeenReleaseNotes = false
       // Store current MUI setting before clearing state
-      const currentMuiSetting = this.shouldInstallMui;
-      this.clearState();
+      const currentMuiSetting = this.shouldInstallMui
+      this.clearState()
       // Restore MUI setting if it was enabled (for devices that support it)
-      this.shouldInstallMui = currentMuiSetting;
-      
+      this.shouldInstallMui = currentMuiSetting
+
       // Update Datadog RUM context with firmware version
       if (import.meta.client) {
         try {
-          const { datadogRum } = await import('@datadog/browser-rum');
-          datadogRum.setGlobalContextProperty('firmware_version', firmware.id);
-        } catch (error) {
-          console.error('Error setting Datadog RUM context:', error);
+          const { datadogRum } = await import('@datadog/browser-rum')
+          datadogRum.setGlobalContextProperty('firmware_version', firmware.id)
+        }
+        catch (error) {
+          console.error('Error setting Datadog RUM context:', error)
         }
       }
     },
     getReleaseFileUrl(fileName: string): string {
-      if (!this.selectedFirmware?.zip_url) return '';
-      const baseUrl = getCorsFriendyReleaseUrl(this.selectedFirmware.zip_url);
-      return `${baseUrl}/${fileName}`;
+      if (!this.selectedFirmware?.zip_url) return ''
+      const baseUrl = getCorsFriendyReleaseUrl(this.selectedFirmware.zip_url)
+      return `${baseUrl}/${fileName}`
     },
     async downloadUf2FileSystem(searchRegex: RegExp) {
-      if (!this.selectedFile) return;
-      const reader = new BlobReader(this.selectedFile);
-      const zipReader = new ZipReader(reader);
+      if (!this.selectedFile) return
+      const reader = new BlobReader(this.selectedFile)
+      const zipReader = new ZipReader(reader)
       const entries = await zipReader.getEntries()
-      console.log('Zip entries:', entries);
+      console.log('Zip entries:', entries)
       const file = entries.find(entry => searchRegex.test(entry.filename))
       if (file) {
         if (file?.getData) {
-          const data = await file.getData(new BlobWriter());
-          saveAs(data, file.filename);
-        } else {
-          throw new Error(`Could not find file with pattern ${searchRegex} in zip`);
+          const data = await file.getData(new BlobWriter())
+          saveAs(data, file.filename)
+        }
+        else {
+          throw new Error(`Could not find file with pattern ${searchRegex} in zip`)
         }
       }
       else {
-        throw new Error(`Could not find file with pattern ${searchRegex} in zip`);
+        throw new Error(`Could not find file with pattern ${searchRegex} in zip`)
       }
-      zipReader.close();
+      zipReader.close()
     },
     async setFirmwareFile(file: File) {
-      this.selectedFile = file;
-      this.selectedFirmware = undefined;
+      this.selectedFile = file
+      this.selectedFirmware = undefined
       // Store current MUI setting before clearing state
-      const currentMuiSetting = this.shouldInstallMui;
-      this.clearState();
+      const currentMuiSetting = this.shouldInstallMui
+      this.clearState()
       // Restore MUI setting if it was enabled (for devices that support it)
-      this.shouldInstallMui = currentMuiSetting;
+      this.shouldInstallMui = currentMuiSetting
     },
     async updateEspFlash(fileName: string, selectedTarget: DeviceHardware) {
-      const terminal = await openTerminal();
+      const terminal = await openTerminal()
 
       try {
-        this.port = await navigator.serial.requestPort({});
-        this.isConnected = true;
+        this.port = await navigator.serial.requestPort({})
+        this.isConnected = true
         this.port.ondisconnect = () => {
-          this.isConnected = false;
-        };
-        const transport = new Transport(this.port, true);
-        const espLoader = await this.connectEsp32(transport, terminal);
-        const content = await this.fetchBinaryContent(fileName);
-        this.isFlashing = true;
+          this.isConnected = false
+        }
+        const transport = new Transport(this.port, true)
+        const espLoader = await this.connectEsp32(transport, terminal)
+        const content = await this.fetchBinaryContent(fileName)
+        this.isFlashing = true
         const flashOptions: FlashOptions = {
           fileArray: [{ data: content, address: 0x10000 }],
           flashSize: 'keep',
@@ -174,49 +176,50 @@ export const useFirmwareStore = defineStore('firmware', {
           flashMode: 'keep',
           flashFreq: 'keep',
           reportProgress: (fileIndex, written, total) => {
-            this.flashPercentDone = Math.round((written / total) * 100);
+            this.flashPercentDone = Math.round((written / total) * 100)
             if (written === total) {
-              this.isFlashing = false;
-              console.log('Done flashing!');
-              this.trackDownload(selectedTarget, true);
+              this.isFlashing = false
+              console.log('Done flashing!')
+              this.trackDownload(selectedTarget, true)
             }
           },
-        };
-        await this.startWrite(terminal, espLoader, transport, flashOptions);
+        }
+        await this.startWrite(terminal, espLoader, transport, flashOptions)
       }
       catch (error: any) {
-        this.handleError(error, terminal);
+        this.handleError(error, terminal)
       }
     },
     handleError(error: Error, terminal: Terminal) {
-      console.error('Error flashing:', error);
-      terminal.writeln('');
-      terminal.writeln(`\x1b[38;5;9m${error}\x1b[0m`);
+      console.error('Error flashing:', error)
+      terminal.writeln('')
+      terminal.writeln(`\x1b[38;5;9m${error}\x1b[0m`)
     },
     async startWrite(terminal: Terminal, espLoader: ESPLoader, transport: Transport, flashOptions: FlashOptions) {
-      await espLoader.writeFlash(flashOptions);
-      await this.resetEsp32(transport);
+      await espLoader.writeFlash(flashOptions)
+      await this.resetEsp32(transport)
       if (this.port) {
-        await this.readSerial(this.port, terminal);
-      } else {
-        throw new Error('Serial port is not defined');
+        await this.readSerial(this.port, terminal)
+      }
+      else {
+        throw new Error('Serial port is not defined')
       }
     },
     async resetEsp32(transport: Transport) {
-      await transport.setRTS(true);
-      await new Promise((resolve) => setTimeout(resolve, 100));
-      await transport.setRTS(false);
+      await transport.setRTS(true)
+      await new Promise(resolve => setTimeout(resolve, 100))
+      await transport.setRTS(false)
     },
-    trackDownload(selectedTarget: DeviceHardware, isCleanInstall: boolean) { 
+    trackDownload(selectedTarget: DeviceHardware, isCleanInstall: boolean) {
       if (selectedTarget.hwModelSlug?.length > 0) {
         // Vercel Analytics tracking
-        track('Download', { 
-          hardwareModel: selectedTarget.hwModelSlug, 
-          arch: selectedTarget.architecture, 
+        track('Download', {
+          hardwareModel: selectedTarget.hwModelSlug,
+          arch: selectedTarget.architecture,
           cleanInstall: isCleanInstall,
           version: this.selectedFirmware?.id || '',
-          count: 1 
-        });
+          count: 1,
+        })
 
         // Datadog tracking - both RUM and Logs for comprehensive coverage
         if (import.meta.client) {
@@ -233,79 +236,80 @@ export const useFirmwareStore = defineStore('firmware', {
             partition_table_version: this.partitionScheme === '8MB' && selectedTarget.hasMui && supportsNew8MBPartitionTable(this.firmwareVersion) ? 'new-8mb' : 'legacy',
             timestamp: new Date().toISOString(),
             user_agent: navigator.userAgent,
-            url: window.location.href
-          };
+            url: window.location.href,
+          }
 
           // RUM Action (for user experience correlation, subject to sampling)
           import('@datadog/browser-rum').then(({ datadogRum }) => {
-            datadogRum.addAction('firmware_flash', flashData);
-          }).catch(error => {
-            console.warn('Datadog RUM not available for flash tracking:', error);
-          });
+            datadogRum.addAction('firmware_flash', flashData)
+          }).catch((error) => {
+            console.warn('Datadog RUM not available for flash tracking:', error)
+          })
 
           // Datadog Logs (for precise counting, no sampling)
           import('@datadog/browser-logs').then(({ datadogLogs }) => {
             datadogLogs.logger.info('Firmware flash completed', {
               event_type: 'firmware_flash',
-              ...flashData
-            });
-          }).catch(error => {
-            console.warn('Datadog Logs not available for flash tracking:', error);
-          });
+              ...flashData,
+            })
+          }).catch((error) => {
+            console.warn('Datadog Logs not available for flash tracking:', error)
+          })
         }
       }
     },
     async cleanInstallEspFlash(fileName: string, otaFileName: string, littleFsFileName: string, selectedTarget: DeviceHardware) {
-      const terminal = await openTerminal();
+      const terminal = await openTerminal()
 
       try {
-        this.port = await navigator.serial.requestPort({});
-        this.isConnected = true;
+        this.port = await navigator.serial.requestPort({})
+        this.isConnected = true
         this.port.ondisconnect = () => {
-          this.isConnected = false;
-        };
-        const transport = new Transport(this.port, true);
-        const espLoader = await this.connectEsp32(transport, terminal);
-        const appContent = await this.fetchBinaryContent(fileName);
-        const otaContent = await this.fetchBinaryContent(otaFileName);
-        const littleFsContent = await this.fetchBinaryContent(littleFsFileName);
+          this.isConnected = false
+        }
+        const transport = new Transport(this.port, true)
+        const espLoader = await this.connectEsp32(transport, terminal)
+        const appContent = await this.fetchBinaryContent(fileName)
+        const otaContent = await this.fetchBinaryContent(otaFileName)
+        const littleFsContent = await this.fetchBinaryContent(littleFsFileName)
 
-        let otaOffset = 0x260000;
-        let spiffsOffset = 0x300000;
-        
-        if (this.partitionScheme == "8MB") {
+        let otaOffset = 0x260000
+        let spiffsOffset = 0x300000
+
+        if (this.partitionScheme == '8MB') {
           // Check if this is a TFT (MUI) device with firmware 2.7.9+ that should use the new partition table
-          const isTftDevice = selectedTarget.hasMui === true;
-          const useNewPartitionTable = isTftDevice && supportsNew8MBPartitionTable(this.firmwareVersion);
-          
-          console.log(`8MB partition selection: TFT device: ${isTftDevice}, Firmware: ${this.firmwareVersion}, Use new table: ${useNewPartitionTable}`);
-          
+          const isTftDevice = selectedTarget.hasMui === true
+          const useNewPartitionTable = isTftDevice && supportsNew8MBPartitionTable(this.firmwareVersion)
+
+          console.log(`8MB partition selection: TFT device: ${isTftDevice}, Firmware: ${this.firmwareVersion}, Use new table: ${useNewPartitionTable}`)
+
           if (useNewPartitionTable) {
             // New 8MB partition table for TFT devices (firmware 2.7.9+)
             // Based on: https://github.com/meshtastic/firmware/blob/d43bd7f45b1c19d95288b5589adda2c0ef117bc4/partition-table-8MB.csv
             // flashApp (ota_1): 0x5D0000, spiffs: 0x670000
-            otaOffset = 0x5D0000;
-            spiffsOffset = 0x670000;
-            console.log(`Using new 8MB partition table: OTA at 0x${otaOffset.toString(16)}, SPIFFS at 0x${spiffsOffset.toString(16)}`);
-          } else {
+            otaOffset = 0x5D0000
+            spiffsOffset = 0x670000
+            console.log(`Using new 8MB partition table: OTA at 0x${otaOffset.toString(16)}, SPIFFS at 0x${spiffsOffset.toString(16)}`)
+          }
+          else {
             // Legacy 8MB partition table
-            otaOffset = 0x340000;
-            spiffsOffset = 0x670000;
-            console.log(`Using legacy 8MB partition table: OTA at 0x${otaOffset.toString(16)}, SPIFFS at 0x${spiffsOffset.toString(16)}`);
+            otaOffset = 0x340000
+            spiffsOffset = 0x670000
+            console.log(`Using legacy 8MB partition table: OTA at 0x${otaOffset.toString(16)}, SPIFFS at 0x${spiffsOffset.toString(16)}`)
           }
         }
-        else if (this.partitionScheme == "16MB") {
+        else if (this.partitionScheme == '16MB') {
           // 16mb
-          otaOffset = 0x650000;
-          spiffsOffset = 0xc90000;
+          otaOffset = 0x650000
+          spiffsOffset = 0xc90000
         }
 
-        this.isFlashing = true;
+        this.isFlashing = true
         const flashOptions: FlashOptions = {
           fileArray: [
             { data: appContent, address: 0x00 },
             { data: otaContent, address: otaOffset },
-            { data: littleFsContent, address: spiffsOffset }
+            { data: littleFsContent, address: spiffsOffset },
           ],
           flashSize: 'keep',
           eraseAll: true,
@@ -313,54 +317,55 @@ export const useFirmwareStore = defineStore('firmware', {
           flashMode: 'keep',
           flashFreq: 'keep',
           reportProgress: (fileIndex, written, total) => {
-            this.flashingIndex = fileIndex;
-            this.flashPercentDone = Math.round((written / total) * 100);
+            this.flashingIndex = fileIndex
+            this.flashPercentDone = Math.round((written / total) * 100)
             if (written === total && fileIndex > 1) {
-              this.isFlashing = false;
-              console.log('Done flashing!');
-              this.trackDownload(selectedTarget, true);
+              this.isFlashing = false
+              console.log('Done flashing!')
+              this.trackDownload(selectedTarget, true)
             }
           },
-        };
-        await this.startWrite(terminal, espLoader, transport, flashOptions);
-      } catch (error: any) {
-        this.handleError(error, terminal);
+        }
+        await this.startWrite(terminal, espLoader, transport, flashOptions)
+      }
+      catch (error: any) {
+        this.handleError(error, terminal)
       }
     },
     async fetchBinaryContent(fileName: string): Promise<string> {
       if (this.selectedFirmware?.zip_url) {
-        const baseUrl = getCorsFriendyReleaseUrl(this.selectedFirmware.zip_url);
-        const response = await fetch(`${baseUrl}/${fileName}`);
-        const blob = await response.blob();
-        const data = await blob.arrayBuffer();
-        return convertToBinaryString(new Uint8Array(data));
+        const baseUrl = getCorsFriendyReleaseUrl(this.selectedFirmware.zip_url)
+        const response = await fetch(`${baseUrl}/${fileName}`)
+        const blob = await response.blob()
+        const data = await blob.arrayBuffer()
+        return convertToBinaryString(new Uint8Array(data))
       }
       if (this.selectedFile && this.isZipFile) {
-        const reader = new BlobReader(this.selectedFile);
-        const zipReader = new ZipReader(reader);
+        const reader = new BlobReader(this.selectedFile)
+        const zipReader = new ZipReader(reader)
         const entries = await zipReader.getEntries()
-        console.log('Zip entries:', entries);
-        console.log('Looking for file matching pattern:', fileName);
-        const file = entries.find(entry => 
-          {
-            if (fileName.startsWith('firmware-tbeam-.'))
-              return !entry.filename.includes('s3') && new RegExp(fileName).test(entry.filename) && (fileName.endsWith('update.bin') === entry.filename.endsWith('update.bin'))
-            return new RegExp(fileName).test(entry.filename) && (fileName.endsWith('update.bin') === entry.filename.endsWith('update.bin'))
-          })
+        console.log('Zip entries:', entries)
+        console.log('Looking for file matching pattern:', fileName)
+        const file = entries.find((entry) => {
+          if (fileName.startsWith('firmware-tbeam-.'))
+            return !entry.filename.includes('s3') && new RegExp(fileName).test(entry.filename) && (fileName.endsWith('update.bin') === entry.filename.endsWith('update.bin'))
+          return new RegExp(fileName).test(entry.filename) && (fileName.endsWith('update.bin') === entry.filename.endsWith('update.bin'))
+        })
         if (file) {
-          console.log('Found file:', file.filename);
+          console.log('Found file:', file.filename)
           if (file?.getData) {
-            const blob = await file.getData(new BlobWriter());
-            const arrayBuffer = await blob.arrayBuffer();
-            return convertToBinaryString(new Uint8Array(arrayBuffer));
+            const blob = await file.getData(new BlobWriter())
+            const arrayBuffer = await blob.arrayBuffer()
+            return convertToBinaryString(new Uint8Array(arrayBuffer))
           }
-          throw new Error(`Could not find file with pattern ${fileName} in zip`);
+          throw new Error(`Could not find file with pattern ${fileName} in zip`)
         }
-      } else if (this.selectedFile && !this.isZipFile) {
-        const buffer = await this.selectedFile.arrayBuffer();
-        return convertToBinaryString(new Uint8Array(buffer));
       }
-      throw new Error('Cannot fetch binary content without a file or firmware selected');
+      else if (this.selectedFile && !this.isZipFile) {
+        const buffer = await this.selectedFile.arrayBuffer()
+        return convertToBinaryString(new Uint8Array(buffer))
+      }
+      throw new Error('Cannot fetch binary content without a file or firmware selected')
     },
     async connectEsp32(transport: Transport, terminal: Terminal): Promise<ESPLoader> {
       const loaderOptions = <LoaderOptions>{
@@ -369,37 +374,38 @@ export const useFirmwareStore = defineStore('firmware', {
         enableTracing: false,
         terminal: {
           clean() {
-            terminal.clear();
+            terminal.clear()
           },
           writeLine(data) {
-            terminal.writeln(data);
+            terminal.writeln(data)
           },
           write(data) {
-            terminal.write(data);
-          }
-        }
-      };
-      const espLoader = new ESPLoader(loaderOptions);
-      const chip = await espLoader.main();
-      console.log("Detected chip:", chip);
-      return espLoader;
+            terminal.write(data)
+          },
+        },
+      }
+      const espLoader = new ESPLoader(loaderOptions)
+      const chip = await espLoader.main()
+      console.log('Detected chip:', chip)
+      return espLoader
     },
     async readSerial(port: SerialPort, terminal: Terminal): Promise<void> {
-      const decoder = new TextDecoderStream();
+      const decoder = new TextDecoderStream()
       if (port.readable) {
-        port.readable.pipeTo(decoder.writable);
-      } else {
-        throw new Error('Serial port is not readable');
+        port.readable.pipeTo(decoder.writable)
       }
-      const inputStream = decoder.readable;
-      const reader = inputStream.getReader();
+      else {
+        throw new Error('Serial port is not readable')
+      }
+      const inputStream = decoder.readable
+      const reader = inputStream.getReader()
 
       while (true) {
-        const{ value } = await reader.read();
+        const { value } = await reader.read()
         if (value) {
-          terminal.write(value);
+          terminal.write(value)
         }
-        await new Promise(resolve => setTimeout(resolve, 5));
+        await new Promise(resolve => setTimeout(resolve, 5))
       }
     },
   },

--- a/stores/serialMonitorStore.ts
+++ b/stores/serialMonitorStore.ts
@@ -1,6 +1,6 @@
-import { defineStore } from 'pinia';
+import { defineStore } from 'pinia'
 
-export const useSerialMonitorStore = defineStore("serialMonitor", {
+export const useSerialMonitorStore = defineStore('serialMonitor', {
   state: () => {
     return {
       baudRate: 115200,
@@ -9,74 +9,76 @@ export const useSerialMonitorStore = defineStore("serialMonitor", {
       isConnected: false,
       isReaderLocked: false,
       port: <SerialPort | undefined>{},
-    };
+    }
   },
   actions: {
     disconnect() {
-      this.isReaderLocked = false;
+      this.isReaderLocked = false
     },
     async unlockPort(port: SerialPort, reader: ReadableStreamDefaultReader<string>) {
       try {
-        const textEncoder = new TextEncoderStream();
-        const writer = textEncoder.writable.getWriter();
-        const writableStreamClosed = textEncoder.readable.pipeTo(port.writable!);
-        reader.cancel();
-        
-        writer.close();
-        await writableStreamClosed;
-        await port.forget();
-        this.isConnected = false;
+        const textEncoder = new TextEncoderStream()
+        const writer = textEncoder.writable.getWriter()
+        const writableStreamClosed = textEncoder.readable.pipeTo(port.writable!)
+        reader.cancel()
+
+        writer.close()
+        await writableStreamClosed
+        await port.forget()
+        this.isConnected = false
       }
       catch (e) {
-        console.log(e);
+        console.log(e)
       }
     },
     async readSerialMonitor(port: SerialPort): Promise<void> {
-      this.terminalBuffer = [];
-      const decoderStream = new TextDecoderStream();
-      port.readable!.pipeTo(decoderStream.writable);
-      const inputStream = decoderStream.readable;
-      const reader = inputStream.getReader();
-      this.isReaderLocked = true;
+      this.terminalBuffer = []
+      const decoderStream = new TextDecoderStream()
+      port.readable!.pipeTo(decoderStream.writable)
+      const inputStream = decoderStream.readable
+      const reader = inputStream.getReader()
+      this.isReaderLocked = true
 
       while (true) {
         if (!this.isReaderLocked) {
-          await this.unlockPort(port, reader);
-          return;
+          await this.unlockPort(port, reader)
+          return
         }
-        let { value } = await reader.read();
+        let { value } = await reader.read()
         if (value) {
-          value = value?.replace(/\r/g, "");
-          if (value.includes("\n")) {
-            value.split("\n").forEach((line, index) => {
+          value = value?.replace(/\r/g, '')
+          if (value.includes('\n')) {
+            value.split('\n').forEach((line, index) => {
               if (index === 0) {
-                const lastLine =
-                  this.terminalBuffer[this.terminalBuffer.length - 1] || "";
-                const newLine = lastLine + line;
-                this.terminalBuffer[this.terminalBuffer.length - 1] = newLine;
-              } else {
-                this.terminalBuffer.push(line);
+                const lastLine
+                  = this.terminalBuffer[this.terminalBuffer.length - 1] || ''
+                const newLine = lastLine + line
+                this.terminalBuffer[this.terminalBuffer.length - 1] = newLine
               }
-            });
-          } else {
-            const lastLine =
-              this.terminalBuffer[this.terminalBuffer.length - 1] || "";
-            const newLine = lastLine + value;
-            this.terminalBuffer[this.terminalBuffer.length - 1] = newLine;
+              else {
+                this.terminalBuffer.push(line)
+              }
+            })
+          }
+          else {
+            const lastLine
+              = this.terminalBuffer[this.terminalBuffer.length - 1] || ''
+            const newLine = lastLine + value
+            this.terminalBuffer[this.terminalBuffer.length - 1] = newLine
           }
         }
-        await new Promise((resolve) => setTimeout(resolve, 5));
+        await new Promise(resolve => setTimeout(resolve, 5))
       }
     },
     async monitorSerial() {
-      this.port = await navigator.serial.requestPort({});
-      await this.port.open({ baudRate: this.baudRate });
-      this.isOpen = true;
-      this.isConnected = true;
+      this.port = await navigator.serial.requestPort({})
+      await this.port.open({ baudRate: this.baudRate })
+      this.isOpen = true
+      this.isConnected = true
       this.port.ondisconnect = () => {
-        this.isConnected = false;
-      };
-      await this.readSerialMonitor(this.port);
+        this.isConnected = false
+      }
+      await this.readSerialMonitor(this.port)
     },
   },
-});
+})

--- a/stores/store.ts
+++ b/stores/store.ts
@@ -1,9 +1,9 @@
 export function createUrl(relativeUrl: string) {
-    let host = window.location.host;
-    if (process.env.NODE_ENV !== 'development' && relativeUrl.startsWith('api')) {
-        host = 'api.meshtastic.org';
-        relativeUrl = relativeUrl.replace('api/', '');
-    }
-    const base = `${window.location.protocol}//${host}`;
-    return `${base}/${relativeUrl}`;
+  let host = window.location.host
+  if (process.env.NODE_ENV !== 'development' && relativeUrl.startsWith('api')) {
+    host = 'api.meshtastic.org'
+    relativeUrl = relativeUrl.replace('api/', '')
+  }
+  const base = `${window.location.protocol}//${host}`
+  return `${base}/${relativeUrl}`
 }

--- a/stores/toastStore.ts
+++ b/stores/toastStore.ts
@@ -1,12 +1,12 @@
-import { defineStore } from 'pinia';
+import { defineStore } from 'pinia'
 
 export interface Toast {
-  id: string;
-  type: 'success' | 'error' | 'warning' | 'info';
-  title: string;
-  message: string;
-  duration?: number;
-  persistent?: boolean;
+  id: string
+  type: 'success' | 'error' | 'warning' | 'info'
+  title: string
+  message: string
+  duration?: number
+  persistent?: boolean
 }
 
 export const useToastStore = defineStore('toast', {
@@ -17,80 +17,80 @@ export const useToastStore = defineStore('toast', {
   actions: {
     addToast(toast: Omit<Toast, 'id'>) {
       // Create a unique key for this toast based on type, title, and message
-      const toastKey = `${toast.type}-${toast.title}-${toast.message}`;
-      
+      const toastKey = `${toast.type}-${toast.title}-${toast.message}`
+
       // Check if we recently showed this exact toast (within 2 seconds)
       if (this.recentToasts.has(toastKey)) {
-        console.log('Duplicate toast prevented:', toastKey);
-        return;
+        console.log('Duplicate toast prevented:', toastKey)
+        return
       }
-      
+
       // Add to recent toasts and remove after 2 seconds
-      this.recentToasts.add(toastKey);
+      this.recentToasts.add(toastKey)
       setTimeout(() => {
-        this.recentToasts.delete(toastKey);
-      }, 10000);
-      
-      const id = Date.now().toString() + Math.random().toString(36).substring(2, 11);
+        this.recentToasts.delete(toastKey)
+      }, 10000)
+
+      const id = Date.now().toString() + Math.random().toString(36).substring(2, 11)
       const newToast: Toast = {
         id,
         duration: toast.duration || 5000,
         persistent: toast.persistent || false,
         ...toast,
-      };
-      
+      }
+
       console.log('Toast added:', {
         id,
         type: toast.type,
-        title: toast.title
-      });
-      
-      this.toasts.push(newToast);
-      
+        title: toast.title,
+      })
+
+      this.toasts.push(newToast)
+
       // Auto-remove toast after duration unless it's persistent
       if (!newToast.persistent && newToast.duration && newToast.duration > 0) {
         setTimeout(() => {
-          this.removeToast(id);
-        }, newToast.duration);
+          this.removeToast(id)
+        }, newToast.duration)
       }
-      
-      return id;
+
+      return id
     },
-    
+
     removeToast(id: string) {
       // On dismiss or expire, clear all toasts
-      this.toasts = [];
+      this.toasts = []
     },
-    
+
     clearAll() {
-      this.toasts = [];
-      this.recentToasts.clear();
+      this.toasts = []
+      this.recentToasts.clear()
     },
-    
+
     // Convenience methods for different toast types
     success(title: string, message: string, options?: Partial<Toast>) {
-      if (this.toasts.length > 0) return;
-      const id = Date.now().toString() + Math.random().toString(36).substring(2, 11);
-      this.toasts.push({ type: 'success', title, message, id, ...options });
+      if (this.toasts.length > 0) return
+      const id = Date.now().toString() + Math.random().toString(36).substring(2, 11)
+      this.toasts.push({ type: 'success', title, message, id, ...options })
     },
     error(title: string, message: string, options?: Partial<Toast>) {
-      if (this.toasts.length > 0) return;
-      const id = Date.now().toString() + Math.random().toString(36).substring(2, 11);
-      this.toasts.push({ type: 'error', title, message, id, ...options });
+      if (this.toasts.length > 0) return
+      const id = Date.now().toString() + Math.random().toString(36).substring(2, 11)
+      this.toasts.push({ type: 'error', title, message, id, ...options })
     },
     warning(title: string, message: string, options?: Partial<Toast>) {
-      if (this.toasts.length > 0) return;
-      const id = Date.now().toString() + Math.random().toString(36).substring(2, 11);
-      this.toasts.push({ type: 'warning', title, message, id, ...options });
+      if (this.toasts.length > 0) return
+      const id = Date.now().toString() + Math.random().toString(36).substring(2, 11)
+      this.toasts.push({ type: 'warning', title, message, id, ...options })
     },
     info(title: string, message: string, options?: Partial<Toast>) {
-      if (this.toasts.length > 0) return;
-      const id = Date.now().toString() + Math.random().toString(36).substring(2, 11);
-      this.toasts.push({ type: 'info', title, message, id, ...options });
+      if (this.toasts.length > 0) return
+      const id = Date.now().toString() + Math.random().toString(36).substring(2, 11)
+      this.toasts.push({ type: 'info', title, message, id, ...options })
     },
     dismiss(id: string) {
       // On dismiss, clear all toasts
-      this.toasts = [];
+      this.toasts = []
     },
   },
-});
+})

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,15 +1,15 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   content: [
-    "./components/**/*.{js,vue,ts}",
-    "./layouts/**/*.vue",
-    "./pages/**/*.vue",
-    "./plugins/**/*.{js,ts}",
-    "./app.vue",
-    "./error.vue",
-    "./node_modules/flowbite/**/*.{js,ts}",
-    "./node_modules/flowbite-vue/**/*.{js,jsx,ts,tsx,vue}",
-  ], 
+    './components/**/*.{js,vue,ts}',
+    './layouts/**/*.vue',
+    './pages/**/*.vue',
+    './plugins/**/*.{js,ts}',
+    './app.vue',
+    './error.vue',
+    './node_modules/flowbite/**/*.{js,ts}',
+    './node_modules/flowbite-vue/**/*.{js,jsx,ts,tsx,vue}',
+  ],
   theme: {
     extend: {},
   },
@@ -17,4 +17,3 @@ export default {
     require('flowbite/plugin'),
   ],
 }
-

--- a/types/api.ts
+++ b/types/api.ts
@@ -1,45 +1,45 @@
 export interface FirmwareResource {
-	id: string;
-	title: string;
-	page_url?: string;
-	zip_url?: string;
-	release_notes?: string;
+  id: string
+  title: string
+  page_url?: string
+  zip_url?: string
+  release_notes?: string
 }
 
 export interface FirmwareReleases {
-	releases: {
-		stable: FirmwareResource[];
-		alpha: FirmwareResource[];
-	};
-	pullRequests: FirmwareResource[];
+  releases: {
+    stable: FirmwareResource[]
+    alpha: FirmwareResource[]
+  }
+  pullRequests: FirmwareResource[]
 }
 
 export interface DeviceHardware {
-	hwModel: number;
-	hwModelSlug: string;
-	platformioTarget: string;
-	architecture: string;
-	activelySupported: boolean;
-	displayName: string;
-	supportLevel?: number;
-	tags?: string[];
-	images?: string[];
-	partitionScheme?: string;
-	requiresDfu?: boolean;
-	hasMui?: boolean;
-	hasInkHud?: boolean;
-	url?: string;
+  hwModel: number
+  hwModelSlug: string
+  platformioTarget: string
+  architecture: string
+  activelySupported: boolean
+  displayName: string
+  supportLevel?: number
+  tags?: string[]
+  images?: string[]
+  partitionScheme?: string
+  requiresDfu?: boolean
+  hasMui?: boolean
+  hasInkHud?: boolean
+  url?: string
 }
 
 export function getCorsFriendyReleaseUrl(url: string) {
-	const zipName = url.split('/').slice(-1)[0];
-	const firmwareName = zipName.replace('.zip', '')
-		.replace('-esp32-', '-')
-		.replace('-esp32c3-', '-')
-		.replace('-esp32c6-', '-')
-		.replace('-esp32s3-', '-')
-		.replace('-nrf52840-', '-')
-		.replace('-stm32-', '-')
-		.replace('-rp2040-', '-')
-	return `https://raw.githubusercontent.com/meshtastic/meshtastic.github.io/master/${firmwareName}`;
+  const zipName = url.split('/').slice(-1)[0]
+  const firmwareName = zipName.replace('.zip', '')
+    .replace('-esp32-', '-')
+    .replace('-esp32c3-', '-')
+    .replace('-esp32c6-', '-')
+    .replace('-esp32s3-', '-')
+    .replace('-nrf52840-', '-')
+    .replace('-stm32-', '-')
+    .replace('-rp2040-', '-')
+  return `https://raw.githubusercontent.com/meshtastic/meshtastic.github.io/master/${firmwareName}`
 }

--- a/utils/fileUtils.ts
+++ b/utils/fileUtils.ts
@@ -1,28 +1,29 @@
 export function downloadBlob(url: string, filename: string) {
-    console.log('Downloading blob', url, filename);
-	let link = document.createElement('a')
-	link.href = window.URL.createObjectURL(url)
-	link.download = filename
+  console.log('Downloading blob', url, filename)
+  const link = document.createElement('a')
+  link.href = window.URL.createObjectURL(url)
+  link.download = filename
 
-	document.body.appendChild(link);
-	link.click()
-	document.body.removeChild(link);
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
 }
 
 export function convertToBinaryString(bytes: Uint8Array) {
-	let binaryString = "";
-	for (let i = 0; i < bytes.length; i++) {
-		binaryString += String.fromCharCode(bytes[i]);
-	}
-	return binaryString;
+  let binaryString = ''
+  for (let i = 0; i < bytes.length; i++) {
+    binaryString += String.fromCharCode(bytes[i])
+  }
+  return binaryString
 }
 
 export async function checkIfRemoteFileExists(url: string): Promise<boolean> {
-	console.log('Checking if remote file exists: ', url);
-	try {
-		const response = await fetch(url, { method: 'HEAD' });
-		return response.ok;
-	} catch {
-		return false;
-	}
+  console.log('Checking if remote file exists: ', url)
+  try {
+    const response = await fetch(url, { method: 'HEAD' })
+    return response.ok
+  }
+  catch {
+    return false
+  }
 }

--- a/utils/i18n.ts
+++ b/utils/i18n.ts
@@ -1,29 +1,30 @@
 // Global i18n instance for use in Pinia stores
 // This provides access to translations outside of Vue component context
 
-let globalI18n: any = null;
+let globalI18n: any = null
 
 export function setGlobalI18n(i18nInstance: any) {
-  globalI18n = i18nInstance;
+  globalI18n = i18nInstance
 }
 
 export function getGlobalI18n() {
-  return globalI18n;
+  return globalI18n
 }
 
 export function t(key: string, params?: any): string {
   if (!globalI18n) {
-    console.warn('Global i18n instance not set, returning key:', key);
-    return key;
+    console.warn('Global i18n instance not set, returning key:', key)
+    return key
   }
-  
+
   try {
-    console.log('Translating key:', key, 'with i18n instance:', globalI18n);
-    const result = globalI18n.t(key, params);
-    console.log('Translation result:', result);
-    return result;
-  } catch (error) {
-    console.warn('Translation error for key:', key, error);
-    return key;
+    console.log('Translating key:', key, 'with i18n instance:', globalI18n)
+    const result = globalI18n.t(key, params)
+    console.log('Translation result:', result)
+    return result
+  }
+  catch (error) {
+    console.warn('Translation error for key:', key, error)
+    return key
   }
 }

--- a/utils/terminal.ts
+++ b/utils/terminal.ts
@@ -1,12 +1,12 @@
-import { Terminal } from 'xterm';
+import { Terminal } from 'xterm'
 
 export async function openTerminal(): Promise<Terminal> {
-    // Remove any previous terminal elements from the DOM
-    const element = document.getElementById('terminal');
-    while (element?.firstChild) {
-        element.removeChild(element.firstChild);
-    }
-    const terminal = new Terminal({ cols: 90, rows: 10, theme: { background: "#1a202c" }});
-    terminal.open(document.getElementById('terminal')!);
-    return terminal;
+  // Remove any previous terminal elements from the DOM
+  const element = document.getElementById('terminal')
+  while (element?.firstChild) {
+    element.removeChild(element.firstChild)
+  }
+  const terminal = new Terminal({ cols: 90, rows: 10, theme: { background: '#1a202c' } })
+  terminal.open(document.getElementById('terminal')!)
+  return terminal
 }

--- a/utils/versionUtils.ts
+++ b/utils/versionUtils.ts
@@ -5,38 +5,38 @@
 /**
  * Compare two semantic version strings
  * @param version1 First version string (e.g., "2.7.9")
- * @param version2 Second version string (e.g., "2.7.8") 
+ * @param version2 Second version string (e.g., "2.7.8")
  * @returns Positive if version1 > version2, negative if version1 < version2, 0 if equal
  */
 export function compareVersions(version1: string, version2: string): number {
   // Remove 'v' prefix if present
-  const clean1 = version1.replace(/^v/, '');
-  const clean2 = version2.replace(/^v/, '');
-  
+  const clean1 = version1.replace(/^v/, '')
+  const clean2 = version2.replace(/^v/, '')
+
   // Split into parts and convert to numbers
-  const parts1 = clean1.split('.').map(part => {
+  const parts1 = clean1.split('.').map((part) => {
     // Handle pre-release versions like "2.7.9.abc123" - take only the numeric part
-    const numeric = part.match(/^\d+/);
-    return numeric ? parseInt(numeric[0], 10) : 0;
-  });
-  
-  const parts2 = clean2.split('.').map(part => {
-    const numeric = part.match(/^\d+/);
-    return numeric ? parseInt(numeric[0], 10) : 0;
-  });
-  
+    const numeric = part.match(/^\d+/)
+    return numeric ? parseInt(numeric[0], 10) : 0
+  })
+
+  const parts2 = clean2.split('.').map((part) => {
+    const numeric = part.match(/^\d+/)
+    return numeric ? parseInt(numeric[0], 10) : 0
+  })
+
   // Pad shorter version with zeros
-  const maxLength = Math.max(parts1.length, parts2.length);
-  while (parts1.length < maxLength) parts1.push(0);
-  while (parts2.length < maxLength) parts2.push(0);
-  
+  const maxLength = Math.max(parts1.length, parts2.length)
+  while (parts1.length < maxLength) parts1.push(0)
+  while (parts2.length < maxLength) parts2.push(0)
+
   // Compare each part
   for (let i = 0; i < maxLength; i++) {
-    const diff = parts1[i] - parts2[i];
-    if (diff !== 0) return diff;
+    const diff = parts1[i] - parts2[i]
+    if (diff !== 0) return diff
   }
-  
-  return 0;
+
+  return 0
 }
 
 /**
@@ -46,7 +46,7 @@ export function compareVersions(version1: string, version2: string): number {
  * @returns true if currentVersion >= targetVersion
  */
 export function isVersionGreaterOrEqual(currentVersion: string, targetVersion: string): boolean {
-  return compareVersions(currentVersion, targetVersion) >= 0;
+  return compareVersions(currentVersion, targetVersion) >= 0
 }
 
 /**
@@ -55,5 +55,5 @@ export function isVersionGreaterOrEqual(currentVersion: string, targetVersion: s
  * @returns true if firmware version is 2.7.9 or above
  */
 export function supportsNew8MBPartitionTable(firmwareVersion: string): boolean {
-  return isVersionGreaterOrEqual(firmwareVersion, '2.7.9');
+  return isVersionGreaterOrEqual(firmwareVersion, '2.7.9')
 }


### PR DESCRIPTION
# Description

Adds ESLint code linting to the project using the official `@nuxt/eslint` module. This provides automated code quality checks and formatting for TypeScript, Vue, and JavaScript files.

**Key additions:**
- ESLint with TypeScript and stylistic formatting support
- `pnpm lint` and `pnpm lint:fix` scripts
- Custom rules configured as warnings (non-blocking)

**Current status:** 0 errors, 34 warnings. Warnings are intentionally non-blocking and can be fixed gradually by anyone in future PRs.

## Type of Change

- [x] New feature
- [x] Documentation update (package.json scripts)

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [x] `pnpm lint` runs successfully (exit code 0)