### PR TITLE
feat(firmware): konami-gated "Nightly (develop)" firmware option

### DIFF
--- a/components/Firmware.vue
+++ b/components/Firmware.vue
@@ -97,6 +97,27 @@
             </li>
           </ul>
           <div
+            v-if="store.prereleaseUnlocked && store.$state.nightly.length > 0"
+            class="px-4 py-2 text-sm text-cyan-400 font-semibold border-theme-bottom"
+          >
+            {{ $t('firmware.nightly') }}
+          </div>
+          <ul
+            v-if="store.prereleaseUnlocked && store.$state.nightly.length > 0"
+            class="py-2 text-sm text-theme-muted"
+            aria-labelledby="dropdownInformationButton"
+          >
+            <li v-for="release in store.$state.nightly">
+              <a
+                href="#"
+                class="block px-4 py-2 hover:text-meshtastic-dark hover:bg-surface-secondary cursor-pointer transition-colors"
+                @click="setSelectedFirmware(release)"
+              >
+                {{ release.title.replace('Meshtastic Firmware ', '') }}
+              </a>
+            </li>
+          </ul>
+          <div
             v-if="!store.couldntFetchFirmwareApi"
             class="px-4 py-2 text-sm text-warning font-semibold border-theme-bottom border-theme-top"
           >
@@ -199,6 +220,7 @@ const { eventMode } = useEventMode()
 const store = useFirmwareStore()
 const deviceStore = useDeviceStore()
 store.fetchList()
+store.fetchNightly()
 
 const selectedVersion = computed(() => {
   if (store.$state.selectedFirmware?.id) {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -60,6 +60,7 @@
     "stable": "Stable (or Beta)",
     "unstable": "Unstable (Alpha)",
     "prerelease": "Pre-release",
+    "nightly": "Nightly (develop)",
     "coming_soon": "Firmware coming soon",
     "error_fetching": "Could not fetch firmware versions from API.",
     "refresh_later": "Refresh the page later to try again.",

--- a/stores/firmwareStore.ts
+++ b/stores/firmwareStore.ts
@@ -16,7 +16,12 @@ import {
   showPrerelease,
   eventMode,
 } from '~/types/resources'
-import { getFirmwareBaseUrl } from '~/utils/firmwareUrl'
+import {
+  getFirmwareBaseUrl,
+  GITHUB_IO_BASE,
+  NIGHTLY_DIR,
+  setNightlyVersion,
+} from '~/utils/firmwareUrl'
 
 import { track } from '@vercel/analytics'
 import { useSessionStorage } from '@vueuse/core'
@@ -120,6 +125,7 @@ export const useFirmwareStore = defineStore('firmware', {
       stable: new Array<FirmwareResource>(),
       alpha: new Array<FirmwareResource>(),
       previews: previews,
+      nightly: new Array<FirmwareResource>(),
       pullRequests: new Array<FirmwareResource>(),
       prFirmware: <FirmwareResource | undefined>undefined,
       prDeepLinkPending: false,
@@ -228,6 +234,28 @@ export const useFirmwareStore = defineStore('firmware', {
           console.error('Error fetching firmware list:', error)
           this.couldntFetchFirmwareApi = true
         })
+    },
+    /**
+     * Discover the current develop "nightly" build published to
+     * meshtastic.github.io/firmware-nightly/. Only ever surfaced behind the
+     * konami code, and skipped entirely in event mode (never on event firmwares).
+     */
+    async fetchNightly() {
+      if (eventMode.enabled) return
+      try {
+        const response = await fetch(`${GITHUB_IO_BASE}/${NIGHTLY_DIR}/index.json`)
+        if (!response.ok) return // 404 before the first nightly is published -> no section
+        const data = await response.json() as { version: string, id?: string, title?: string }
+        const id = data.id ?? `v${data.version}`
+        setNightlyVersion(id) // register so getManifestBasePath routes it to firmware-nightly/
+        this.nightly = [{
+          id,
+          title: data.title ?? `Meshtastic Firmware ${data.version} Nightly`,
+        }]
+      }
+      catch (error) {
+        console.warn('No nightly build available', error)
+      }
     },
     /**
      * Load a pull request's CI build as a selectable firmware version.

--- a/stores/firmwareStore.ts
+++ b/stores/firmwareStore.ts
@@ -245,12 +245,17 @@ export const useFirmwareStore = defineStore('firmware', {
       try {
         const response = await fetch(`${GITHUB_IO_BASE}/${NIGHTLY_DIR}/index.json`)
         if (!response.ok) return // 404 before the first nightly is published -> no section
-        const data = await response.json() as { version: string, id?: string, title?: string }
-        const id = data.id ?? `v${data.version}`
+        const data = await response.json() as { version?: string, id?: string, title?: string }
+        const id = data.id ?? (data.version ? `v${data.version}` : undefined)
+        if (!id) {
+          console.warn('Nightly index.json missing id/version', data)
+          return // malformed pointer -> don't surface a broken entry
+        }
         setNightlyVersion(id) // register so getManifestBasePath routes it to firmware-nightly/
+        const version = id.replace(/^v/, '')
         this.nightly = [{
           id,
-          title: data.title ?? `Meshtastic Firmware ${data.version} Nightly`,
+          title: data.title ?? `Meshtastic Firmware ${version} Nightly`,
         }]
       }
       catch (error) {

--- a/utils/firmwareUrl.ts
+++ b/utils/firmwareUrl.ts
@@ -1,6 +1,21 @@
+import { reactive } from 'vue'
 import { eventMode } from '~/types/resources'
 
 export const GITHUB_IO_BASE = 'https://raw.githubusercontent.com/meshtastic/meshtastic.github.io/master'
+
+// Single, stable github.io folder that always holds the current develop nightly build.
+export const NIGHTLY_DIR = 'firmware-nightly'
+
+// Nightly (develop) build version, discovered at runtime from
+// firmware-nightly/index.json and only ever surfaced behind the konami code
+// (never in event mode). Reactive so the dropdown re-renders when it resolves;
+// read synchronously below to route this version to the firmware-nightly/ folder.
+export const nightlyState = reactive<{ id: string }>({ id: '' })
+
+/** Record the current nightly firmware version id (e.g. 'v2.8.0.abc1234'). */
+export function setNightlyVersion(id: string): void {
+  nightlyState.id = id
+}
 
 /**
  * Determine the correct base path for a firmware version
@@ -10,6 +25,10 @@ export const GITHUB_IO_BASE = 'https://raw.githubusercontent.com/meshtastic/mesh
  */
 export function getManifestBasePath(version: string): string {
   const cleanVersion = version.replace(/^v/, '')
+  // Nightly (develop) build lives in a single stable folder, not firmware-<version>/
+  if (nightlyState.id && cleanVersion === nightlyState.id.replace(/^v/, '')) {
+    return NIGHTLY_DIR
+  }
   const eventVersion = eventMode.firmware.id.replace(/^v/, '')
   // Check if this is the event firmware version
   if (cleanVersion === eventVersion) {


### PR DESCRIPTION
## What

Adds the develop **nightly** build as its own selectable firmware in the picker, revealed **only by the konami code** (↑↑↓↓←→←→ B A) and **never shown in event mode**.

Companion to the firmware PR [meshtastic/firmware#10957](https://github.com/meshtastic/firmware/pull/10957), which publishes the nightly to `meshtastic.github.io/firmware-nightly/`.

## How

- **`utils/firmwareUrl.ts`** — new `NIGHTLY_DIR = 'firmware-nightly'` and a reactive `nightlyState`. `getManifestBasePath()` routes the nightly version to the single, stable `firmware-nightly/` folder (mirrors how event firmware resolves to `event/<prefix>/…`), so all existing notes/manifest/binary fetch + flash paths work unchanged.
- **`stores/firmwareStore.ts`** — `fetchNightly()` reads `firmware-nightly/index.json` (the version pointer the firmware CI writes) to discover the current develop build. Returns early in event mode, so nightly is never fetched or shown on event firmwares. Registers the version via `setNightlyVersion()`.
- **`components/Firmware.vue`** — calls `fetchNightly()` and renders a distinct **“Nightly (develop)”** section gated on the existing `store.prereleaseUnlocked` konami flag, inside the normal-mode branch only (so it can't appear in event mode).
- **`i18n/locales/en.json`** — `firmware.nightly` source label (other locales sync via Crowdin).

## Notes

- Degrades gracefully: before the first nightly is published, `index.json` 404s and the section is simply absent (no error surfaced to users).
- The `nightlyState` deliberately lives in `utils/firmwareUrl.ts` (not the protected `types/resources.ts`).
- Live konami verification of the happy path awaits the first published nightly from the firmware PR; until then the section renders empty by design.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new **Nightly (develop)** firmware option to the firmware dropdown when prerelease access is available.
  * The firmware panel now loads nightly release data and surfaces nightly builds when available.
  * Nightly selections now open from the correct nightly URL path.
* **Localization**
  * Updated English UI text to include the **Nightly (develop)** label in the firmware options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->