### PR TITLE
make error Toasts appear in front of modals

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -173,7 +173,7 @@
       </transition-group>
     </div>
 
-    <div v-show="isConnected" class="fixed right-2 sm:right-4 top-4 sm:top-6 group z-[10000]">
+    <div v-show="isConnected" class="fixed right-2 sm:right-4 top-4 sm:top-6 group z-[60]">
       <button
         type="button"
         :disabled="true"

--- a/components/Device.vue
+++ b/components/Device.vue
@@ -36,7 +36,7 @@
         id="device-modal"
         tabindex="-1"
         aria-hidden="true"
-        class="hidden fixed inset-0 z-[60] flex items-start justify-center modal-backdrop backdrop-blur-sm px-4 sm:px-6 md:px-8 py-8 md:py-12"
+        class="hidden fixed inset-0 z-[50] flex items-start justify-center modal-backdrop backdrop-blur-sm px-4 sm:px-6 md:px-8 py-8 md:py-12"
       >
         <div
           class="relative w-full max-w-6xl"

--- a/components/Flash.vue
+++ b/components/Flash.vue
@@ -38,7 +38,7 @@
         id="flash-modal"
         tabindex="-1"
         aria-hidden="true"
-        class="hidden fixed inset-0 z-[60] modal-backdrop backdrop-blur-sm px-4 sm:px-6 md:px-8 py-8 md:py-12"
+        class="hidden fixed inset-0 z-[50] modal-backdrop backdrop-blur-sm px-4 sm:px-6 md:px-8 py-8 md:py-12"
       >
         <div class="flex h-full w-full items-start justify-center">
           <div class="relative w-full max-w-5xl">
@@ -69,7 +69,7 @@
         id="erase-modal"
         tabindex="-1"
         aria-hidden="true"
-        class="hidden fixed inset-0 z-[60] bg-black/30 backdrop-blur-sm px-4 sm:px-6 md:px-8 py-8 md:py-12"
+        class="hidden fixed inset-0 z-50 bg-black/30 backdrop-blur-sm px-4 sm:px-6 md:px-8 py-8 md:py-12"
       >
         <div class="flex h-full w-full items-start justify-center">
           <div class="relative w-full max-w-3xl">

--- a/components/ToastNotifications.vue
+++ b/components/ToastNotifications.vue
@@ -1,6 +1,6 @@
 <template>
   <Teleport to="body">
-    <div class="fixed top-6 right-6 z-50 space-y-3">
+    <div class="fixed top-6 right-6 z-[70] space-y-3">
       <TransitionGroup
         name="toast"
         tag="div"


### PR DESCRIPTION
The `ToastNotifications` currently appear behind the device/flash/erase modals (and backdrops). We see these errors when we e.g. hit "Auto-detect" on the `Device` modal, or "Flash" on the `Flash` modal, with no device connected (or we're in a browser without Web Serial).

<img width="1474" height="604" alt="webFlasherErrorNotification" src="https://github.com/user-attachments/assets/e378a554-9f64-451e-9ea3-182036a255b6" />

Let's adjust the z-index of `ToastNotifications` so they'll appear in the right place.

The `ToastNotifications` also conflict with the Device Status "button". They're on the same level in the DOM and share the same stacking context. We currently have (since #297) `z-10000` set for Device Status (I'm guessing so it would appear in front of the modals). However, we probably want error notifications to be the front-most thing, so let's turn down the `z-index` for Device Status (but still have it appear in front of the modals).

Current:
- Error (50)
- Modal (60)
- DeviceStatus (10000)

New:
- Modal (50)
- DeviceStatus (60)
- Error (70)