### PR TITLE
fix: force dio flash mode for T-LoRa T3-S3 to prevent boot read errors

### DIFF
--- a/stores/firmwareStore.ts
+++ b/stores/firmwareStore.ts
@@ -179,7 +179,7 @@ export const useFirmwareStore = defineStore('firmware', {
           flashSize: 'keep',
           eraseAll: false,
           compress: true,
-          flashMode: 'keep',
+          flashMode: selectedTarget.platformioTarget.startsWith('tlora-t3s3') ? 'dio' : 'keep',
           flashFreq: 'keep',
           reportProgress: (fileIndex, written, total) => {
             this.flashPercentDone = Math.round((written / total) * 100)
@@ -320,7 +320,7 @@ export const useFirmwareStore = defineStore('firmware', {
           flashSize: 'keep',
           eraseAll: true,
           compress: true,
-          flashMode: 'keep',
+          flashMode: selectedTarget.platformioTarget.startsWith('tlora-t3s3') ? 'dio' : 'keep',
           flashFreq: 'keep',
           reportProgress: (fileIndex, written, total) => {
             this.flashingIndex = fileIndex


### PR DESCRIPTION
# Description

Forces `flashMode: 'dio'` for LILYGO T-LoRa T3-S3 (`tlora-t3s3`) targets during both update and clean install operations.

This resolves boot loop issues where the device fails with `flash read err, 1000` and `rst:0x10 (RTCWDT_RTC_RESET)` because the default `flashMode: 'keep'` was attempting to use a mode (likely `qio`) not supported by this hardware configuration.

Fixes #251

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as appropriate
- [ ] All existing tests pass

---

## Hardware Model Acceptance Policy

### New Hardware Model Acceptance Policy

Due to limited availability and ongoing support, new Hardware Models will only be accepted from [Meshtastic Backers and Partners](https://meshtastic.com/). The Meshtastic team reserves the right to make exceptions to this policy.

#### Alternative for Community Contributors

You are welcome to use one of the existing DIY hardware models in your PlatformIO environment and create a pull request in the firmware project. Please note the following conditions:

- The device will **not** be officially supported by the core Meshtastic team.
- The device will **not** appear in the [Web Flasher](https://flasher.meshtastic.org/) or Github release assets.
- You will be responsible for ongoing maintenance and support.
- Community-contributed / DIY hardware models are considered experimental and will likely have limited or no testing.

#### Getting Official Support

To have your hardware model officially supported and included in the Meshtastic ecosystem, consider becoming a Meshtastic Backer or Partner. Visit [meshtastic.com](https://meshtastic.com/) for more information about partnership opportunities.

---

## Protected Files Notice

**The following files are protected and changes to them will be automatically rejected:**

- `public/data/hardware-list.json` - Auto-generated Hardware definitions (additionally see policy above)
- `types/resources.ts` - Auto-generated resource definitions
- `i18n/locales/**` - Translation files (managed via [Crowdin](https://meshtastic.crowdin.com/web-flasher))
