### PR TITLE
Disable erase UF2 flow for Seeed MeshTracker X1

### DIFF
--- a/components/Flash.vue
+++ b/components/Flash.vue
@@ -10,7 +10,7 @@
       {{ $t('flash.title') }}
     </button>
     <button
-      v-show="['nrf52840', 'rp2040'].includes(deviceStore.selectedArchitecture)"
+      v-show="deviceStore.supportsUf2Erase"
       data-tooltip-target="tooltip-erase"
       class="btn-icon mx-2"
       type="button"
@@ -90,7 +90,7 @@
                 :title-override="`${$t('flash.erase_flash')} ${deviceStore.$state.selectedTarget?.displayName || ''}`"
               />
               <div class="flex-1 overflow-y-auto p-3 sm:p-4 relative z-10">
-                <TargetsEraseUf2 v-if="['nrf52840', 'rp2040'].includes(deviceStore.selectedArchitecture)" />
+                <TargetsEraseUf2 v-if="deviceStore.supportsUf2Erase" />
               </div>
             </div>
           </div>

--- a/stores/deviceStore.ts
+++ b/stores/deviceStore.ts
@@ -95,6 +95,15 @@ export const useDeviceStore = defineStore('device', {
       const sd73Devices = ['WIO_WM1110', 'TRACKER_T1000_E', 'XIAO_NRF52_KIT', 'SEEED_SOLAR_NODE', 'SEEED_WIO_TRACKER_L1', 'SEEED_WIO_TRACKER_L1_EINK']
       return sd73Devices.includes(this.selectedTarget?.hwModelSlug || '')
     },
+    /**
+     * UF2 erase is offered for nRF52840/RP2040 targets, minus devices where the
+     * erase UF2 is not safe to use.
+     */
+    supportsUf2Erase(): boolean {
+      const noEraseUf2Devices = ['MESH_TRACKER_X1']
+      return ['nrf52840', 'rp2040'].includes(this.selectedArchitecture)
+        && !noEraseUf2Devices.includes(this.selectedTarget?.hwModelSlug || '')
+    },
     enterDfuVersion(): string {
       if (this.isSelectedNrf) {
         return '2.2.17'


### PR DESCRIPTION
Turns off the erase UF2 option for the Seeed MeshTracker X1.

## Changes

- New `supportsUf2Erase` getter in `stores/deviceStore.ts` — the existing `nrf52840`/`rp2040` architecture check, minus an opt-out list of hardware slugs (currently just `MESH_TRACKER_X1`).
- `components/Flash.vue` gates both the erase (trash) button and the `TargetsEraseUf2` modal body on that getter, so the flow isn't reachable even by targeting the modal directly.

Flashing is untouched — `TargetsUf2` and the preflight file check still key off architecture.

## Testing

Verified locally against the dev server. The X1 is currently `activelySupported: false` in `hardware-list.json` so it's filtered out of the picker; I temporarily flipped that flag to exercise the UI and reverted it (no change to that file in this PR).

- X1 selected: erase button `display: none`, erase modal body contains only its header — no DFU steps, no UF2 download link. Flash modal still shows the full UF2 flash flow.
- Seeed Wio Tracker L1 (control, same architecture): erase button visible, erase modal still serves `/uf2/nrf_erase_sd7_3.uf2`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the erase controls to appear only on devices that support UF2 erase.
  * Prevented erase options from being shown for unsupported device architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->