### PR TITLE
chore(event): sync bundled manifest with Dragon Con 2026

### DIFF
--- a/public/data/event_firmware.json
+++ b/public/data/event_firmware.json
@@ -106,7 +106,7 @@
       "eventEnd": "2026-08-09",
       "timeZone": "America/Los_Angeles",
       "location": "Las Vegas Convention Center, Las Vegas, Nevada, USA",
-      "iconUrl": null,
+      "iconUrl": "https://api.meshtastic.org/resource/eventFirmware/defcon34.png",
       "accentColor": "#0D294A",
       "domain": "defcon.meshtastic.org",
       "links": [
@@ -164,6 +164,39 @@
         "title": "Meshtastic Firmware 2.8.0.9334cd3",
         "zipUrl": null,
         "releaseNotes": "## Welcome to Burning Man 2026!\n\n### ⚠️ Flash the Latest 2026 Firmware\n\nFlash your node with the latest Burning Man 2026 firmware before joining the mesh. Burning Mesh firmware from previous years is not compatible with the 2026 mesh. Use the [Burning Man Firmware Flasher](https://burn.meshtastic.org) to install the current release.\n\nThis Burning Mesh firmware includes event defaults tuned for Black Rock City, including the SHORT_TURBO modem preset, frequency slot 33, an Everyone channel, event routing limits, and location-sharing protections on the event channel.\n\n### ⚠️ Important: Backup Before Flashing\n\nIf you care about what is currently stored on your node, back up your keys and configuration before proceeding. A full erase is not required for a normal update, but installation and reset choices can replace saved configuration.\n\nIf you updated from a previous version or installed a UF2 on an nRF52 device, perform a factory reset to activate Burning Man mode.\n\n### Learn More\n\n- [Burning Man Firmware Flasher](https://burn.meshtastic.org)\n- [Quick Start Guide](https://docs.burningmesh.org/en/guides/quick_start)\n- [Android Offline Maps](https://docs.burningmesh.org/en/offline_maps/android_offline_maps)\n- [iOS Offline Maps](https://docs.burningmesh.org/en/offline_maps/ios_offline_maps)\n- [Burning Mesh Discord](https://discord.gg/eXUBcCEJuH)"
+      }
+    },
+    {
+      "edition": "DRAGON_CON",
+      "displayName": "Dragon Con 2026",
+      "welcomeMessage": "Welcome to Dragon Con 2026!",
+      "tag": "Dragon Con",
+      "eventStart": "2026-09-03",
+      "eventEnd": "2026-09-07",
+      "timeZone": "America/New_York",
+      "location": "Atlanta, Georgia, USA",
+      "iconUrl": "https://api.meshtastic.org/resource/eventFirmware/dragoncon2026.png",
+      "accentColor": "#F2C94C",
+      "domain": "dragon.meshtastic.org",
+      "links": [
+        { "label": "Dragon Con Firmware Flasher", "url": "https://dragon.meshtastic.org" },
+        { "label": "MtnMe.sh Community", "url": "https://mtnme.sh" },
+        { "label": "Event Website", "url": "https://dragoncon.com" }
+      ],
+      "theme": {
+        "name": "40th Anniversary",
+        "tagline": "Celebrating 40 years of fandom",
+        "colors": { "primary": "#5B2482", "secondary": "#8A4FB8", "accent": "#F2C94C" },
+        "palette": ["#5B2482", "#8A4FB8", "#F2C94C"],
+        "fonts": { "heading": "Lato", "body": "Atkinson Hyperlegible" }
+      },
+      "firmware": {
+        "slug": "dragoncon2026",
+        "version": "2.8.0.a820487",
+        "id": "v2.8.0.a820487",
+        "title": "Meshtastic Firmware 2.8.0.a820487",
+        "zipUrl": null,
+        "releaseNotes": "## Welcome to Dragon Con 2026! 🐉\n\n### ⚠️ Flash the Latest 2026 Firmware\n\nFlash your node with the latest Dragon Con 2026 firmware before joining the mesh. Use the [Dragon Con Firmware Flasher](https://dragon.meshtastic.org) to install the current release.\n\nThis Dragon Con firmware includes event defaults tuned for Atlanta, including the MEDIUM_FAST modem preset, frequency slot 45, event channels, and event routing limits.\n\n### ⚠️ Important: Backup Before Flashing\n\nIf you care about what is currently stored on your node, back up your keys and configuration before proceeding. A full erase is not required for a normal update, but installation and reset choices can replace saved configuration.\n\nIf you updated from a previous version or installed a UF2 on an nRF52 device, perform a factory reset to activate Dragon Con mode.\n\n### Learn More\n\n- [Dragon Con Firmware Flasher](https://dragon.meshtastic.org)\n- [Quick Start Guide](https://docs.meshtastic.org/en/guides/quick_start)\n- [Meshtastic Discord](https://discord.gg/eXUBcCEJuH)"
       }
     }
   ]


### PR DESCRIPTION
Pulls [meshtastic/api@50d39cb](https://github.com/meshtastic/api/commit/50d39cbfada2d80599db88bdc5bc7ce6d1f27eee) into the flasher's offline snapshot.

`public/data/event_firmware.json` is the PWA-precached mirror of upstream `data/eventFirmware.json` (it gates first paint when venue Wi-Fi can't reach the API), so it's now byte-identical to upstream again.

## Changes

- **Adds the `DRAGON_CON` edition** — Dragon Con 2026, Sept 3–7, Atlanta, on `dragon.meshtastic.org`, firmware `2.8.0.a820487`.
- **Picks up the `DEFCON` `iconUrl`** the snapshot had drifted on (was `null` locally, set upstream).

## Verification

- Build is real and fully published: `meshtastic.github.io/event/dragoncon2026/firmware-2.8.0.a820487` (524 files).
- Both icon URLs return 200.
- `cmp` against the upstream blob at that commit: identical.
- 243 tests pass. Lint output is unchanged from `main` (281 pre-existing problems, all in untouched `.ts` files).

## Why no code changes

Editions resolve generically from the manifest — `EventFirmwareEdition.edition` is a plain `string`, `LogoHeader.vue` has a catch-all `v-else-if="eventMode.enabled"` branch that renders `eventMode.iconUrl`, and `staticEventModes` only backstops events with *no* manifest entry (Hamcation). Dragon Con brands itself from the manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Dragon Con 2026 event information, including schedule, branding, links, theme, firmware metadata, and release notes.
  * Added an event icon for DEF CON 34.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->