### PR TITLE
chore(event): sync Dragon Con tagline from api

### DIFF
--- a/public/data/event_firmware.json
+++ b/public/data/event_firmware.json
@@ -185,7 +185,7 @@
       ],
       "theme": {
         "name": "40th Anniversary",
-        "tagline": "Celebrating 40 years of fandom",
+        "tagline": "🐉 Dragontastic 2026 🐉",
         "colors": { "primary": "#5B2482", "secondary": "#8A4FB8", "accent": "#F2C94C" },
         "palette": ["#5B2482", "#8A4FB8", "#F2C94C"],
         "fonts": { "heading": "Lato", "body": "Atkinson Hyperlegible" }


### PR DESCRIPTION
Pulls [meshtastic/api@7871563](https://github.com/meshtastic/api/commit/78715631b) ("Dragontastic: Remove text, change tagline") into the flasher's offline snapshot, following on from #417.

## Change

One line — the `DRAGON_CON` theme tagline:

```diff
-"tagline": "Celebrating 40 years of fandom",
+"tagline": "🐉 Dragontastic 2026 🐉",
```

`public/data/event_firmware.json` is `cmp`-identical to upstream `data/eventFirmware.json` at HEAD again.

## The PNG half of that commit needs nothing here

The same upstream commit also replaced `static/eventFirmware/dragoncon2026.png` (the "remove text" part). The flasher hotlinks event icons straight from `api.meshtastic.org/resource/eventFirmware/` rather than bundling copies — confirmed no local asset exists — so the new artwork is served automatically with no change on this side.

## Verification

- Diffed against the api repo's default-branch HEAD blob, not just the named commit, so nothing newer is missed.
- 243 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the Dragon Con 2026 event tagline to “🐉 Dragontastic 2026 🐉”.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->