### PR TITLE
feat: add FAB26 Boston to bundled event firmware fallback

### DIFF
--- a/public/data/event_firmware.json
+++ b/public/data/event_firmware.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "generatedAt": "2026-06-30T00:00:00Z",
+  "generatedAt": "2026-07-18T00:00:00Z",
   "source": "bundled",
   "editions": [
     {
@@ -63,6 +63,38 @@
         "title": "Meshtastic Firmware 2.7.26.004b486",
         "zipUrl": "https://github.com/meshtastic/meshtastic.github.io/raw/master/event/opensauce2026/firmware-2.7.26.004b486.zip",
         "releaseNotes": "## Welcome to Open Sauce 2026! 🔧\n\nThis firmware has been customized for Open Sauce with factory default configurations.\n\n### ⚠️ Important: Backup Before Flashing\n\nIf your device has existing settings or encryption keys, **backup your keys / configurations** before proceeding. Flashing will reset your device to factory settings for the event.\n\n### Quick Start\n\n1. Ensure a **data-capable USB cable** is connected\n2. Select your device type\n3. Choose \"Full Erase and Install\"\n4. After flashing, download the Meshtastic app and pair via Bluetooth\n5. If you updated from a previous version or installed a UF2 on an NRF52 device, you will need to perform a factory reset on the device to activate the Open Sauce mode.\n\n**Happy meshing from San Mateo!**"
+      }
+    },
+    {
+      "edition": "FAB",
+      "displayName": "FAB26 Boston",
+      "welcomeMessage": "Welcome to FAB26 Boston! 🛠️",
+      "tag": "FAB26",
+      "eventStart": "2026-07-27",
+      "eventEnd": "2026-07-31",
+      "timeZone": "America/New_York",
+      "location": "MIT, Cambridge, Massachusetts, USA",
+      "iconUrl": "https://api.meshtastic.org/resource/eventFirmware/fab26.png",
+      "accentColor": "#13293D",
+      "domain": "fab26.meshtastic.org",
+      "links": [
+        { "label": "Event Website", "url": "https://fab26.fabevent.org" },
+        { "label": "Fab Foundation", "url": "https://fabfoundation.org" }
+      ],
+      "theme": {
+        "name": "Reimagine the Future",
+        "tagline": "Celebrating 25 years of the Fab Lab Network and reimagining the next 25.",
+        "colors": { "primary": "#13293D", "secondary": "#BF2620", "accent": "#EAB14B" },
+        "palette": ["#13293D", "#BF2620", "#F6F2E8", "#EAB14B", "#D3CABA"],
+        "fonts": { "heading": "Montserrat", "body": "Montserrat" }
+      },
+      "firmware": {
+        "slug": "fab2026",
+        "version": null,
+        "id": null,
+        "title": null,
+        "zipUrl": null,
+        "releaseNotes": null
       }
     },
     {

--- a/public/data/event_firmware.json
+++ b/public/data/event_firmware.json
@@ -76,7 +76,7 @@
       "location": "MIT, Cambridge, Massachusetts, USA",
       "iconUrl": "https://api.meshtastic.org/resource/eventFirmware/fab26.png",
       "accentColor": "#13293D",
-      "domain": "fab26.meshtastic.org",
+      "domain": "fab.meshtastic.org",
       "links": [
         { "label": "Event Website", "url": "https://fab26.fabevent.org" },
         { "label": "Fab Foundation", "url": "https://fabfoundation.org" }


### PR DESCRIPTION
## Summary

Mirrors the **FAB26 Boston** edition into the bundled offline manifest at `public/data/event_firmware.json`, so the event resolves even when the live API (`GET resource/eventFirmware`) is unreachable. Matching is by domain, so no other code changes are needed — the edition flows through the existing dynamic manifest logic.

FAB26 is the International Fab Lab Conference & Symposium — **July 27–31, 2026**, MIT / Cambridge MA. Inserted chronologically between Open Sauce and DEF CON; `generatedAt` bumped. Theme, palette (navy/red/gold from [fab26.fabevent.org](https://fab26.fabevent.org)), and firmware fields are identical to the live manifest.

## Companion PRs

- **api** — adds the `FAB` edition to the live manifest + bundled icon (source of truth).
- **protobufs** — adds `FAB = 20` to the `FirmwareEdition` enum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)