### PR TITLE
feat: resolve event mode from the api event-firmware manifest

### DIFF
--- a/components/Firmware.vue
+++ b/components/Firmware.vue
@@ -45,7 +45,7 @@
             </li>
             <li v-else>
               <span class="block px-4 py-2 italic text-theme-muted">
-                Firmware coming soon
+                {{ $t('firmware.coming_soon') }}
               </span>
             </li>
           </ul>

--- a/components/Firmware.vue
+++ b/components/Firmware.vue
@@ -10,139 +10,144 @@
       :class="{ 'animate-bounce': store.prereleaseUnlocked && !store.$state.selectedFirmware?.id }"
       type="button"
       :disabled="!canSelectFirmware"
-        @click.stop="toggleDropdown"
+      @click.stop="toggleDropdown"
     >
       {{ selectedVersion.replace('Meshtastic Firmware ', '').replace('Technical ', '') }}
       <ChevronDown class="w-2.5 h-2.5 ms-2" />
     </button>
-      <Teleport to="body">
-        <div
-          id="dropdownFirmware"
-          ref="dropdownRef"
-          v-show="isOpen"
-          class="fixed z-[120] rounded-xl shadow-2xl max-w-sm overflow-y-auto backdrop-blur-xl dropdown-menu"
-          :style="dropdownStyle"
-        >
-      <!-- Event Mode: Single firmware option -->
-      <template v-if="eventMode.enabled">
-        <div
-          class="px-4 py-2 text-sm text-meshtastic font-semibold border-theme-bottom"
-        >
-          {{ eventMode.eventName }}
-        </div>
-        <ul
-          class="py-2 text-sm text-theme-muted"
-          aria-labelledby="dropdownInformationButton"
-        >
-          <li>
-            <a
-              href="#"
-              class="block px-4 py-2 hover:text-meshtastic-dark hover:bg-surface-secondary cursor-pointer transition-colors"
-              @click="setSelectedFirmware(eventMode.firmware)"
-            >
-              {{ eventMode.firmware.title.replace('Meshtastic Firmware ', '') }}
-            </a>
-          </li>
-        </ul>
-      </template>
+    <Teleport to="body">
+      <div
+        v-show="isOpen"
+        id="dropdownFirmware"
+        ref="dropdownRef"
+        class="fixed z-[120] rounded-xl shadow-2xl max-w-sm overflow-y-auto backdrop-blur-xl dropdown-menu"
+        :style="dropdownStyle"
+      >
+        <!-- Event Mode: Single firmware option -->
+        <template v-if="eventMode.enabled">
+          <div
+            class="px-4 py-2 text-sm text-meshtastic font-semibold border-theme-bottom"
+          >
+            {{ eventMode.eventName }}
+          </div>
+          <ul
+            class="py-2 text-sm text-theme-muted"
+            aria-labelledby="dropdownInformationButton"
+          >
+            <li v-if="eventMode.firmware.id">
+              <a
+                href="#"
+                class="block px-4 py-2 hover:text-meshtastic-dark hover:bg-surface-secondary cursor-pointer transition-colors"
+                @click="setSelectedFirmware(eventMode.firmware)"
+              >
+                {{ (eventMode.firmware.title || '').replace('Meshtastic Firmware ', '') }}
+              </a>
+            </li>
+            <li v-else>
+              <span class="block px-4 py-2 italic text-theme-muted">
+                Firmware coming soon
+              </span>
+            </li>
+          </ul>
+        </template>
 
-      <!-- Normal Mode: Full firmware list -->
-      <template v-else>
-      <div
-        v-if="store.$state.prFirmware"
-        class="px-4 py-2 text-sm text-purple-400 font-semibold border-theme-bottom"
-      >
-        {{ $t('firmware.pull_request') }}
-      </div>
-      <ul
-        v-if="store.$state.prFirmware"
-        class="py-2 text-sm text-theme-muted"
-        aria-labelledby="dropdownInformationButton"
-      >
-        <li>
-          <a
-            href="#"
-            class="block px-4 py-2 hover:text-meshtastic-dark hover:bg-surface-secondary cursor-pointer transition-colors"
-            @click="setSelectedFirmware(store.$state.prFirmware)"
+        <!-- Normal Mode: Full firmware list -->
+        <template v-else>
+          <div
+            v-if="store.$state.prFirmware"
+            class="px-4 py-2 text-sm text-purple-400 font-semibold border-theme-bottom"
           >
-            {{ store.$state.prFirmware.title }}
-            <span class="block text-xs text-theme-muted truncate max-w-[18rem]">{{ store.$state.prFirmware.prBuild?.prTitle }}</span>
-          </a>
-        </li>
-      </ul>
-      <div
-        v-if="store.prereleaseUnlocked && store.$state.previews.length > 0"
-        class="px-4 py-2 text-sm text-meshtastic font-semibold border-theme-bottom"
-      >
-        {{ $t('firmware.prerelease') }}
-      </div>
-      <ul
-        v-if="store.prereleaseUnlocked && store.$state.previews.length > 0"
-        class="py-2 text-sm text-theme-muted"
-        aria-labelledby="dropdownInformationButton"
-      >
-        <li v-for="release in store.$state.previews">
-          <a
-            href="#"
-            class="block px-4 py-2 hover:text-meshtastic-dark hover:bg-surface-secondary cursor-pointer transition-colors"
-            @click="setSelectedFirmware(release)"
+            {{ $t('firmware.pull_request') }}
+          </div>
+          <ul
+            v-if="store.$state.prFirmware"
+            class="py-2 text-sm text-theme-muted"
+            aria-labelledby="dropdownInformationButton"
           >
-            {{ release.title.replace('Meshtastic Firmware ', '').replace('Pre-release ', '') }}
-          </a>
-        </li>
-      </ul>
-      <div
-        v-if="!store.couldntFetchFirmwareApi"
-        class="px-4 py-2 text-sm text-warning font-semibold border-theme-bottom border-theme-top"
-      >
-        {{ $t('firmware.unstable') }}
-      </div>
-      <ul
-        v-if="!store.couldntFetchFirmwareApi"
-        class="py-2 text-sm text-theme-muted"
-        aria-labelledby="dropdownInformationButton"
-      >
-        <li v-for="release in store.$state.alpha">
-          <a
-            href="#"
-            class="block px-4 py-2 hover:text-meshtastic-dark hover:bg-surface-secondary cursor-pointer transition-colors"
-            @click="setSelectedFirmware(release)"
+            <li>
+              <a
+                href="#"
+                class="block px-4 py-2 hover:text-meshtastic-dark hover:bg-surface-secondary cursor-pointer transition-colors"
+                @click="setSelectedFirmware(store.$state.prFirmware)"
+              >
+                {{ store.$state.prFirmware.title }}
+                <span class="block text-xs text-theme-muted truncate max-w-[18rem]">{{ store.$state.prFirmware.prBuild?.prTitle }}</span>
+              </a>
+            </li>
+          </ul>
+          <div
+            v-if="store.prereleaseUnlocked && store.$state.previews.length > 0"
+            class="px-4 py-2 text-sm text-meshtastic font-semibold border-theme-bottom"
           >
-            {{ release.title.replace('Meshtastic Firmware ', '') }}
-          </a>
-        </li>
-      </ul>
-      <div
-        v-if="!store.couldntFetchFirmwareApi"
-        class="px-4 py-2 text-sm text-green-400 font-semibold border-theme-bottom border-theme-top"
-      >
-        {{ $t('firmware.stable') }}
-      </div>
-      <ul
-        v-if="!store.couldntFetchFirmwareApi"
-        class="py-2 text-sm text-theme-muted"
-        aria-labelledby="dropdownInformationButton"
-      >
-        <li v-for="release in store.$state.stable">
-          <span
-            class="block px-4 py-2 hover:text-meshtastic-dark hover:bg-surface-secondary cursor-pointer transition-colors"
-            @click="setSelectedFirmware(release)"
+            {{ $t('firmware.prerelease') }}
+          </div>
+          <ul
+            v-if="store.prereleaseUnlocked && store.$state.previews.length > 0"
+            class="py-2 text-sm text-theme-muted"
+            aria-labelledby="dropdownInformationButton"
           >
-            {{ release.title.replace('Meshtastic Firmware ', '') }}
-          </span>
-        </li>
-      </ul>
-      <div
-        v-if="store.couldntFetchFirmwareApi"
-        class="px-3 sm:px-4 py-3 w-full sm:w-96 max-w-sm rounded-xl text-xs sm:text-sm border error-fetch-box break-words"
-      >
-        <strong>{{ $t('firmware.error_fetching') }}</strong>
-        <br>
-        {{ $t('firmware.refresh_later') }}
-        {{ $t('firmware.upload_alternative') }}
-        <FolderOpen class="h-3 w-3 inline" /> {{ $t('firmware.icon') }}
-      </div>
-      </template>
+            <li v-for="release in store.$state.previews">
+              <a
+                href="#"
+                class="block px-4 py-2 hover:text-meshtastic-dark hover:bg-surface-secondary cursor-pointer transition-colors"
+                @click="setSelectedFirmware(release)"
+              >
+                {{ release.title.replace('Meshtastic Firmware ', '').replace('Pre-release ', '') }}
+              </a>
+            </li>
+          </ul>
+          <div
+            v-if="!store.couldntFetchFirmwareApi"
+            class="px-4 py-2 text-sm text-warning font-semibold border-theme-bottom border-theme-top"
+          >
+            {{ $t('firmware.unstable') }}
+          </div>
+          <ul
+            v-if="!store.couldntFetchFirmwareApi"
+            class="py-2 text-sm text-theme-muted"
+            aria-labelledby="dropdownInformationButton"
+          >
+            <li v-for="release in store.$state.alpha">
+              <a
+                href="#"
+                class="block px-4 py-2 hover:text-meshtastic-dark hover:bg-surface-secondary cursor-pointer transition-colors"
+                @click="setSelectedFirmware(release)"
+              >
+                {{ release.title.replace('Meshtastic Firmware ', '') }}
+              </a>
+            </li>
+          </ul>
+          <div
+            v-if="!store.couldntFetchFirmwareApi"
+            class="px-4 py-2 text-sm text-green-400 font-semibold border-theme-bottom border-theme-top"
+          >
+            {{ $t('firmware.stable') }}
+          </div>
+          <ul
+            v-if="!store.couldntFetchFirmwareApi"
+            class="py-2 text-sm text-theme-muted"
+            aria-labelledby="dropdownInformationButton"
+          >
+            <li v-for="release in store.$state.stable">
+              <span
+                class="block px-4 py-2 hover:text-meshtastic-dark hover:bg-surface-secondary cursor-pointer transition-colors"
+                @click="setSelectedFirmware(release)"
+              >
+                {{ release.title.replace('Meshtastic Firmware ', '') }}
+              </span>
+            </li>
+          </ul>
+          <div
+            v-if="store.couldntFetchFirmwareApi"
+            class="px-3 sm:px-4 py-3 w-full sm:w-96 max-w-sm rounded-xl text-xs sm:text-sm border error-fetch-box break-words"
+          >
+            <strong>{{ $t('firmware.error_fetching') }}</strong>
+            <br>
+            {{ $t('firmware.refresh_later') }}
+            {{ $t('firmware.upload_alternative') }}
+            <FolderOpen class="h-3 w-3 inline" /> {{ $t('firmware.icon') }}
+          </div>
+        </template>
       </div>
     </Teleport>
     <button

--- a/components/LogoHeader.vue
+++ b/components/LogoHeader.vue
@@ -60,7 +60,9 @@
       <h1 class="logo-title">
         <span class="logo-title-gradient">{{ $t('header_title') }}</span>
       </h1>
-      <p class="logo-tagline">{{ eventMode.eventName }}</p>
+      <p class="logo-tagline">
+        {{ eventMode.eventName }}
+      </p>
     </div>
 
     <!-- Hamvention event branding variant -->
@@ -78,7 +80,44 @@
       <h1 class="logo-title">
         <span class="logo-title-gradient">{{ $t('header_title') }}</span>
       </h1>
-      <p class="logo-tagline">{{ eventMode.eventName }}</p>
+      <p class="logo-tagline">
+        {{ eventMode.eventName }}
+      </p>
+    </div>
+
+    <!-- Generic event branding (theme-driven, e.g. DEFCON) -->
+    <div
+      v-else-if="eventMode.enabled"
+      class="logo-header-content"
+    >
+      <div class="logo-container">
+        <div class="logo-glow">
+          <img
+            v-if="eventMode.iconUrl"
+            :src="eventMode.iconUrl"
+            class="logo-icon-event"
+            :alt="`${eventMode.eventName} Logo`"
+          >
+          <img
+            v-else-if="themeStore.isDark"
+            src="@/assets/img/logo.svg"
+            class="logo-icon"
+            alt="Meshtastic Logo"
+          >
+          <img
+            v-else
+            src="@/assets/img/logo-dark.svg"
+            class="logo-icon"
+            alt="Meshtastic Logo"
+          >
+        </div>
+      </div>
+      <h1 class="logo-title">
+        <span class="logo-title-gradient">{{ $t('header_title') }}</span>
+      </h1>
+      <p class="logo-tagline">
+        {{ eventMode.tagline || eventMode.eventName }}
+      </p>
     </div>
 
     <!-- Standard variant -->
@@ -105,7 +144,9 @@
       <h1 class="logo-title">
         <span class="logo-title-gradient">{{ $t('header_title') }}</span>
       </h1>
-      <p class="logo-tagline">{{ $t('description') }}</p>
+      <p class="logo-tagline">
+        {{ $t('description') }}
+      </p>
     </div>
   </div>
 </template>

--- a/composables/useEventMode.ts
+++ b/composables/useEventMode.ts
@@ -1,23 +1,13 @@
 import { computed } from 'vue'
-import { eventMode as staticEventMode } from '~/types/resources'
+import { eventMode as activeEventMode } from '~/types/resources'
 
+// The active event mode is resolved once at startup by
+// plugins/eventMode.client.ts (manifest by hostname, with a static fallback).
+// This composable just exposes that reactive singleton; consumers keep using
+// `eventMode.value` / `eventMode.enabled` exactly as before.
 export const useEventMode = () => {
-  const isEventDomain = computed(() => {
-    if (process.client) {
-      return window.location.hostname.includes(staticEventMode.domain)
-    }
-    return false
-  })
-
-  const eventMode = computed(() => {
-    if (isEventDomain.value) {
-      return {
-        ...staticEventMode,
-        enabled: true,
-      }
-    }
-    return staticEventMode
-  })
+  const eventMode = computed(() => activeEventMode)
+  const isEventDomain = computed(() => activeEventMode.enabled)
 
   return { eventMode, isEventDomain }
 }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -60,6 +60,7 @@
     "stable": "Stable (or Beta)",
     "unstable": "Unstable (Alpha)",
     "prerelease": "Pre-release",
+    "coming_soon": "Firmware coming soon",
     "error_fetching": "Could not fetch firmware versions from API.",
     "refresh_later": "Refresh the page later to try again.",
     "upload_alternative": "Alternatively, you can upload a firmware.zip file from the Github releases or an individual firmware-update.bin file for an ESP32 based device by clicking the icon.",

--- a/plugins/eventMode.client.ts
+++ b/plugins/eventMode.client.ts
@@ -1,0 +1,46 @@
+import { fetchApiManifest, fetchBundledManifest, hostMatches, manifestEditionToEventMode, resolveActiveEdition, applyEventTheme } from '~/utils/eventManifest'
+import type { EventFirmwareResponse } from '~/types/eventFirmware'
+import { setActiveEventMode, staticEventModes } from '~/types/resources'
+
+// Resolve the active event edition for the current host. ssr:false guarantees
+// window is available, and Nuxt awaits async plugins — so we gate first paint
+// ONLY on the fast, same-origin bundled snapshot (offline-first). The
+// cross-origin live API is refreshed in the BACKGROUND and reactively re-applied,
+// so a slow/unreachable API never blanks the screen for any visitor.
+export default defineNuxtPlugin(async () => {
+  const hostname = window.location.hostname
+  // ?event=DEFCON lets you preview an edition on localhost.
+  const override = new URLSearchParams(window.location.search).get('event')
+
+  const applyManifest = (manifest: EventFirmwareResponse): boolean => {
+    const edition = resolveActiveEdition(manifest, hostname, override)
+    if (!edition) return false
+    setActiveEventMode(manifestEditionToEventMode(edition))
+    applyEventTheme(edition.theme)
+    return true
+  }
+
+  try {
+    const bundled = await fetchBundledManifest()
+    if (!applyManifest(bundled)) {
+      // Events not present in the manifest (e.g. Hamcation has no FirmwareEdition).
+      const fallback = staticEventModes.find(e => hostMatches(hostname, e.domain))
+      if (fallback) {
+        setActiveEventMode({ ...fallback, enabled: true })
+        applyEventTheme(fallback.theme)
+      }
+    }
+  }
+  catch (e) {
+    console.error('eventMode: failed to resolve bundled manifest', e)
+  }
+
+  // Background refresh from the source of truth; reactively re-applies if the
+  // live API resolves an edition for this host (e.g. a build that shipped after
+  // this app was deployed). Never blocks mount.
+  fetchApiManifest()
+    .then((api) => {
+      if (api) applyManifest(api)
+    })
+    .catch(() => {})
+})

--- a/public/data/event_firmware.json
+++ b/public/data/event_firmware.json
@@ -1,0 +1,133 @@
+{
+  "version": 2,
+  "generatedAt": "2026-06-30T00:00:00Z",
+  "source": "bundled",
+  "editions": [
+    {
+      "edition": "HAMVENTION",
+      "displayName": "Dayton Hamvention 2026",
+      "welcomeMessage": "Welcome to Hamvention! 🍖📻",
+      "tag": "Hamvention",
+      "eventStart": "2026-05-15",
+      "eventEnd": "2026-05-17",
+      "timeZone": "America/New_York",
+      "location": "Xenia, Ohio, USA",
+      "iconUrl": "https://api.meshtastic.org/resource/eventFirmware/hamvention.png",
+      "accentColor": "#BF1E2E",
+      "domain": "hamvention.meshtastic.org",
+      "links": [
+        { "label": "Event Website", "url": "https://hamvention.org" }
+      ],
+      "theme": {
+        "name": "Radio Adventure",
+        "tagline": "Exploring the many avenues amateur radio has to offer.",
+        "colors": { "primary": "#BF1E2E", "secondary": null, "accent": null },
+        "palette": ["#BF1E2E"],
+        "fonts": null
+      },
+      "firmware": {
+        "slug": "dayton2026",
+        "version": "2.7.23.07741e6",
+        "id": "v2.7.23.07741e6",
+        "title": "Meshtastic Firmware 2.7.23.07741e6",
+        "zipUrl": "https://github.com/meshtastic/meshtastic.github.io/raw/master/event/dayton2026/firmware-2.7.23.07741e6.zip",
+        "releaseNotes": "## Welcome to Dayton Hamvention 2026!\n\nThis firmware has been customized for Hamvention with factory default configurations.\n\n### ⚠️ Important: Backup Before Flashing\n\nIf your device has existing settings or encryption keys, **backup your keys / configurations** before proceeding. Flashing will reset your device to factory settings for the event.\n\n### Quick Start\n\n1. Ensure a **data-capable USB cable** is connected\n2. Select your device type\n3. Choose \"Full Erase and Install\"\n4. After flashing, download the Meshtastic app and pair via Bluetooth\n5. If you updated from a previous version or installed a UF2 on an NRF52 device, you will need to perform a factory reset on the device to activate the Hamvention mode.\n\n**73 and happy meshing from Dayton!**"
+      }
+    },
+    {
+      "edition": "OPEN_SAUCE",
+      "displayName": "Open Sauce 2026",
+      "welcomeMessage": "Welcome to Open Sauce! 🔧",
+      "tag": "Open Sauce",
+      "eventStart": "2026-07-17",
+      "eventEnd": "2026-07-19",
+      "timeZone": "America/Los_Angeles",
+      "location": "San Mateo, California, USA",
+      "iconUrl": null,
+      "accentColor": "#E94F1D",
+      "domain": "opensauce.meshtastic.org",
+      "links": [
+        { "label": "Event Website", "url": "https://opensauce.com" }
+      ],
+      "theme": {
+        "name": null,
+        "tagline": null,
+        "colors": { "primary": "#E94F1D", "secondary": null, "accent": null },
+        "palette": ["#E94F1D"],
+        "fonts": null
+      },
+      "firmware": {
+        "slug": "opensauce2026",
+        "version": null,
+        "id": null,
+        "title": null,
+        "zipUrl": null,
+        "releaseNotes": null
+      }
+    },
+    {
+      "edition": "DEFCON",
+      "displayName": "DEF CON 34",
+      "welcomeMessage": "Welcome to DEF CON 34! 💀",
+      "tag": "DEFCON",
+      "eventStart": "2026-08-06",
+      "eventEnd": "2026-08-09",
+      "timeZone": "America/Los_Angeles",
+      "location": "Las Vegas Convention Center, Las Vegas, Nevada, USA",
+      "iconUrl": null,
+      "accentColor": "#0D294A",
+      "domain": "defcon.meshtastic.org",
+      "links": [
+        { "label": "Event Website", "url": "https://defcon.org" },
+        { "label": "DEF CON 34 Theme", "url": "https://defcon.org/html/defcon-34/dc-34-theme.html" },
+        { "label": "Mastodon", "url": "https://defcon.social" }
+      ],
+      "theme": {
+        "name": "Agency",
+        "tagline": "Agency is self-determination. It's about making choices that increase yours, AND helping others to control theirs.",
+        "colors": { "primary": "#0D294A", "secondary": "#017FA4", "accent": "#E0004E" },
+        "palette": ["#0D294A", "#017FA4", "#105F66", "#6CCDB8", "#F1B435", "#E0004E"],
+        "fonts": { "heading": "Lato", "body": "Atkinson Hyperlegible" }
+      },
+      "firmware": {
+        "slug": "defcon2026",
+        "version": null,
+        "id": null,
+        "title": null,
+        "zipUrl": null,
+        "releaseNotes": null
+      }
+    },
+    {
+      "edition": "BURNING_MAN",
+      "displayName": "Burning Man 2026",
+      "welcomeMessage": "Welcome to Burning Man! 🔥",
+      "tag": "Burning Man",
+      "eventStart": "2026-08-30",
+      "eventEnd": "2026-09-07",
+      "timeZone": "America/Los_Angeles",
+      "location": "Black Rock City, Nevada, USA",
+      "iconUrl": null,
+      "accentColor": "#EC8819",
+      "domain": "burningman.meshtastic.org",
+      "links": [
+        { "label": "Event Website", "url": "https://burningman.org" }
+      ],
+      "theme": {
+        "name": "Axis Mundi",
+        "tagline": "The axis of the world — a celestial column connecting earth, sky, and the realms between.",
+        "colors": { "primary": "#EC8819", "secondary": null, "accent": null },
+        "palette": ["#EC8819"],
+        "fonts": null
+      },
+      "firmware": {
+        "slug": "burningman2026",
+        "version": null,
+        "id": null,
+        "title": null,
+        "zipUrl": null,
+        "releaseNotes": null
+      }
+    }
+  ]
+}

--- a/types/eventFirmware.ts
+++ b/types/eventFirmware.ts
@@ -1,0 +1,55 @@
+// Shape of the api.meshtastic.org `GET resource/eventFirmware` manifest.
+// Mirrors meshtastic/api src/lib/eventFirmware.ts (and the offline snapshot in
+// public/data/event_firmware.json). The manifest is the single source of truth
+// for event editions; the web-flasher resolves the active edition by hostname
+// and maps it into an EventModeConfig (see utils/eventManifest.ts).
+
+export interface EventFirmwareLink {
+  label: string
+  url: string
+}
+
+export interface EventFirmwareTheme {
+  name?: string | null // theme title, e.g. "Agency"
+  tagline?: string | null
+  colors?: {
+    primary?: string | null
+    secondary?: string | null
+    accent?: string | null
+  } | null
+  palette?: string[] | null
+  fonts?: { heading?: string | null, body?: string | null } | null
+}
+
+export interface EventFirmwareBuild {
+  slug: string // meshtastic.github.io event path segment, e.g. "defcon2026"
+  version?: string | null
+  id?: string | null
+  title?: string | null
+  zipUrl?: string | null
+  releaseNotes?: string | null
+}
+
+export interface EventFirmwareEdition {
+  edition: string // FirmwareEdition proto enum name, e.g. "DEFCON"
+  displayName: string
+  welcomeMessage: string
+  tag?: string | null
+  eventStart?: string | null
+  eventEnd?: string | null
+  timeZone?: string | null
+  location?: string | null
+  iconUrl?: string | null
+  accentColor?: string | null
+  domain?: string | null
+  links?: EventFirmwareLink[]
+  theme?: EventFirmwareTheme | null
+  firmware?: EventFirmwareBuild | null
+}
+
+export interface EventFirmwareResponse {
+  version: number
+  generatedAt?: string
+  source?: string
+  editions: EventFirmwareEdition[]
+}

--- a/types/resources.ts
+++ b/types/resources.ts
@@ -1,4 +1,6 @@
+import { reactive } from 'vue';
 import type { FirmwareResource } from './api';
+import type { EventFirmwareTheme } from './eventFirmware';
 
 // Remove the OfflineHardwareList since it's now in /public/data/hardware-list.json
 
@@ -21,6 +23,10 @@ export interface EventModeConfig {
   pathPrefix: string;
   domain: string;
   firmware: FirmwareResource;
+  // Branding pulled from the manifest edition (optional — set in event mode).
+  theme?: EventFirmwareTheme;
+  tagline?: string;
+  iconUrl?: string;
 }
 
 const eventFirmwareId = '2.7.23.07741e6';
@@ -45,26 +51,6 @@ If your device has existing settings or encryption keys, **backup your keys / co
 **73 and happy meshing!**
 `;
 
-const hamventionReleaseNotes = `
-## Welcome to Dayton Hamvention 2026!
-
-This firmware has been customized for Hamvention with factory default configurations.
-
-### ⚠️ Important: Backup Before Flashing
-
-If your device has existing settings or encryption keys, **backup your keys / configurations** before proceeding. Flashing will reset your device to factory settings for the event.
-
-### Quick Start
-
-1. Ensure a **data-capable USB cable** is connected
-2. Select your device type
-3. Choose "Full Erase and Install"
-4. After flashing, download the Meshtastic app and pair via Bluetooth
-5. If you updated from a previous version or installed a UF2 on an NRF52 device, you will need to perform a factory reset on the device to activate the Hamvention mode.
-
-**73 and happy meshing from Dayton!**
-`;
-
 const hamcationEventMode: EventModeConfig = {
   enabled: false,
   eventName: 'Orlando Hamcation 2026',
@@ -79,22 +65,29 @@ const hamcationEventMode: EventModeConfig = {
   },
 };
 
-const hamventionEventMode: EventModeConfig = {
-  enabled: false,
-  eventName: 'Dayton Hamvention 2026',
-  eventTag: 'Hamvention',
-  pathPrefix: 'dayton2026',
-  domain: 'hamvention.meshtastic.org',
-  firmware: {
-    id: `v${eventFirmwareId}`,
-    title: `Meshtastic Firmware ${eventFirmwareId}`,
-    zip_url: `https://github.com/meshtastic/meshtastic.github.io/raw/master/event/dayton2026/firmware-${eventFirmwareId}.zip`,
-    release_notes: hamventionReleaseNotes,
-  },
-};
+// Static event configs kept as an offline fallback for events with NO entry in
+// the api event-firmware manifest (Hamcation has no FirmwareEdition enum, so it
+// never appears there). Manifest-backed events (Hamvention, DEFCON, …) resolve
+// dynamically and take precedence; see plugins/eventMode.client.ts.
+export const staticEventModes: EventModeConfig[] = [hamcationEventMode];
 
-// Active event — change this line to switch which event the flasher locks to.
-export const eventMode: EventModeConfig = hamventionEventMode;
+// Active event mode. Disabled until plugins/eventMode.client.ts resolves the
+// current host against the manifest (or the static fallback above). Reactive so
+// components re-render when it resolves; a plain object so the firmware store and
+// firmwareUrl util can read it synchronously.
+export const eventMode = reactive<EventModeConfig>({
+  enabled: false,
+  eventName: '',
+  eventTag: '',
+  pathPrefix: '',
+  domain: '',
+  firmware: { id: '', title: '' },
+});
+
+/** Replace the active event mode in place, preserving the shared reference. */
+export function setActiveEventMode(config: EventModeConfig): void {
+  Object.assign(eventMode, config);
+}
 
 export const vendorCobrandingTag = "";
 export const supportedVendorDeviceTags = ["RAK", "B&Q", "LilyGo", "Seeed", "Heltec", "DIY", "Elecrow", "M5Stack", "NomadStar", "muzi"];

--- a/utils/eventManifest.ts
+++ b/utils/eventManifest.ts
@@ -1,0 +1,149 @@
+import type { EventFirmwareEdition, EventFirmwareResponse, EventFirmwareTheme } from '~/types/eventFirmware'
+import type { EventModeConfig } from '~/types/resources'
+
+// Same-origin bundled snapshot gates first paint, so it gets a short timeout;
+// the cross-origin live API only refreshes in the background and can wait longer.
+const BUNDLED_TIMEOUT_MS = 2000
+const API_TIMEOUT_MS = 2500
+// Offline snapshot shipped with the app (public/data/event_firmware.json, same
+// origin and PWA-precached) so event mode still resolves when the cross-origin
+// API is unreachable — venue Wi-Fi is unreliable. Kept in sync with meshtastic/api.
+const BUNDLED_MANIFEST_URL = '/data/event_firmware.json'
+const EMPTY_MANIFEST: EventFirmwareResponse = { version: 0, editions: [] }
+
+async function fetchManifest(url: string, timeoutMs: number): Promise<EventFirmwareResponse | null> {
+  try {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), timeoutMs)
+    const res = await fetch(url, { signal: controller.signal })
+    clearTimeout(timer)
+    if (res.ok) {
+      return await res.json() as EventFirmwareResponse
+    }
+  }
+  catch {
+    // offline, slow, timed out, or non-JSON body — caller decides the fallback
+  }
+  return null
+}
+
+/**
+ * Bundled snapshot (same origin, PWA-precached). Used to resolve event mode
+ * BEFORE mount so first paint never waits on the cross-origin API. Degrades to
+ * an empty manifest (no active event) if even this is unreachable.
+ */
+export async function fetchBundledManifest(): Promise<EventFirmwareResponse> {
+  return (await fetchManifest(BUNDLED_MANIFEST_URL, BUNDLED_TIMEOUT_MS)) ?? EMPTY_MANIFEST
+}
+
+/**
+ * Live manifest from the API (source of truth, fresh dates/versions). The `/api`
+ * prefix is proxied to api.meshtastic.org (see nuxt.config.ts). Returns null on
+ * any failure; the caller keeps the bundled result. Fetched in the background so
+ * a slow/unreachable API never blocks first paint.
+ */
+export async function fetchApiManifest(): Promise<EventFirmwareResponse | null> {
+  return fetchManifest('/api/resource/eventFirmware', API_TIMEOUT_MS)
+}
+
+/**
+ * Whether the current host belongs to an event edition's domain. Exact match or
+ * a subdomain of it — NOT a substring, so a full host like `flash.meshtastic.org`
+ * never matches a (mis-authored) bare suffix like `meshtastic.org`.
+ */
+export function hostMatches(hostname: string, domain?: string | null): boolean {
+  return !!domain && (hostname === domain || hostname.endsWith(`.${domain}`))
+}
+
+/**
+ * Pick the edition for the current host. An optional override (e.g. the
+ * `?event=DEFCON` query param) matches by edition enum name or tag — handy for
+ * local development where the hostname is `localhost`.
+ */
+export function resolveActiveEdition(
+  manifest: EventFirmwareResponse,
+  hostname: string,
+  override?: string | null,
+): EventFirmwareEdition | null {
+  if (override) {
+    const key = override.toUpperCase()
+    const byKey = manifest.editions.find(
+      e => e.edition.toUpperCase() === key || (e.tag ?? '').toUpperCase() === key,
+    )
+    if (byKey) return byKey
+  }
+  return manifest.editions.find(e => hostMatches(hostname, e.domain)) ?? null
+}
+
+/**
+ * Map a manifest edition onto the EventModeConfig the rest of the flasher
+ * already consumes. Editions whose firmware build has not shipped yet (version
+ * null) yield an empty firmware id, which the UI treats as "coming soon".
+ */
+export function manifestEditionToEventMode(edition: EventFirmwareEdition): EventModeConfig {
+  const fw = edition.firmware
+  return {
+    enabled: true,
+    eventName: edition.displayName,
+    eventTag: edition.tag ?? edition.displayName,
+    pathPrefix: fw?.slug ?? '',
+    domain: edition.domain ?? '',
+    firmware: {
+      id: fw?.id ?? '',
+      title: fw?.title ?? edition.displayName,
+      zip_url: fw?.zipUrl ?? undefined,
+      release_notes: fw?.releaseNotes ?? undefined,
+    },
+    theme: edition.theme ?? undefined,
+    tagline: edition.theme?.tagline ?? undefined,
+    iconUrl: edition.iconUrl ?? undefined,
+  }
+}
+
+function clampByte(n: number): number {
+  return Math.max(0, Math.min(255, Math.round(n)))
+}
+
+/** Parse #RRGGBB into [r, g, b]; returns null for anything else. */
+function parseHex(hex: string): [number, number, number] | null {
+  const m = /^#([0-9a-f]{6})$/i.exec(hex.trim())
+  if (!m) return null
+  const int = Number.parseInt(m[1], 16)
+  return [(int >> 16) & 0xff, (int >> 8) & 0xff, int & 0xff]
+}
+
+function hexToRgba(hex: string, alpha: number): string | null {
+  const rgb = parseHex(hex)
+  if (!rgb) return null
+  return `rgba(${rgb[0]}, ${rgb[1]}, ${rgb[2]}, ${alpha})`
+}
+
+function darken(hex: string, amount: number): string | null {
+  const rgb = parseHex(hex)
+  if (!rgb) return null
+  const [r, g, b] = rgb.map(c => clampByte(c * (1 - amount)))
+  return `#${[r, g, b].map(c => c.toString(16).padStart(2, '0')).join('')}`
+}
+
+/**
+ * Re-tint the UI from the edition theme by overriding the accent CSS variables
+ * defined in assets/css/main.css. The whole interface (logo glow, gradient
+ * title, buttons) reads these, so this is all the wiring branding needs.
+ */
+export function applyEventTheme(theme?: EventFirmwareTheme | null): void {
+  const primary = theme?.colors?.primary
+  if (!primary || !parseHex(primary)) return
+  const root = document.documentElement
+  const secondary = theme?.colors?.secondary && parseHex(theme.colors.secondary)
+    ? theme.colors.secondary
+    : darken(primary, 0.25)
+
+  root.style.setProperty('--accent', primary)
+  if (secondary) root.style.setProperty('--accent-dark', secondary)
+  const glow = hexToRgba(primary, 0.3)
+  if (glow) root.style.setProperty('--accent-glow', glow)
+  const subtle = hexToRgba(primary, 0.5)
+  if (subtle) root.style.setProperty('--accent-subtle', subtle)
+  // Also feed the manifest-theme.css variables some components reference.
+  root.style.setProperty('--primary-color', primary)
+}


### PR DESCRIPTION
Replace the hardcoded EventModeConfig with dynamic resolution from api.meshtastic.org/resource/eventFirmware, so standing up an event becomes a manifest edit rather than a code change.

- plugins/eventMode.client.ts: gate first paint on the same-origin bundled snapshot (offline-first), match the host (or ?event= override) to an edition, populate the reactive eventMode singleton + theme, then refresh from the live API in the background so a slow/unreachable API never blocks mount.
- utils/eventManifest.ts: manifest loaders, exact/subdomain host matcher, manifest -> EventModeConfig adapter, and accent-CSS-var theming.
- types/eventFirmware.ts: manifest types mirroring meshtastic/api.
- public/data/event_firmware.json: bundled offline snapshot.
- types/resources.ts: eventMode is now a reactive singleton populated at runtime; Hamcation kept as a static fallback (it has no FirmwareEdition enum).
- LogoHeader.vue: generic theme-driven event header (e.g. DEFCON).
- Firmware.vue: show "coming soon" when an event build has not shipped yet.

# Description

<!-- Please provide a brief description of the changes in this PR -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as appropriate
- [ ] All existing tests pass

---

## Hardware Model Acceptance Policy

### New Hardware Model Acceptance Policy

Due to limited availability and ongoing support, new Hardware Models will only be accepted from [Meshtastic Backers and Partners](https://meshtastic.com/). The Meshtastic team reserves the right to make exceptions to this policy.

#### Alternative for Community Contributors

You are welcome to use one of the existing DIY hardware models in your PlatformIO environment and create a pull request in the firmware project. Please note the following conditions:

- The device will **not** be officially supported by the core Meshtastic team.
- The device will **not** appear in the [Web Flasher](https://flasher.meshtastic.org/) or Github release assets.
- You will be responsible for ongoing maintenance and support.
- Community-contributed / DIY hardware models are considered experimental and will likely have limited or no testing.

#### Getting Official Support

To have your hardware model officially supported and included in the Meshtastic ecosystem, consider becoming a Meshtastic Backer or Partner. Visit [meshtastic.com](https://meshtastic.com/) for more information about partnership opportunities.

---

## Protected Files Notice

**The following files are protected and changes to them will be automatically rejected:**

- `public/data/hardware-list.json` - Auto-generated Hardware definitions (additionally see policy above)
- `types/resources.ts` - Auto-generated resource definitions
- `i18n/locales/**` - Translation files (managed via [Crowdin](https://meshtastic.crowdin.com/web-flasher))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added event-mode branding and theming that can automatically update the UI and tagline per active event.
  * Introduced offline-first event firmware manifests with edition-aware firmware support (including prerelease handling).
  * Added automatic event-mode resolution from the current host, with optional URL override and live refresh in the background.
* **Bug Fixes**
  * Improved firmware dropdown behavior with a “Firmware coming soon” placeholder when details are missing.
  * Fixed edge cases in firmware/event title rendering when some text fields are absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->