### PR TITLE
feat: update Burning Man 2026 firmware to 2.8.0.9334cd3

### DIFF
--- a/public/data/event_firmware.json
+++ b/public/data/event_firmware.json
@@ -159,9 +159,9 @@
       },
       "firmware": {
         "slug": "burningmesh2026",
-        "version": "2.8.0.6fd990c",
-        "id": "v2.8.0.6fd990c",
-        "title": "Meshtastic Firmware 2.8.0.6fd990c",
+        "version": "2.8.0.9334cd3",
+        "id": "v2.8.0.9334cd3",
+        "title": "Meshtastic Firmware 2.8.0.9334cd3",
         "zipUrl": null,
         "releaseNotes": "## Welcome to Burning Man 2026!\n\n### ⚠️ Flash the Latest 2026 Firmware\n\nFlash your node with the latest Burning Man 2026 firmware before joining the mesh. Burning Mesh firmware from previous years is not compatible with the 2026 mesh. Use the [Burning Man Firmware Flasher](https://burn.meshtastic.org) to install the current release.\n\nThis Burning Mesh firmware includes event defaults tuned for Black Rock City, including the SHORT_TURBO modem preset, frequency slot 33, an Everyone channel, event routing limits, and location-sharing protections on the event channel.\n\n### ⚠️ Important: Backup Before Flashing\n\nIf you care about what is currently stored on your node, back up your keys and configuration before proceeding. A full erase is not required for a normal update, but installation and reset choices can replace saved configuration.\n\nIf you updated from a previous version or installed a UF2 on an nRF52 device, perform a factory reset to activate Burning Man mode.\n\n### Learn More\n\n- [Burning Man Firmware Flasher](https://burn.meshtastic.org)\n- [Quick Start Guide](https://docs.burningmesh.org/en/guides/quick_start)\n- [Android Offline Maps](https://docs.burningmesh.org/en/offline_maps/android_offline_maps)\n- [iOS Offline Maps](https://docs.burningmesh.org/en/offline_maps/ios_offline_maps)\n- [Burning Mesh Discord](https://discord.gg/eXUBcCEJuH)"
       }


### PR DESCRIPTION
Points the Burning Man 2026 edition at the newest `event/burningmesh2026` build.

Built by [CI run 32206334633](https://github.com/meshtastic/firmware/actions/runs/32206334633) from `event/burningmesh2026` @ `9334cd3`.

```
2.8.0.6fd990c → 2.8.0.9334cd3
```

`slug`, `zipUrl`, `releaseNotes`, and `generatedAt` are unchanged — same 3-line shape as the previous bumps.

## What's new since 2.8.0.6fd990c

- `dbd6a31` — relay foreign packets whose channel hash collides with a local channel ([#11544](https://github.com/meshtastic/firmware/pull/11544))
- `32563e0` — coerce coordinate traffic to the position channel on event builds ([#11545](https://github.com/meshtastic/firmware/pull/11545))
- `2efff18` — make the coordinate-port RX expectation event-mode aware
- `9334cd3` — don't reference the position module on `MESHTASTIC_EXCLUDE_GPS` builds

The last one is a build fix for the coordinate-channel change; the three earlier attempts to build this branch were cancelled by successive pushes, so `9334cd3` is the first of them to publish.

## Verification

The build directory holds 509 files, matching the previous build, so the publish is complete. Every URL the flasher resolves returns 200 at `event/burningmesh2026/firmware-2.8.0.9334cd3/`: `release_notes.md`, `firmware-2.8.0.9334cd3.json`, and the per-target `.mt.json` files.

Spot-checked `firmware-tlora-t3s3-epaper-2.8.0.9334cd3.mt.json` — `mt-esp32s3-ota.bin` at `app1`, `spiffs` at `0x340000` — the values the manifest-driven path from #395 reads, so this flashes with correct filenames and offsets.

Event tests pass (32/32 across `firmwareUrl`, `eventManifest`, `eventDevices`, `firmwareStore.eventMode`).

Paired with the matching change in meshtastic/api, the source of truth this snapshot syncs from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the Burning Man 2026 firmware version, identifier, and title to `2.8.0.9334cd3`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->