### PR TITLE
fix: use manifest-driven flashing in event mode

### DIFF
--- a/stores/firmwareStore.eventMode.test.ts
+++ b/stores/firmwareStore.eventMode.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { eventMode, setActiveEventMode } from '~/types/resources'
+import { setGlobalI18n } from '~/utils/i18n'
+import { useFirmwareStore } from './firmwareStore'
+
+// The store module reads window.location at import time (createUrl).
+// vi.hoisted runs before the imports above are evaluated.
+vi.hoisted(() => {
+  (globalThis as any).window = { location: { host: 'localhost:3000', protocol: 'https:' } }
+})
+
+const EVENT_VERSION = '2.8.0.c800fc8'
+const EVENT_BASE = `https://raw.githubusercontent.com/meshtastic/meshtastic.github.io/master/event/defcon34/firmware-${EVENT_VERSION}`
+
+const RELEASE_MANIFEST = {
+  version: EVENT_VERSION,
+  targets: [
+    { board: 'tlora-t3s3-epaper', platform: 'esp32s3' },
+  ],
+}
+
+const fetchMock = vi.fn()
+vi.stubGlobal('fetch', fetchMock)
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status })
+}
+
+/** Snapshot of the module-level eventMode singleton, restored after each test. */
+const defaultEventMode = { ...eventMode }
+
+function enableDefconEventMode() {
+  setActiveEventMode({
+    enabled: true,
+    eventName: 'DEF CON 34',
+    eventTag: 'DEFCON',
+    pathPrefix: 'defcon34',
+    domain: 'defcon.meshtastic.org',
+    firmware: {
+      id: `v${EVENT_VERSION}`,
+      title: `Meshtastic Firmware ${EVENT_VERSION}`,
+      release_notes: 'Welcome to DEF CON',
+    },
+  })
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  setGlobalI18n({ t: (key: string) => key })
+  fetchMock.mockReset()
+})
+
+afterEach(() => {
+  setActiveEventMode(defaultEventMode as any)
+})
+
+describe('firmwareStore event mode', () => {
+  it('resolves the locked firmware so the release manifest loads', async () => {
+    enableDefconEventMode()
+    fetchMock.mockResolvedValueOnce(jsonResponse(RELEASE_MANIFEST))
+
+    const store = useFirmwareStore()
+    await store.fetchList()
+
+    // Only the release manifest — the firmware list API is never called in event mode
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledWith(`${EVENT_BASE}/firmware-${EVENT_VERSION}.json`)
+    expect(store.releaseManifest).toEqual(RELEASE_MANIFEST)
+    expect(store.selectedFirmware?.id).toBe(`v${EVENT_VERSION}`)
+  })
+
+  it('does not re-resolve the locked firmware once the manifest is loaded', async () => {
+    enableDefconEventMode()
+    fetchMock.mockResolvedValueOnce(jsonResponse(RELEASE_MANIFEST))
+
+    const store = useFirmwareStore()
+    await store.fetchList()
+    await store.fetchList()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves the release manifest alone when the event build has not shipped yet', async () => {
+    setActiveEventMode({
+      enabled: true,
+      eventName: 'DEF CON 34',
+      eventTag: 'DEFCON',
+      pathPrefix: '',
+      domain: 'defcon.meshtastic.org',
+      firmware: { id: '', title: 'DEF CON 34' },
+    })
+
+    const store = useFirmwareStore()
+    await store.fetchList()
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(store.releaseManifest).toBeUndefined()
+  })
+})
+
+describe('firmwareStore file getters', () => {
+  it('are false rather than throwing before a file is picked', () => {
+    const store = useFirmwareStore()
+
+    expect(store.selectedFile).toBeUndefined()
+    expect(store.hasFirmwareFile).toBe(false)
+    expect(store.isZipFile).toBe(false)
+    expect(store.isFactoryBin).toBe(false)
+  })
+
+  it('classifies a picked file by name', async () => {
+    const store = useFirmwareStore()
+
+    await store.setFirmwareFile(new File([''], 'firmware-2.8.0.zip'))
+    expect(store.isZipFile).toBe(true)
+    expect(store.isFactoryBin).toBe(false)
+
+    await store.setFirmwareFile(new File([''], 'firmware-tlora-t3s3-epaper-2.8.0.factory.bin'))
+    expect(store.isZipFile).toBe(false)
+    expect(store.isFactoryBin).toBe(true)
+  })
+})
+
+describe('fetchBinaryContent', () => {
+  it('throws instead of flashing the body of a failed download', async () => {
+    const store = useFirmwareStore()
+    store.selectedFirmware = { id: `v${EVENT_VERSION}`, title: 'test' }
+    enableDefconEventMode()
+    fetchMock.mockResolvedValueOnce(new Response('404: Not Found', { status: 404 }))
+
+    await expect(store.fetchBinaryContent('bleota-s3.bin')).rejects.toThrow(/HTTP 404/)
+  })
+})

--- a/stores/firmwareStore.ts
+++ b/stores/firmwareStore.ts
@@ -136,7 +136,7 @@ export const useFirmwareStore = defineStore('firmware', {
       // previous selection can detect they are stale and skip store writes
       prGeneration: 0,
       selectedFirmware: eventMode.enabled ? eventMode.firmware : <FirmwareResource | undefined>{},
-      selectedFile: <File | undefined>{},
+      selectedFile: <File | undefined>undefined,
       baudRate: 115200,
       hasSeenReleaseNotes: false,
       shouldCleanInstall: false,
@@ -178,8 +178,11 @@ export const useFirmwareStore = defineStore('firmware', {
     percentDone: state => `${state.flashPercentDone}%`,
     firmwareVersion: state => state.selectedFirmware?.id ? state.selectedFirmware.id.replace('v', '') : '.+',
     canShowFlash: state => state.selectedFirmware?.id ? state.hasSeenReleaseNotes : true,
-    isZipFile: state => state.selectedFile?.name.endsWith('.zip'),
-    isFactoryBin: state => state.selectedFile?.name.endsWith('.factory.bin'),
+    // Guard the name too, not just the file: a File is only ever set from a real
+    // upload, but reading these before one exists must not throw — they are
+    // evaluated from watchers and render (see components/targets/Esp32.vue).
+    isZipFile: state => (state.selectedFile?.name || '').endsWith('.zip'),
+    isFactoryBin: state => (state.selectedFile?.name || '').endsWith('.factory.bin'),
   },
   actions: {
     clearState() {
@@ -197,9 +200,18 @@ export const useFirmwareStore = defineStore('firmware', {
       // Skip fetching firmware list in event mode - use locked firmware only
       if (eventMode.enabled) {
         console.log('Event mode enabled, skipping firmware API fetch')
+        // The locked build is pre-seeded into state, so setSelectedFirmware()
+        // never runs for it — and that is the only place the release manifest is
+        // fetched. Without it every event flash falls through to the legacy
+        // convention-based path, which uses stale partition offsets and asks for
+        // bleota*.bin (gone since 2.8). Resolve it here so event domains take the
+        // same manifest-driven path as flash.meshtastic.org.
+        if (eventMode.firmware?.id && !this.releaseManifest) {
+          await this.setSelectedFirmware(eventMode.firmware)
+        }
         return
       }
-      
+
       firmwareApi.get<FirmwareReleases>()
         .then(async (response: FirmwareReleases) => {
           // Fetch release notes for each firmware version from meshtastic.github.io
@@ -1034,7 +1046,14 @@ export const useFirmwareStore = defineStore('firmware', {
       }
       if (this.selectedFirmware?.id) {
         const baseUrl = getFirmwareBaseUrl(this.selectedFirmware.id)
-        const response = await fetch(`${baseUrl}/${fileName}`)
+        const url = `${baseUrl}/${fileName}`
+        const response = await fetch(url)
+        // Without this a 404 body ("404: Not Found") is happily flashed to the
+        // partition as a 14-byte payload — silently corrupting it instead of
+        // failing the flash.
+        if (!response.ok) {
+          throw new Error(`Could not download ${fileName} (HTTP ${response.status} from ${url})`)
+        }
         const blob = await response.blob()
         const data = await blob.arrayBuffer()
         return convertToBinaryString(new Uint8Array(data))


### PR DESCRIPTION
## Problem

Event domains (defcon.meshtastic.org et al.) were flashing devices into a boot loop. From a DEF CON flash log on a T-LoRa T3-S3 e-paper:

```
Wrote 16 bytes (24 compressed) at 0x260000     <- the string "404: Not Found"
Wrote 786432 bytes at 0x300000                 <- littlefs, wrong offset
Hard resetting via RTS pin...
Guru Meditation Error: Core 1 panic'ed (IntegerDivideByZero)
```

The build's actual partition table (`firmware-tlora-t3s3-epaper-2.8.0.c800fc8.mt.json`) puts `flashApp` at `0x2A0000` and `spiffs` at `0x340000`, so the filesystem image straddled the two — the spiffs partition ended up holding the middle of a littlefs image rather than a valid one.

Three defects chained:

1. **Event mode never loaded the release manifest.** `setSelectedFirmware()` is the only place `releaseManifest` is fetched, and event mode pre-seeds `selectedFirmware` straight into store state instead of calling it. No release manifest means `loadTargetManifest()` never runs, so every event flash fell through to the legacy convention-based path. Regular releases on flash.meshtastic.org always resolve a manifest, which is why this only showed up on an event domain.
2. **`fetchBinaryContent()` never checked `response.ok`.** The legacy path asks for `bleota-s3.bin`, which exists in no currently-published build (renamed `mt-esp32s3-ota.bin` — verified 404 across 2.7.23, 2.7.24, 2.7.26, nightly and the DEF CON build). The 404 body was converted to a binary string and flashed as the OTA payload.
3. **`isZipFile` / `isFactoryBin` threw before a file was picked.** `selectedFile` defaulted to `{}`, so `.name.endsWith()` raised `TypeError: Cannot read properties of undefined`. It fired from the `shouldCleanInstall` watcher in `components/targets/Esp32.vue`, killing the check that decides whether "Bundle WebUI" is offered.

## Changes

- `fetchList()` resolves the locked event firmware through `setSelectedFirmware()` so event domains take the same manifest-driven path as flash.meshtastic.org.
- `fetchBinaryContent()` throws on a non-OK response instead of flashing the error body.
- `selectedFile` defaults to `undefined`; both getters are name-safe.

## Verification

Local dev server at `?event=DEFCON` (same bundled manifest production resolves): the store loads the 140-target DEF CON release manifest, both getters return `false` instead of throwing, and `loadTargetManifest('tlora-t3s3-epaper')` resolves the correct flash plan.

| file | offset | before |
| --- | --- | --- |
| `firmware-tlora-t3s3-epaper-2.8.0.c800fc8.factory.bin` | `0x0` | `0x0` |
| `mt-esp32s3-ota.bin` | `0x2A0000` | 404 body at `0x260000` |
| `littlefs-tlora-t3s3-epaper-2.8.0.c800fc8.bin` | `0x340000` | `0x300000` |

New `stores/firmwareStore.eventMode.test.ts` covers event-mode manifest resolution, the getters, and the failed-download guard. Full suite: 164 passing.

Once deployed, "Full erase and install" recovers devices already flashed with the bad offsets.

## Not covered here

- `api.meshtastic.org` returns HTTP 500 with no `Access-Control-Allow-Origin` for `Origin: https://defcon.meshtastic.org`, while `https://flash.meshtastic.org` gets a 204 with the header. Event subdomains need adding to the API's CORS allowlist — no client-side fix. Cosmetic today since `deviceStore.fetchList()` falls back to the bundled `hardware-list.json`.
- The legacy path still references `bleota*.bin`. Those files exist in no published build, so it can now only fail loudly rather than corrupt a partition. Left alone since that path exists to serve older releases, but it is worth revisiting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Event mode now loads the correct locked firmware release information.
  * Failed firmware downloads are rejected instead of being processed as valid files.
  * Firmware file details now remain stable when no file has been selected.

* **Tests**
  * Added coverage for event-mode firmware resolution and caching.
  * Added tests for missing firmware, file selection states, and failed downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->