### PR TITLE
Fix: survey Turnstile token expires before submission

### DIFF
--- a/appscript/survey/Code.gs
+++ b/appscript/survey/Code.gs
@@ -301,7 +301,9 @@ function isArray(value) {
 
 function verifyTurnstile(token) {
   var properties = PropertiesService.getScriptProperties()
-  var secret = properties.getProperty('TURNSTILE_SECRET')
+  // Trimmed: a stray space pasted into the property yields invalid-input-secret,
+  // which looks identical to a bad token from the outside.
+  var secret = (properties.getProperty('TURNSTILE_SECRET') || '').replace(/^\s+|\s+$/g, '')
 
   if (!secret) {
     // Fail closed. A missing secret in production is a configuration error, and
@@ -325,6 +327,13 @@ function verifyTurnstile(token) {
       muteHttpExceptions: true,
     })
     var result = JSON.parse(response.getContentText())
+    if (result.success !== true) {
+      // Cloudflare's error codes are the only way to tell a reused token
+      // (timeout-or-duplicate) from a misconfigured key (invalid-input-secret)
+      // from a genuine bot. Without them every failure looks the same from the
+      // outside, which is exactly how this cost an afternoon.
+      console.warn('Turnstile rejected a token: ' + JSON.stringify(result['error-codes'] || []))
+    }
     return { passed: result.success === true, mode: result.success ? 'verified' : 'rejected' }
   }
   catch (err) {

--- a/components/survey/useTurnstile.ts
+++ b/components/survey/useTurnstile.ts
@@ -85,6 +85,13 @@ export function useTurnstile(siteKey: string, container: Ref<HTMLElement | null>
     widgetId = window.turnstile.render(container.value, {
       'sitekey': siteKey,
       'theme': 'auto',
+      // Tokens expire after roughly five minutes — about how long the survey
+      // takes. Without auto-refresh a respondent who solves the challenge and
+      // then reads carefully arrives at Submit holding a dead token, and the
+      // server rejects it as a failed spam check with nothing visibly wrong.
+      'refresh-expired': 'auto',
+      'retry': 'auto',
+      'retry-interval': 2000,
       'callback': (value: string) => {
         token.value = value
         error.value = ''


### PR DESCRIPTION
# Description

Follow-up to #408. The survey still reports "Spam check failed" on submit even though the Turnstile widget shows **Success!** and both keys are correct.

## Cause

Turnstile tokens expire after roughly five minutes. The survey is designed to take about five minutes. #408 moved the widget mount to the last section, which helps, but a respondent who solves the challenge and then reads the remaining questions carefully still arrives at Submit holding an expired token. The server rejects it, and the page reports a failed spam check with nothing visibly wrong — the widget is still sitting there showing Success.

Verified on the live deployment that this is not a configuration problem:

- Site key is well-formed (24 chars, no stray whitespace)
- Secret is valid: `siteverify` with a dummy token returns `invalid-input-response`, which is the response a *correct* secret gives

## Changes

- **`refresh-expired: 'auto'`** so the widget renews its own token rather than going stale while the respondent reads. Adds `retry: 'auto'` for transient network failures.
- **Log Cloudflare's `error-codes` on rejection.** Previously a reused token (`timeout-or-duplicate`), a misconfigured secret (`invalid-input-secret`) and a genuine bot were indistinguishable from the outside — every one surfaced as the same generic message. This was the single biggest obstacle to diagnosing the problem.
- **Trim the secret** server-side, matching the site-key trim from #408. A stray space produces `invalid-input-secret`, which looks identical to a bad token.

## Type of Change

- [x] Bug fix

## Testing

- [x] 243 tests pass
- [x] `pnpm run build` succeeds; eslint clean on all touched files
- [x] Confirmed against the live endpoint that the secret and site key are both valid, isolating the failure to token age

Note: `utils/eventManifest.test.ts` and `utils/firmwareUrl.test.ts` have lint errors that pre-date this branch and are untouched here.

## Deployment

Needs both halves:

1. Merge and redeploy the site — the `refresh-expired` behaviour is client-side
2. Re-paste `appscript/survey/Code.gs` and deploy a new Apps Script version — that ships the error-code logging, so any remaining failure names itself in the execution log instead of having to be inferred


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Turnstile verification by handling extra whitespace in configuration values.
  * Added clearer error reporting when verification is rejected.
  * Automatically refreshes expired verification tokens.
  * Retries failed token generation every two seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->