### PR TITLE
feat: update DEF CON 34 firmware to 2.8.0.8adc7c3

### DIFF
--- a/public/data/event_firmware.json
+++ b/public/data/event_firmware.json
@@ -123,11 +123,11 @@
       },
       "firmware": {
         "slug": "defcon34",
-        "version": "2.8.0.b00d76f",
-        "id": "v2.8.0.b00d76f",
-        "title": "Meshtastic Firmware 2.8.0.b00d76f",
-        "zipUrl": "https://github.com/meshtastic/meshtastic.github.io/raw/master/event/defcon34/firmware-2.8.0.b00d76f.zip",
-        "releaseNotes": "> ⚠️ **Preview Build:** This is a preview release for DEF CON 34 and may change before the event.\n\n## Welcome to DEF CON 34! 💀\n\nThis firmware has been customized for DEF CON 34 with factory default configurations.\n\n### ⚠️ Important: Backup Before Flashing\n\nIf your device has existing settings or encryption keys, **backup your keys / configurations** before proceeding. Flashing will reset your device to factory settings for the event.\n\n### Quick Start\n\n1. Ensure a **data-capable USB cable** is connected\n2. Select your device type\n3. Choose \"Full Erase and Install\"\n4. After flashing, download the Meshtastic app and pair via Bluetooth\n5. If you updated from a previous version or installed a UF2 on an NRF52 device, you will need to perform a factory reset on the device to activate the DEF CON mode.\n\n**Happy meshing from Las Vegas!**"
+        "version": "2.8.0.8adc7c3",
+        "id": "v2.8.0.8adc7c3",
+        "title": "Meshtastic Firmware 2.8.0.8adc7c3",
+        "zipUrl": "https://github.com/meshtastic/meshtastic.github.io/raw/master/event/defcon34/firmware-2.8.0.8adc7c3.zip",
+        "releaseNotes": "## Welcome to DEF CON 34! 💀\n\nThis firmware has been customized for DEF CON 34 with factory default configurations.\n\n### ⚠️ Important: Backup Before Flashing\n\nIf your device has existing settings or encryption keys, **backup your keys / configurations** before proceeding. Flashing will reset your device to factory settings for the event.\n\n### Quick Start\n\n1. Ensure a **data-capable USB cable** is connected\n2. Select your device type\n3. Choose \"Full Erase and Install\"\n4. After flashing, download the Meshtastic app and pair via Bluetooth\n5. If you updated from a previous version or installed a UF2 on an NRF52 device, you will need to perform a factory reset on the device to activate the DEF CON mode.\n\n**Happy meshing from Las Vegas!**"
       }
     },
     {


### PR DESCRIPTION
Points the DEF CON 34 edition at the newly published build:
[`event/defcon34/firmware-2.8.0.8adc7c3`](https://github.com/meshtastic/meshtastic.github.io/tree/master/event/defcon34/firmware-2.8.0.8adc7c3) (was `2.8.0.b00d76f`).

- `version` / `id` / `title` / `zipUrl` bumped to `2.8.0.8adc7c3`
- **Preview-build warning removed** from the release notes — this is the real event build, so the notes now open with `## Welcome to DEF CON 34! 💀` exactly like every other edition's do

The `slug` stays `defcon34`, so the flasher's derived path `event/{slug}/firmware-{version}` resolves to the new directory. Verified live before opening: the manifest the flasher fetches (`firmware-2.8.0.8adc7c3.json`) and a sample device artifact (`firmware-heltec-v3-2.8.0.8adc7c3.factory.bin`) both return 200 from `raw.githubusercontent.com`.

Companion PR keeps the API manifest and the flasher's bundled fallback copy in sync.

Note (pre-existing, not changed here): the `zipUrl` convention — `event/{slug}/firmware-{version}.zip` — 404s for *every* edition, since github.io stores these builds as directories rather than a single zip. It's carried forward as-is; worth a separate cleanup if nothing consumes it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated DEF CON 34 firmware metadata, including the version, identifier, title, and download link.
  * Refreshed the release notes to reflect the newer firmware and removed the preview-build notice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->