### PR TITLE
refactor: Centralize font imports and define custom font families in Tailwind

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -17,7 +17,7 @@
 
     <section
       id="main"
-      class="text-gray-400 body-font px-3 sm:px-5"
+      class="text-gray-400 font-body px-3 sm:px-5"
     >
       <transition
         name="flash"
@@ -43,7 +43,7 @@
                 >
                 <Device />
               </div>
-              <h2 class="text-lg sm:text-xl font-medium title-font text-white mt-5">
+              <h2 class="text-lg sm:text-xl font-medium font-title text-white mt-5">
                 {{ $t('device.title') }}
               </h2>
               <p class="text-sm sm:text-base leading-relaxed mt-2">
@@ -58,7 +58,7 @@
                 />
                 <Firmware />
               </div>
-              <h2 class="text-lg sm:text-xl font-medium title-font text-white mt-5">
+              <h2 class="text-lg sm:text-xl font-medium font-title text-white mt-5">
                 {{ $t('firmware.title') }}
               </h2>
               <p class="text-sm sm:text-base leading-relaxed mt-2">
@@ -70,7 +70,7 @@
                 <Zap class="h-60 w-60 p-5 mt-10 mb-10 mx-auto text-white" />
                 <Flash />
               </div>
-              <h2 class="text-lg sm:text-xl font-medium title-font text-white mt-5">
+              <h2 class="text-lg sm:text-xl font-medium font-title text-white mt-5">
                 Flash
               </h2>
               <p class="text-sm sm:text-base leading-relaxed mt-2">
@@ -245,23 +245,6 @@ onMounted(() => {
 </script>
 
 <style>
-  @import url('https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap');
-  @import url('https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:ital,wght@0,400;0,700;1,400;1,700&display=swap');
-  /* Additional Atkinson Hyperlegible fallback */
-  @font-face {
-    font-family: 'Atkinson Hyperlegible';
-    src: url('https://fonts.gstatic.com/s/atkinsonhyperlegible/v11/9Bt23C1KxNDXMspQ1lPyU89-1h6ONRlW45GE.woff2') format('woff2');
-    font-weight: 400;
-    font-style: normal;
-    font-display: swap;
-  }
-  @font-face {
-    font-family: 'Atkinson Hyperlegible';
-    src: url('https://fonts.gstatic.com/s/atkinsonhyperlegible/v11/9Bt43C1KxNDXMspQ1lPyU89-1h6ONRlW45G055LkgA.woff2') format('woff2');
-    font-weight: 700;
-    font-style: normal;
-    font-display: swap;
-  }
   :root {
     --bg-color: #1e1f2a;
     --text-color: #FFFFFF;
@@ -269,7 +252,7 @@ onMounted(() => {
     --secondary-color: #67EA94;
   }
   body {
-    font-family: 'Atkinson Hyperlegible', 'Lato', 'Inter', sans-serif;
+    @apply font-body;
     background-color: var(--bg-color);
     color: var(--text-color);
   }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,3 +1,6 @@
+@import url('https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:ital,wght@0,400;0,700;1,400;1,700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/components/DeviceDetail.vue
+++ b/components/DeviceDetail.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex flex-col items-center p-2 w-full sm:w-56">
     <h5
-      class="mb-1 text-xs sm:text-[0.75rem] text-white"
+      class="mb-1 text-md sm:text-[0.75rem] text-white"
       :class="{ 'text-yellow-400': !isSupporterDevice(props.device) }"
     >
       {{ props.device.displayName }}

--- a/components/ToastNotifications.vue
+++ b/components/ToastNotifications.vue
@@ -123,10 +123,7 @@ function reloadPage() {
   transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-/* Ensure proper font family */
-.max-w-sm {
-  font-family: 'Atkinson Hyperlegible', 'Lato', 'Inter', sans-serif;
-}
+
 
 /* Custom focus ring for meshtastic theme */
 .focus\:ring-meshtastic:focus {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,7 +11,13 @@ export default {
     './node_modules/flowbite-vue/**/*.{js,jsx,ts,tsx,vue}',
   ],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: ['Inter', 'sans-serif'],
+        title: ['Inter', 'sans-serif'],
+        body: ['"Atkinson Hyperlegible"', 'sans-serif'],
+      },
+    },
   },
   plugins: [
     require('flowbite/plugin'),


### PR DESCRIPTION
# Description

Fixed font rendering issues where custom fonts ("Atkinson Hyperlegible" and "Inter") were not being applied correctly due to missing CSS definitions and fragile manual imports.

**Changes:**
- **Global Imports:** Moved font imports to [assets/css/main.css](cci:7://file:///Users/home/Developer/web-flasher/assets/css/main.css:0:0-0:0) using reliable Google Fonts URLs.
- **Tailwind Config:** Updated [tailwind.config.js](cci:7://file:///Users/home/Developer/web-flasher/tailwind.config.js:0:0-0:0) to explicitly define `font-body` (Atkinson Hyperlegible) and `font-title`/`font-sans` (Inter).
- **Refactor:** Updated [app.vue](cci:7://file:///Users/home/Developer/web-flasher/app.vue:0:0-0:0) to replace legacy undefined classes (`body-font`, `title-font`) with correct Tailwind utilities and removed redundant manual `@font-face` declarations.
- **Cleanup:** Removed unused and hardcoded font styles in [components/ToastNotifications.vue](cci:7://file:///Users/home/Developer/web-flasher/components/ToastNotifications.vue:0:0-0:0).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests as appropriate
- [ ] All existing tests pass

---

## Hardware Model Acceptance Policy

### New Hardware Model Acceptance Policy

Due to limited availability and ongoing support, new Hardware Models will only be accepted from [Meshtastic Backers and Partners](https://meshtastic.com/). The Meshtastic team reserves the right to make exceptions to this policy.

#### Alternative for Community Contributors

You are welcome to use one of the existing DIY hardware models in your PlatformIO environment and create a pull request in the firmware project. Please note the following conditions:

- The device will **not** be officially supported by the core Meshtastic team.
- The device will **not** appear in the [Web Flasher](https://flasher.meshtastic.org/) or Github release assets.
- You will be responsible for ongoing maintenance and support.
- Community-contributed / DIY hardware models are considered experimental and will likely have limited or no testing.

#### Getting Official Support

To have your hardware model officially supported and included in the Meshtastic ecosystem, consider becoming a Meshtastic Backer or Partner. Visit [meshtastic.com](https://meshtastic.com/) for more information about partnership opportunities.

---

## Protected Files Notice

**The following files are protected and changes to them will be automatically rejected:**

- [public/data/hardware-list.json](cci:7://file:///Users/home/Developer/web-flasher/public/data/hardware-list.json:0:0-0:0) - Auto-generated Hardware definitions (additionally see policy above)
- [types/resources.ts](cci:7://file:///Users/home/Developer/web-flasher/types/resources.ts:0:0-0:0) - Auto-generated resource definitions
- `i18n/locales/**` - Translation files (managed via [Crowdin](https://meshtastic.crowdin.com/web-flasher))