### PR TITLE
Serve the SoftDevice 7.3 erase UF2 to the Seeed MeshTracker X1

### DIFF
--- a/components/Flash.vue
+++ b/components/Flash.vue
@@ -10,7 +10,7 @@
       {{ $t('flash.title') }}
     </button>
     <button
-      v-show="deviceStore.supportsUf2Erase"
+      v-show="['nrf52840', 'rp2040'].includes(deviceStore.selectedArchitecture)"
       data-tooltip-target="tooltip-erase"
       class="btn-icon mx-2"
       type="button"
@@ -90,7 +90,7 @@
                 :title-override="`${$t('flash.erase_flash')} ${deviceStore.$state.selectedTarget?.displayName || ''}`"
               />
               <div class="flex-1 overflow-y-auto p-3 sm:p-4 relative z-10">
-                <TargetsEraseUf2 v-if="deviceStore.supportsUf2Erase" />
+                <TargetsEraseUf2 v-if="['nrf52840', 'rp2040'].includes(deviceStore.selectedArchitecture)" />
               </div>
             </div>
           </div>

--- a/components/targets/EraseUf2.vue
+++ b/components/targets/EraseUf2.vue
@@ -68,7 +68,7 @@
           </span>
         </div>
         <a
-          :href="uf2File"
+          :href="deviceStore.eraseUf2File"
           download=""
           class="inline-flex w-[250px] justify-center items-center py-2 px-3 text-sm font-medium focus:outline-none bg-meshtastic rounded-lg hover:bg-white focus:z-10 focus:ring-4 focus:ring-gray-200 text-black"
         >
@@ -132,21 +132,12 @@ import {
   Info,
 } from 'lucide-vue-next'
 import { track } from '@vercel/analytics'
-import { computed } from 'vue'
 
 import { useDeviceStore } from '../../stores/deviceStore'
 import { useFirmwareStore } from '../../stores/firmwareStore'
 
 const deviceStore = useDeviceStore()
 const firmwareStore = useFirmwareStore()
-
-const uf2File = computed(() => {
-  if (!deviceStore.isSelectedNrf) {
-    return '/uf2/pico_erase.uf2'
-  }
-
-  return deviceStore.isSoftDevice7point3 ? '/uf2/nrf_erase_sd7_3.uf2' : '/uf2/nrf_erase2.uf2'
-})
 
 const closeModal = () => {
   document.getElementById('erase-modal')?.click() // Flowbite bug

--- a/stores/deviceStore.test.ts
+++ b/stores/deviceStore.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import type { DeviceHardware } from '~/types/api'
+import { useDeviceStore } from './deviceStore'
+
+// The store module reads window.location at import time (createUrl).
+// vi.hoisted runs before the imports above are evaluated.
+vi.hoisted(() => {
+  (globalThis as any).window = { location: { host: 'localhost:3000', protocol: 'https:' } }
+})
+
+function makeTarget(overrides: Partial<DeviceHardware>): DeviceHardware {
+  return {
+    hwModel: 1,
+    hwModelSlug: 'TEST',
+    platformioTarget: 'test',
+    architecture: 'nrf52840',
+    activelySupported: true,
+    displayName: 'Test',
+    ...overrides,
+  }
+}
+
+const SD73_ERASE = '/uf2/nrf_erase_sd7_3.uf2'
+const SD611_ERASE = '/uf2/nrf_erase2.uf2'
+
+describe('deviceStore factory-erase UF2 selection', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('serves the SoftDevice 7.3 erase file to the Seeed MeshTracker X1', () => {
+    const store = useDeviceStore()
+    store.selectedTarget = makeTarget({
+      hwModel: 128,
+      hwModelSlug: 'MESH_TRACKER_X1',
+      platformioTarget: 'seeed_mesh_tracker_X1',
+      tags: ['Seeed'],
+    })
+    expect(store.isSoftDevice7point3).toBe(true)
+    expect(store.eraseUf2File).toBe(SD73_ERASE)
+  })
+
+  it.each([
+    'WIO_WM1110',
+    'TRACKER_T1000_E',
+    'XIAO_NRF52_KIT',
+    'SEEED_SOLAR_NODE',
+    'SEEED_WIO_TRACKER_L1',
+    'SEEED_WIO_TRACKER_L1_EINK',
+  ])('serves the SoftDevice 7.3 erase file to %s', (slug) => {
+    const store = useDeviceStore()
+    store.selectedTarget = makeTarget({ hwModelSlug: slug, tags: ['Seeed'] })
+    expect(store.eraseUf2File).toBe(SD73_ERASE)
+  })
+
+  it('treats any Seeed nRF52840 board as SoftDevice 7.3, even when not listed by slug', () => {
+    const store = useDeviceStore()
+    store.selectedTarget = makeTarget({ hwModelSlug: 'SEEED_SOME_FUTURE_BOARD', tags: ['Seeed'] })
+    expect(store.isSoftDevice7point3).toBe(true)
+    expect(store.eraseUf2File).toBe(SD73_ERASE)
+  })
+
+  it('does not apply the Seeed default to non-nRF architectures', () => {
+    const store = useDeviceStore()
+    store.selectedTarget = makeTarget({ hwModelSlug: 'SEEED_XIAO_S3', architecture: 'esp32-s3', tags: ['Seeed'] })
+    expect(store.isSoftDevice7point3).toBe(false)
+  })
+
+  it.each([
+    ['RAK4631', ['RAK']],
+    ['T_ECHO', ['LilyGo']],
+    ['HELTEC_MESH_NODE_T114', ['Heltec']],
+  ])('serves the SoftDevice 6.1.1 erase file to %s', (slug, tags) => {
+    const store = useDeviceStore()
+    store.selectedTarget = makeTarget({ hwModelSlug: slug, tags })
+    expect(store.isSoftDevice7point3).toBe(false)
+    expect(store.eraseUf2File).toBe(SD611_ERASE)
+  })
+
+  it('serves the RP2040 erase file to rp2040 targets', () => {
+    const store = useDeviceStore()
+    store.selectedTarget = makeTarget({ hwModelSlug: 'RPI_PICO', architecture: 'rp2040', tags: ['Raspberry Pi'] })
+    expect(store.eraseUf2File).toBe('/uf2/pico_erase.uf2')
+  })
+
+  it('is not SoftDevice 7.3 when nothing is selected', () => {
+    const store = useDeviceStore()
+    expect(store.isSoftDevice7point3).toBe(false)
+  })
+})

--- a/stores/deviceStore.ts
+++ b/stores/deviceStore.ts
@@ -92,18 +92,45 @@ export const useDeviceStore = defineStore('device', {
     isSelectedNrf(): boolean {
       return this.selectedArchitecture.startsWith('nrf52')
     },
+    /**
+     * Whether the selected nRF52 target's bootloader carries SoftDevice S140
+     * v7.3.0 (app base 0x27000) rather than v6.1.1 (app base 0x26000). This
+     * picks the factory-erase UF2: the v6.1.1 build is flashed at 0x26000,
+     * which on a v7.3.0 device overwrites the last page of the SoftDevice and
+     * leaves the board unbootable until the bootloader + SoftDevice package is
+     * reflashed (#85, #145).
+     *
+     * Every Seeed nRF52840 board ships the v7.3.0 bootloader (see
+     * meshtastic/nrf52_factory_erase), so Seeed is treated as v7.3.0 by default
+     * rather than adding each new board here one at a time. Mis-serving the
+     * v7.3.0 file to a v6.1.1 board is the benign direction (recoverable with
+     * a normal firmware reflash), so defaulting towards v7.3.0 is the safe bet.
+     */
     isSoftDevice7point3(): boolean {
-      const sd73Devices = ['WIO_WM1110', 'TRACKER_T1000_E', 'XIAO_NRF52_KIT', 'SEEED_SOLAR_NODE', 'SEEED_WIO_TRACKER_L1', 'SEEED_WIO_TRACKER_L1_EINK']
-      return sd73Devices.includes(this.selectedTarget?.hwModelSlug || '')
+      const sd73Devices = [
+        'WIO_WM1110',
+        'TRACKER_T1000_E',
+        'XIAO_NRF52_KIT',
+        'SEEED_SOLAR_NODE',
+        'SEEED_WIO_TRACKER_L1',
+        'SEEED_WIO_TRACKER_L1_EINK',
+        'MESH_TRACKER_X1',
+      ]
+      const target = this.selectedTarget
+      if (!target) return false
+      if (sd73Devices.includes(target.hwModelSlug || '')) return true
+      return this.isSelectedNrf && (target.tags?.includes('Seeed') ?? false)
     },
     /**
-     * UF2 erase is offered for nRF52840/RP2040 targets, minus devices where the
-     * erase UF2 is not safe to use.
+     * Factory-erase UF2 (under /public/uf2) for the selected target. The nRF52
+     * build has to match the target's SoftDevice layout — see
+     * isSoftDevice7point3 for what happens when it doesn't.
      */
-    supportsUf2Erase(): boolean {
-      const noEraseUf2Devices = ['MESH_TRACKER_X1']
-      return ['nrf52840', 'rp2040'].includes(this.selectedArchitecture)
-        && !noEraseUf2Devices.includes(this.selectedTarget?.hwModelSlug || '')
+    eraseUf2File(): string {
+      if (!this.isSelectedNrf) {
+        return '/uf2/pico_erase.uf2'
+      }
+      return this.isSoftDevice7point3 ? '/uf2/nrf_erase_sd7_3.uf2' : '/uf2/nrf_erase2.uf2'
     },
     enterDfuVersion(): string {
       if (this.isSelectedNrf) {


### PR DESCRIPTION
Follow-up to #397, which turned the erase flow off for the Seeed MeshTracker X1 as a stopgap. This is the root-cause fix: serve the X1 the **SoftDevice 7.3** erase UF2 and turn the flow back on.

## Why the X1 was getting bricked

- The X1 ships the Adafruit bootloader with **S140 v7.3.0** — app base `0x27000` ([`boards/mesh-tracker-x1.json`](https://github.com/meshtastic/firmware/blob/develop/boards/mesh-tracker-x1.json): `"sd_version": "7.3.0"`, linker `nrf52840_s140_v7.ld`).
- It was missing from the `sd73Devices` slug list in `deviceStore`, so the erase modal fell through to `nrf_erase2.uf2` — the **v6.1.1** build, whose blocks are written starting at **`0x26000`**. (`nrf_erase_sd7_3.uf2` is the same tool relinked at `0x27000`.)
- The Adafruit bootloader accepts UF2 writes from `MBR_SIZE` (`0x1000`) up to the bootloader ([`uf2cfg.h`](https://github.com/adafruit/Adafruit_nRF52_Bootloader/blob/master/src/usb/uf2/uf2cfg.h): `USER_FLASH_START = MBR_SIZE`), so nothing protects the SoftDevice region. On a 7.3.0 layout the first block lands on the **last 4 KB page of the SoftDevice**, and the app slot at `0x27000` gets the middle of the erase program.
- Result: the board won't boot, and re-flashing normal firmware (which only writes ≥ `0x27000`) doesn't repair the SoftDevice page — it needs the bootloader + SoftDevice package (`mesh_tracker_x1_bootloader-0.10.0-13`) reflashed from DFU, or SWD.

Same failure as #85 (T1000-E) and #145 (Xiao nRF52 Kit): every new Seeed nRF52840 board has hit this until its slug was added to the list. The erase tool itself only runs `InternalFS.format()` on the stock LittleFS partition, which the X1 uses too, so with the right build it is safe. Seeed's own [X1 wiki](https://wiki.seeedstudio.com/x1_get_started_for_meshtastic/) points users at the trash icon in the web flasher as the factory-reset procedure, so the flow is worth having back.

## Changes

- `stores/deviceStore.ts`
  - `isSoftDevice7point3`: add `MESH_TRACKER_X1`, and treat **any Seeed nRF52840 board as SD 7.3 by default**. All Seeed boards ship the 7.3.0 bootloader (per [meshtastic/nrf52_factory_erase](https://github.com/meshtastic/nrf52_factory_erase): `s140_nrf52_730_softdevice` = "All Seeed"), and every Seeed nRF52840 slug currently in the hardware list is already in the explicit list — so this only changes behaviour for boards we haven't heard of yet. Mis-serving the 7.3 file to a 6.1.1 board is the benign direction (SoftDevice untouched, recoverable with a normal firmware reflash), which is why the default leans this way.
  - New `eraseUf2File` getter — the erase-file choice moves out of the component so it can be unit-tested.
- `components/targets/EraseUf2.vue`: use the getter.
- `components/Flash.vue`: drop the X1 exclusion from #397.
- `stores/deviceStore.test.ts`: X1 → `nrf_erase_sd7_3.uf2`; all six listed slugs → 7.3; unlisted Seeed nRF52840 → 7.3; Seeed ESP32 → not 7.3; RAK4631 / T-Echo / T114 → `nrf_erase2.uf2`; rp2040 → `pico_erase.uf2`; no selection → false.

## Testing

- `vitest run`: 19 files / 257 tests pass (14 new).
- `nuxt dev` builds the changed components without errors and serves both `/uf2/nrf_erase_sd7_3.uf2` and `/uf2/nrf_erase2.uf2`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added architecture-specific factory erase support for nRF52840 and RP2040 devices.
  - Automatically selects the correct erase file for supported hardware, including newer and older nRF52 variants.

- **Bug Fixes**
  - Corrected erase-file selection for Seeed, RAK, LilyGo, Heltec, and RP2040 devices.
  - Restricted erase controls to compatible device architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->