### PR TITLE
feat: update Burning Man 2026 firmware to 2.8.0.6fd990c

### DIFF
--- a/public/data/event_firmware.json
+++ b/public/data/event_firmware.json
@@ -159,9 +159,9 @@
       },
       "firmware": {
         "slug": "burningmesh2026",
-        "version": "2.8.0.2651f28",
-        "id": "v2.8.0.2651f28",
-        "title": "Meshtastic Firmware 2.8.0.2651f28",
+        "version": "2.8.0.6fd990c",
+        "id": "v2.8.0.6fd990c",
+        "title": "Meshtastic Firmware 2.8.0.6fd990c",
         "zipUrl": null,
         "releaseNotes": "## Welcome to Burning Man 2026!\n\n### ⚠️ Flash the Latest 2026 Firmware\n\nFlash your node with the latest Burning Man 2026 firmware before joining the mesh. Burning Mesh firmware from previous years is not compatible with the 2026 mesh. Use the [Burning Man Firmware Flasher](https://burn.meshtastic.org) to install the current release.\n\nThis Burning Mesh firmware includes event defaults tuned for Black Rock City, including the SHORT_TURBO modem preset, frequency slot 33, an Everyone channel, event routing limits, and location-sharing protections on the event channel.\n\n### ⚠️ Important: Backup Before Flashing\n\nIf you care about what is currently stored on your node, back up your keys and configuration before proceeding. A full erase is not required for a normal update, but installation and reset choices can replace saved configuration.\n\nIf you updated from a previous version or installed a UF2 on an nRF52 device, perform a factory reset to activate Burning Man mode.\n\n### Learn More\n\n- [Burning Man Firmware Flasher](https://burn.meshtastic.org)\n- [Quick Start Guide](https://docs.burningmesh.org/en/guides/quick_start)\n- [Android Offline Maps](https://docs.burningmesh.org/en/offline_maps/android_offline_maps)\n- [iOS Offline Maps](https://docs.burningmesh.org/en/offline_maps/ios_offline_maps)\n- [Burning Mesh Discord](https://discord.gg/eXUBcCEJuH)"
       }


### PR DESCRIPTION
Points the Burning Man 2026 edition at the newest `event/burningmesh2026` build.

Built by [CI run 31985534118](https://github.com/meshtastic/firmware/actions/runs/31985534118) from `event/burningmesh2026` @ `6fd990c`, whose head commit is `fix(mesh): dedup opaque relays to prevent an undecryptable-frame broadcast storm` ([meshtastic/firmware#11522](https://github.com/meshtastic/firmware/pull/11522)) — worth having on a mesh the size of Black Rock City.

```
2.8.0.2651f28 → 2.8.0.6fd990c
```

`slug`, `zipUrl`, `releaseNotes`, and `generatedAt` are unchanged — same 3-line shape as the previous two bumps.

## Verification

Every URL the flasher resolves for this build returns 200 at `event/burningmesh2026/firmware-2.8.0.6fd990c/`: `release_notes.md`, `firmware-2.8.0.6fd990c.json`, and the per-target `.mt.json` files.

Spot-checked `firmware-tlora-t3s3-epaper-2.8.0.6fd990c.mt.json` — the board that boot-looped at DEF CON — and it carries `mt-esp32s3-ota.bin` at `app1` with `spiffs` at `0x340000`, which is what the manifest-driven path added in #395 reads. So this build flashes with the right filenames and offsets rather than falling through to the legacy convention-based path.

Event tests pass (32/32 across `firmwareUrl`, `eventManifest`, `eventDevices`, `firmwareStore.eventMode`).

Paired with the matching change in meshtastic/api, which is the source of truth this snapshot syncs from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the Burning Man 2026 firmware version and identifier to `2.8.0.6fd990c`.
  * Refreshed the associated firmware title to reflect the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->