### PR TITLE
feat(fab26): wire in published FAB26 firmware build

### DIFF
--- a/public/data/event_firmware.json
+++ b/public/data/event_firmware.json
@@ -89,12 +89,12 @@
         "fonts": { "heading": "Montserrat", "body": "Montserrat" }
       },
       "firmware": {
-        "slug": "fab2026",
-        "version": null,
-        "id": null,
-        "title": null,
-        "zipUrl": null,
-        "releaseNotes": null
+        "slug": "fab26",
+        "version": "2.7.27.d250d89",
+        "id": "v2.7.27.d250d89",
+        "title": "Meshtastic Firmware 2.7.27.d250d89",
+        "zipUrl": "https://github.com/meshtastic/meshtastic.github.io/raw/master/event/fab26/firmware-2.7.27.d250d89.zip",
+        "releaseNotes": "## Welcome to FAB26 Boston! 🛠️\n\nThis firmware has been customized for FAB26 Boston with factory default configurations.\n\n### ⚠️ Important: Backup Before Flashing\n\nIf your device has existing settings or encryption keys, **backup your keys / configurations** before proceeding. Flashing will reset your device to factory settings for the event.\n\n### Quick Start\n\n1. Ensure a **data-capable USB cable** is connected\n2. Select your device type\n3. Choose \"Full Erase and Install\"\n4. After flashing, download the Meshtastic app and pair via Bluetooth\n5. If you updated from a previous version or installed a UF2 on an NRF52 device, you will need to perform a factory reset on the device to activate the FAB26 mode.\n\n**Happy meshing from Boston!**"
       }
     },
     {


### PR DESCRIPTION
## Summary

Mirrors the live manifest ([api PR](https://github.com/meshtastic/api/pull/106)) into the bundled offline fallback (`public/data/event_firmware.json`), now that the FAB26 Boston build has shipped to [`event/fab26/firmware-2.7.27.d250d89`](https://github.com/meshtastic/meshtastic.github.io/tree/master/event/fab26).

## Changes

- Populates the FAB26 `firmware` block: version `2.7.27.d250d89`, id `v2.7.27.d250d89`, title, zipUrl, event release notes (was `null` / "coming soon").
- **Corrects `slug`** from the provisional `fab2026` to the published **`fab26`**. `utils/firmwareUrl.ts` builds the download path as `event/${pathPrefix}/firmware-${version}`, so the slug must match the real directory.

## Verification

The path the flasher builds resolves: `raw.githubusercontent.com/meshtastic/meshtastic.github.io/master/event/fab26/firmware-2.7.27.d250d89/firmware-2.7.27.d250d89.json` → **200**. Firmware block is byte-identical to the api manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the FAB26 Boston firmware entry with accurate version, download information, identifier, and release notes.
  * Added event-specific Quick Start guidance for firmware version 2.7.27.d250d89.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->