### PR TITLE
feat: update Burning Man 2026 event firmware

### DIFF
--- a/public/data/event_firmware.json
+++ b/public/data/event_firmware.json
@@ -143,6 +143,7 @@
       "accentColor": "#EC8819",
       "domain": "burn.meshtastic.org",
       "links": [
+        { "label": "Burning Man Firmware Flasher", "url": "https://burn.meshtastic.org" },
         { "label": "Quick Start Guide", "url": "https://docs.burningmesh.org/en/guides/quick_start" },
         { "label": "Android Offline Maps", "url": "https://docs.burningmesh.org/en/offline_maps/android_offline_maps" },
         { "label": "iOS Offline Maps", "url": "https://docs.burningmesh.org/en/offline_maps/ios_offline_maps" },
@@ -162,7 +163,7 @@
         "id": "v2.8.0.1cf8338",
         "title": "Meshtastic Firmware 2.8.0.1cf8338",
         "zipUrl": null,
-        "releaseNotes": "## Welcome to Burning Man 2026!\n\nThis Burning Mesh firmware includes event defaults tuned for Black Rock City, including the SHORT_TURBO modem preset, frequency slot 33, an Everyone channel, event routing limits, and location-sharing protections on the event channel.\n\n### ⚠️ Important: Backup Before Flashing\n\nIf you care about what is currently stored on your node, back up your keys and configuration before proceeding. A full erase is not required for a normal update, but installation and reset choices can replace saved configuration.\n\nIf you updated from a previous version or installed a UF2 on an nRF52 device, perform a factory reset to activate Burning Man mode.\n\n### Learn More\n\n- [Quick Start Guide](https://docs.burningmesh.org/en/guides/quick_start)\n- [Android Offline Maps](https://docs.burningmesh.org/en/offline_maps/android_offline_maps)\n- [iOS Offline Maps](https://docs.burningmesh.org/en/offline_maps/ios_offline_maps)\n- [Burning Mesh Discord](https://discord.gg/eXUBcCEJuH)"
+        "releaseNotes": "## Welcome to Burning Man 2026!\n\n### ⚠️ Flash the Latest 2026 Firmware\n\nFlash your node with the latest Burning Man 2026 firmware before joining the mesh. Burning Mesh firmware from previous years is not compatible with the 2026 mesh. Use the [Burning Man Firmware Flasher](https://burn.meshtastic.org) to install the current release.\n\nThis Burning Mesh firmware includes event defaults tuned for Black Rock City, including the SHORT_TURBO modem preset, frequency slot 33, an Everyone channel, event routing limits, and location-sharing protections on the event channel.\n\n### ⚠️ Important: Backup Before Flashing\n\nIf you care about what is currently stored on your node, back up your keys and configuration before proceeding. A full erase is not required for a normal update, but installation and reset choices can replace saved configuration.\n\nIf you updated from a previous version or installed a UF2 on an nRF52 device, perform a factory reset to activate Burning Man mode.\n\n### Learn More\n\n- [Burning Man Firmware Flasher](https://burn.meshtastic.org)\n- [Quick Start Guide](https://docs.burningmesh.org/en/guides/quick_start)\n- [Android Offline Maps](https://docs.burningmesh.org/en/offline_maps/android_offline_maps)\n- [iOS Offline Maps](https://docs.burningmesh.org/en/offline_maps/ios_offline_maps)\n- [Burning Mesh Discord](https://discord.gg/eXUBcCEJuH)"
       }
     }
   ]

--- a/public/data/event_firmware.json
+++ b/public/data/event_firmware.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "generatedAt": "2026-07-18T00:00:00Z",
+  "generatedAt": "2026-08-13T00:00:00Z",
   "source": "bundled",
   "editions": [
     {
@@ -133,32 +133,36 @@
     {
       "edition": "BURNING_MAN",
       "displayName": "Burning Man 2026",
-      "welcomeMessage": "Welcome to Burning Man! 🔥",
+      "welcomeMessage": "Welcome to Burning Man 2026!",
       "tag": "Burning Man",
-      "eventStart": "2026-08-30",
+      "eventStart": "2026-08-28",
       "eventEnd": "2026-09-07",
       "timeZone": "America/Los_Angeles",
       "location": "Black Rock City, Nevada, USA",
-      "iconUrl": null,
+      "iconUrl": "https://api.meshtastic.org/resource/eventFirmware/burningman2026.png",
       "accentColor": "#EC8819",
-      "domain": "burningman.meshtastic.org",
+      "domain": "burn.meshtastic.org",
       "links": [
+        { "label": "Quick Start Guide", "url": "https://docs.burningmesh.org/en/guides/quick_start" },
+        { "label": "Android Offline Maps", "url": "https://docs.burningmesh.org/en/offline_maps/android_offline_maps" },
+        { "label": "iOS Offline Maps", "url": "https://docs.burningmesh.org/en/offline_maps/ios_offline_maps" },
+        { "label": "Burning Mesh Discord", "url": "https://discord.gg/eXUBcCEJuH" },
         { "label": "Event Website", "url": "https://burningman.org" }
       ],
       "theme": {
         "name": "Axis Mundi",
-        "tagline": "The axis of the world — a celestial column connecting earth, sky, and the realms between.",
-        "colors": { "primary": "#EC8819", "secondary": null, "accent": null },
-        "palette": ["#EC8819"],
-        "fonts": null
+        "tagline": "Rooted in our shared past, branching into possibility.",
+        "colors": { "primary": "#111111", "secondary": "#F2F2F2", "accent": "#EC8819" },
+        "palette": ["#111111", "#F2F2F2", "#EC8819"],
+        "fonts": { "heading": "Lato", "body": "Atkinson Hyperlegible" }
       },
       "firmware": {
-        "slug": "burningman2026",
-        "version": null,
-        "id": null,
-        "title": null,
+        "slug": "burningmesh2026",
+        "version": "2.8.0.1cf8338",
+        "id": "v2.8.0.1cf8338",
+        "title": "Meshtastic Firmware 2.8.0.1cf8338",
         "zipUrl": null,
-        "releaseNotes": null
+        "releaseNotes": "## Welcome to Burning Man 2026!\n\nThis Burning Mesh firmware includes event defaults tuned for Black Rock City, including the SHORT_TURBO modem preset, frequency slot 33, an Everyone channel, event routing limits, and location-sharing protections on the event channel.\n\n### ⚠️ Important: Backup Before Flashing\n\nIf you care about what is currently stored on your node, back up your keys and configuration before proceeding. A full erase is not required for a normal update, but installation and reset choices can replace saved configuration.\n\nIf you updated from a previous version or installed a UF2 on an nRF52 device, perform a factory reset to activate Burning Man mode.\n\n### Learn More\n\n- [Quick Start Guide](https://docs.burningmesh.org/en/guides/quick_start)\n- [Android Offline Maps](https://docs.burningmesh.org/en/offline_maps/android_offline_maps)\n- [iOS Offline Maps](https://docs.burningmesh.org/en/offline_maps/ios_offline_maps)\n- [Burning Mesh Discord](https://discord.gg/eXUBcCEJuH)"
       }
     }
   ]

--- a/utils/eventManifest.test.ts
+++ b/utils/eventManifest.test.ts
@@ -44,6 +44,21 @@ describe('manifestEditionToEventMode', () => {
     // Falls back to the display name so the header still reads sensibly.
     expect(cfg.firmware.title).toBe('Open Sauce 2026')
   })
+
+  it('keeps a known version informational when permanent artifacts have not shipped', () => {
+    const cfg =
+      manifestEditionToEventMode({
+        ...comingSoonEdition,
+        firmware: {
+          ...comingSoonEdition.firmware!,
+          version: '2.8.0.1cf8338',
+          title: 'Meshtastic Firmware 2.8.0.1cf8338',
+        },
+      })
+    expect(cfg.firmware.id).toBe('')
+    expect(cfg.firmware.title).toBe('Meshtastic Firmware 2.8.0.1cf8338')
+    expect(cfg.firmware.zip_url).toBeUndefined()
+  })
 })
 
 describe('resolveEventAccentVars', () => {


### PR DESCRIPTION
## Summary

- Sync the Burning Man 2026 bundled event-firmware manifest with the API metadata.
- Use `burn.meshtastic.org` for first-load and offline event detection.
- Point event flashing at published firmware `2.8.0.1cf8338` under `burningmesh2026`.
- Add coverage showing that version and title metadata without a firmware ID remains non-flashable.

## Validation

- `pnpm test:run` — 188 tests passed.
- `pnpm build` — passed.
- TypeScript and JSON diagnostics — clean.
- Published firmware manifest — HTTP 200.

## Companion PR

- https://github.com/meshtastic/api/pull/117


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Burning Man 2026 event information, including dates, branding, resources, theme styling, firmware metadata, and release notes.

* **Bug Fixes**
  * Improved handling of informational firmware editions without downloadable artifacts, preserving version details while omitting unavailable download links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->