### PR TITLE
Fix: Turnstile widget never rendered, blocking survey submission

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -313,7 +313,7 @@ const { eventMode } = useEventMode()
 const surveyAvailable = computed(() =>
   eventMode.value.enabled
   && eventMode.value.eventTag === SURVEY_EVENT_TAG
-  && Boolean(config.public.surveyWebhookUrl),
+  && Boolean(String(config.public.surveyWebhookUrl ?? '').trim()),
 )
 
 // The survey lives at ?survey=1 rather than its own route: this app has no

--- a/components/survey/SurveyForm.vue
+++ b/components/survey/SurveyForm.vue
@@ -127,7 +127,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 import { ArrowLeft, ArrowRight, Send } from 'lucide-vue-next'
 
 import QuestionCard from './QuestionCard.vue'
@@ -170,16 +170,31 @@ const submitError = ref('')
 const submitted = ref(false)
 
 const turnstileContainer = ref<HTMLElement | null>(null)
-const turnstile = useTurnstile(config.public.turnstileSiteKey as string, turnstileContainer)
+// Trimmed: a stray space in the deploy environment's value silently yields an
+// invalid sitekey, and Turnstile then renders nothing with no error callback.
+const turnstile = useTurnstile(
+  (config.public.turnstileSiteKey as string ?? '').trim(),
+  turnstileContainer,
+)
 
 const screen = computed<TerminalId | 'error' | 'filling'>(() => {
   if (submitted.value) return 'complete'
   return terminal.value ?? 'filling'
 })
 
-onMounted(() => {
+// Turnstile refuses to render into a hidden container, and reports nothing when
+// it does: no widget, no error callback, and the respondent only finds out at
+// submit time via "complete the spam check" with nothing to complete. The
+// widget lives inside a v-show block, so defer mounting until the respondent
+// actually reaches the last section and the container has real layout.
+const turnstileRequested = ref(false)
+
+watch(isLastSection, async (onLastSection) => {
+  if (!onLastSection || turnstileRequested.value) return
+  turnstileRequested.value = true
+  await nextTick()
   turnstile.mount()
-})
+}, { immediate: true })
 
 // Scroll the survey back to the top on section change, otherwise a long section
 // leaves the respondent halfway down the next one.
@@ -203,7 +218,7 @@ async function onSubmit() {
   submitting.value = true
   submitError.value = ''
 
-  const result = await submitSurvey(config.public.surveyWebhookUrl as string, {
+  const result = await submitSurvey((config.public.surveyWebhookUrl as string ?? '').trim(), {
     schemaVersion: SCHEMA_VERSION,
     answers: payloadAnswers(),
     durationMs: elapsedMs(),


### PR DESCRIPTION
# Description

The DEF CON survey is live but cannot be submitted: pressing Submit reports "Please complete the spam check before submitting" while no Turnstile widget is visible anywhere on the page.

## Cause

Two independent problems, either of which is enough to break it.

**1. The widget was mounted while hidden.**

`turnstile.mount()` ran in `onMounted`, when the respondent is still on the first section. The widget's container sits inside a `v-show="isLastSection"` block, so at that moment it is `display: none`. Turnstile does not render into a hidden element, and fires no error callback when it declines to — so there was no widget, no error message, and the failure only surfaced at submit time asking the respondent to complete something that was never displayed.

The mount is now deferred until the last section is actually reached, after `nextTick` so the container has layout.

**2. The configured site key has a leading space.**

The live site currently ships:

```
turnstileSiteKey:" 0x4AAAAAAEOdpIEK_cCM6uml"
```

Turnstile rejects that as an invalid sitekey and again renders nothing. This needs fixing in the deployment environment, but the code should not be one stray keystroke away from a silent failure, so the site key and webhook URL are now trimmed before use.

## Type of Change

- [x] Bug fix

## Testing

- [x] 243 tests pass
- [x] `eslint` clean, `pnpm run build` succeeds
- [x] Verified locally with `?event=DEFCON&survey=1`: the widget appears on the final section and Submit proceeds

## Deployment note

Fixing the leading space in `TURNSTILE_SITE_KEY` requires a redeploy to take effect, since public runtime config is baked in at build time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved survey availability checks so blank or whitespace-only webhook settings are treated as unavailable.
  * Trimmed survey security and webhook configuration values before use.
  * Fixed survey security verification rendering so it appears correctly when its section becomes visible.
  * Prevented verification controls from loading prematurely in hidden survey sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->