### PR TITLE
feat: unlock 2.8 pre-release builds for everyone

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -412,8 +412,10 @@ window.addEventListener('keydown', (event) => {
 
     konamiCodeIndex.value++
     if (konamiCodeIndex.value === konamiKeys.length) {
-      console.log('Unlocking pre-release section')
-      firmwareStore.$state.prereleaseUnlocked = true
+      // Pre-release and nightly builds are available to everyone now, so the
+      // code only turns on the easter eggs.
+      console.log('Unlocking easter eggs')
+      firmwareStore.$state.konamiUnlocked = true
       document.body.classList.add('konami-code')
       document.getElementById('main')?.classList.add('konami-code')
       document.getElementById('footer')?.classList.add('konami-code')

--- a/components/AlphanautFeedback.vue
+++ b/components/AlphanautFeedback.vue
@@ -298,19 +298,17 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, onMounted, reactive, ref, watch, type Component } from 'vue'
+import { computed, nextTick, onMounted, reactive, ref, type Component } from 'vue'
 import { onKeyStroke, useEventListener } from '@vueuse/core'
 import { Bug, CircleCheck, CircleX, Eye, LoaderCircle, RefreshCw, Send, TriangleAlert, X } from 'lucide-vue-next'
 import { useI18n } from 'vue-i18n'
 import type { AlphanautOutcome, AlphanautReportForm, AppPlatform } from '~/types/alphanaut'
 import { useAlphanautStore } from '~/stores/alphanautStore'
-import { useFirmwareStore } from '~/stores/firmwareStore'
 import { useSerialMonitorStore } from '~/stores/serialMonitorStore'
 import { useToastStore } from '~/stores/toastStore'
 
 const { t } = useI18n()
 const store = useAlphanautStore()
-const firmwareStore = useFirmwareStore()
 const serialMonitorStore = useSerialMonitorStore()
 const toastStore = useToastStore()
 
@@ -475,13 +473,6 @@ async function retryQueued() {
 onMounted(() => {
   const config = useRuntimeConfig()
   store.configure(config.public.feedbackWebhookUrl as string, config.public.feedbackToken as string)
-
-  // Reuse the existing Konami handler (it sets prereleaseUnlocked) to reveal the
-  // tool, and persist that unlock across visits.
-  if (firmwareStore.prereleaseUnlocked) store.unlock()
-  watch(() => firmwareStore.prereleaseUnlocked, (v) => {
-    if (v) store.unlock()
-  })
 
   // Drain any reports queued while offline in a previous session.
   if (store.enabled) {

--- a/components/Firmware.vue
+++ b/components/Firmware.vue
@@ -7,7 +7,7 @@
       id="dropdownFirmwareButton"
       ref="buttonRef"
       class="btn-primary disabled:bg-zinc-600"
-      :class="{ 'animate-bounce': store.prereleaseUnlocked && !store.$state.selectedFirmware?.id }"
+      :class="{ 'animate-bounce': store.konamiUnlocked && !store.$state.selectedFirmware?.id }"
       type="button"
       :disabled="!canSelectFirmware"
       @click.stop="toggleDropdown"
@@ -76,13 +76,13 @@
             </li>
           </ul>
           <div
-            v-if="store.prereleaseUnlocked && store.$state.previews.length > 0"
+            v-if="store.$state.previews.length > 0"
             class="px-4 py-2 text-sm text-meshtastic font-semibold border-theme-bottom"
           >
             {{ $t('firmware.prerelease') }}
           </div>
           <ul
-            v-if="store.prereleaseUnlocked && store.$state.previews.length > 0"
+            v-if="store.$state.previews.length > 0"
             class="py-2 text-sm text-theme-muted"
             aria-labelledby="dropdownInformationButton"
           >
@@ -97,13 +97,13 @@
             </li>
           </ul>
           <div
-            v-if="store.prereleaseUnlocked && store.$state.nightly.length > 0"
+            v-if="store.$state.nightly.length > 0"
             class="px-4 py-2 text-sm text-cyan-400 font-semibold border-theme-bottom"
           >
             {{ $t('firmware.nightly') }}
           </div>
           <ul
-            v-if="store.prereleaseUnlocked && store.$state.nightly.length > 0"
+            v-if="store.$state.nightly.length > 0"
             class="py-2 text-sm text-theme-muted"
             aria-labelledby="dropdownInformationButton"
           >

--- a/components/Flash.vue
+++ b/components/Flash.vue
@@ -45,7 +45,7 @@
             <div class="modal-content relative flex flex-col max-h-[90vh] overflow-hidden rounded-2xl shadow-2xl text-theme">
               <!-- Chirpy Bouncing Background -->
               <video
-                v-if="firmwareStore.isFlashing && firmwareStore.$state.prereleaseUnlocked"
+                v-if="firmwareStore.isFlashing && firmwareStore.$state.konamiUnlocked"
                 autoplay
                 loop
                 muted
@@ -76,7 +76,7 @@
             <div class="modal-content relative flex flex-col max-h-[90vh] overflow-hidden rounded-2xl shadow-2xl text-theme">
               <!-- Chirpy Bouncing Background -->
               <video
-                v-if="firmwareStore.isFlashing && firmwareStore.$state.prereleaseUnlocked"
+                v-if="firmwareStore.isFlashing && firmwareStore.$state.konamiUnlocked"
                 autoplay
                 loop
                 muted

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -37,7 +37,7 @@ export default defineNuxtConfig({
       datadogClientToken: process.env.DATADOG_CLIENT_TOKEN || '',
       datadogEnv: process.env.NODE_ENV || 'production',
       cookieyesClientId: process.env.COOKIEYES_CLIENT_ID || '',
-      // Alphanaut feedback tool (hidden bug reporter). Empty URL = feature disabled.
+      // Alphanaut feedback tool (2.8 bug reporter). Empty URL = feature disabled.
       feedbackWebhookUrl: process.env.FEEDBACK_WEBHOOK_URL || '',
       // NOTE: public runtime config ships in the browser bundle, so this token is
       // intentionally NOT a secret — it is only a best-effort speed-bump against

--- a/stores/alphanautStore.test.ts
+++ b/stores/alphanautStore.test.ts
@@ -58,11 +58,10 @@ beforeEach(() => {
 })
 
 describe('visibility gate', () => {
-  it('is visible only when enabled + unlocked + a 2.8 firmware is selected', () => {
+  it('is visible when enabled + a 2.8 firmware is selected', () => {
     const store = useAlphanautStore()
     fakeFirmware.selectedFirmware = { id: 'v2.8.0.abc' }
     store.configure('https://x/exec', '')
-    store.unlock()
 
     expect(store.currentVersion).toBe('2.8.0.abc')
     expect(store.isTargetVersion).toBe(true)
@@ -73,7 +72,6 @@ describe('visibility gate', () => {
     const store = useAlphanautStore()
     fakeFirmware.selectedFirmware = { id: 'v2.7.9.abc' }
     store.configure('https://x/exec', '')
-    store.unlock()
     expect(store.isTargetVersion).toBe(false)
     expect(store.isVisible).toBe(false)
   })
@@ -82,16 +80,7 @@ describe('visibility gate', () => {
     const store = useAlphanautStore()
     fakeFirmware.selectedFirmware = { id: 'v2.8.0.abc' }
     store.configure('', '')
-    store.unlock()
     expect(store.enabled).toBe(false)
-    expect(store.isVisible).toBe(false)
-  })
-
-  it('hides while locked', () => {
-    const store = useAlphanautStore()
-    fakeFirmware.selectedFirmware = { id: 'v2.8.0.abc' }
-    store.configure('https://x/exec', '')
-    expect(store.unlocked).toBe(false)
     expect(store.isVisible).toBe(false)
   })
 
@@ -99,7 +88,6 @@ describe('visibility gate', () => {
     const store = useAlphanautStore()
     fakeFirmware.selectedFirmware = { id: '', prBuild: { version: '2.8.0', prNumber: 42 } }
     store.configure('https://x/exec', '')
-    store.unlock()
     expect(store.currentVersion).toBe('2.8.0')
     expect(store.isTargetVersion).toBe(true)
   })

--- a/stores/alphanautStore.ts
+++ b/stores/alphanautStore.ts
@@ -34,13 +34,11 @@ export type SubmitOutcome
     | { status: 'rejected', error?: string }
 
 /**
- * State + orchestration for the hidden alphanaut feedback tool. Reads live
+ * State + orchestration for the alphanaut feedback tool. Reads live
  * device/firmware/serial state; never writes to any core flasher store.
  */
 export const useAlphanautStore = defineStore('alphanaut', {
   state: () => ({
-    // Persists across visits — once Konami reveals the tool it stays revealed.
-    unlocked: useLocalStorage('alphanautUnlocked', false),
     queue: useLocalStorage<QueuedSubmission[]>('alphanautQueue', []),
     flushing: false,
     endpoint: '',
@@ -61,9 +59,9 @@ export const useAlphanautStore = defineStore('alphanaut', {
       return isAlphanautVersion(this.currentVersion)
     },
 
-    /** The badge shows only when enabled + Konami-unlocked + a 2.8 build is selected. */
+    /** The badge shows whenever the tool is enabled and a 2.8 build is selected. */
     isVisible(): boolean {
-      return this.enabled && this.unlocked && this.isTargetVersion
+      return this.enabled && this.isTargetVersion
     },
 
     /**
@@ -95,11 +93,6 @@ export const useAlphanautStore = defineStore('alphanaut', {
     configure(url: string | undefined, token: string | undefined) {
       this.endpoint = url ?? ''
       this.token = token ?? ''
-    },
-
-    /** Latch the persistent unlock flag (called when Konami fires). */
-    unlock() {
-      this.unlocked = true
     },
 
     /** Snapshot the live firmware + hardware context when the panel opens. */

--- a/stores/firmwareStore.ts
+++ b/stores/firmwareStore.ts
@@ -152,7 +152,8 @@ export const useFirmwareStore = defineStore('firmware', {
       isConnected: false,
       port: <SerialPort | undefined>{},
       couldntFetchFirmwareApi: false,
-      prereleaseUnlocked: useSessionStorage('prereleaseUnlocked', false),
+      // Konami code easter eggs (retro theme + chirpy flash background) only.
+      konamiUnlocked: useSessionStorage('konamiUnlocked', false),
       hasManifest: false,
       manifest: <FirmwareManifest | undefined>undefined,
       releaseManifest: <ReleaseManifest | undefined>undefined,
@@ -237,8 +238,8 @@ export const useFirmwareStore = defineStore('firmware', {
     },
     /**
      * Discover the current develop "nightly" build published to
-     * meshtastic.github.io/firmware-nightly/. Only ever surfaced behind the
-     * konami code, and skipped entirely in event mode (never on event firmwares).
+     * meshtastic.github.io/firmware-nightly/. Skipped entirely in event mode
+     * (never on event firmwares).
      */
     async fetchNightly() {
       if (eventMode.enabled) return

--- a/types/alphanaut.ts
+++ b/types/alphanaut.ts
@@ -1,4 +1,4 @@
-// Types for the alphanaut feedback tool (hidden bug reporter for the 2.8
+// Types for the alphanaut feedback tool (bug reporter for the 2.8
 // pre-release testing group). Self-contained: nothing here is imported by core
 // flasher code. See stores/alphanautStore.ts and utils/alphanautSubmit.ts.
 

--- a/utils/firmwareUrl.ts
+++ b/utils/firmwareUrl.ts
@@ -7,9 +7,9 @@ export const GITHUB_IO_BASE = 'https://raw.githubusercontent.com/meshtastic/mesh
 export const NIGHTLY_DIR = 'firmware-nightly'
 
 // Nightly (develop) build version, discovered at runtime from
-// firmware-nightly/index.json and only ever surfaced behind the konami code
-// (never in event mode). Reactive so the dropdown re-renders when it resolves;
-// read synchronously below to route this version to the firmware-nightly/ folder.
+// firmware-nightly/index.json (never surfaced in event mode). Reactive so the
+// dropdown re-renders when it resolves; read synchronously below to route this
+// version to the firmware-nightly/ folder.
 export const nightlyState = reactive<{ id: string }>({ id: '' })
 
 /** Record the current nightly firmware version id (e.g. 'v2.8.0.abc1234'). */


### PR DESCRIPTION
Anyone can now flash 2.8 builds without knowing the konami code.

## What changed

- **Pre-release section** — no longer gated on the konami unlock. It renders whenever the API returns a `Preview` release (still empty today, so this takes effect the moment a 2.8 Preview is published).
- **Nightly (develop) section** — no longer gated either. This is where 2.8 actually lives right now (`v2.8.0.5ded0ec`), so this is the visible part of the change.
- **Alphanaut feedback reporter** — shows whenever a 2.8 build is selected, instead of additionally requiring the konami unlock. Testers can now report bugs on the builds they just got access to. The empty-webhook kill switch (`FEEDBACK_WEBHOOK_URL`) is untouched, and its own `alphanautUnlocked` localStorage latch is removed as dead state.
- **Konami code still works** — it now only turns on the easter eggs (retro theme + chirpy flash background), so `firmwareStore.prereleaseUnlocked` is renamed to `konamiUnlocked` to match what it actually gates. Comments claiming these builds are konami-only are updated.

## Verification

Ran locally against the live API with a fresh session (`sessionStorage.konamiUnlocked === "false"`, no `konami-code` class on body):

- The dropdown lists **Nightly (develop) → 2.8.0.5ded0ec Nightly** at the top with no key sequence entered.
- Selecting it surfaces the **Feedback** badge (dev server started with a dummy `FEEDBACK_WEBHOOK_URL`; with the var unset the badge stays dark as before).
- No console errors.

`npm run test:run` — 135 passed / 10 files. The alphanaut visibility-gate tests were updated to drop the unlock step, and the now-meaningless `hides while locked` case was removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Konami Code to unlock easter eggs, including retro visuals and enhanced flash-screen effects.
  * Preview and nightly firmware sections now appear when firmware is available.
  * The feedback tool is available automatically for supported firmware versions.

* **Bug Fixes**
  * Improved feedback-tool visibility and disabled it correctly when its service endpoint is unavailable.

* **Documentation**
  * Clarified descriptions for the feedback tool, firmware channels, and easter egg behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->