### PR TITLE
chore(event): sync Dragon Con URL fixes from api

### DIFF
--- a/public/data/event_firmware.json
+++ b/public/data/event_firmware.json
@@ -180,8 +180,9 @@
       "domain": "dragon.meshtastic.org",
       "links": [
         { "label": "Dragon Con Firmware Flasher", "url": "https://dragon.meshtastic.org" },
+        { "label": "EFF @ Dragon Con", "url": "https://www.eff.org/event/eff-dragoncon-1" },
         { "label": "MtnMe.sh Community", "url": "https://mtnme.sh" },
-        { "label": "Event Website", "url": "https://dragoncon.com" }
+        { "label": "Event Website", "url": "https://dragoncon.org" }
       ],
       "theme": {
         "name": "40th Anniversary",
@@ -196,7 +197,7 @@
         "id": "v2.8.0.a820487",
         "title": "Meshtastic Firmware 2.8.0.a820487",
         "zipUrl": null,
-        "releaseNotes": "## Welcome to Dragon Con 2026! 🐉\n\n### ⚠️ Flash the Latest 2026 Firmware\n\nFlash your node with the latest Dragon Con 2026 firmware before joining the mesh. Use the [Dragon Con Firmware Flasher](https://dragon.meshtastic.org) to install the current release.\n\nThis Dragon Con firmware includes event defaults tuned for Atlanta, including the MEDIUM_FAST modem preset, frequency slot 45, event channels, and event routing limits.\n\n### ⚠️ Important: Backup Before Flashing\n\nIf you care about what is currently stored on your node, back up your keys and configuration before proceeding. A full erase is not required for a normal update, but installation and reset choices can replace saved configuration.\n\nIf you updated from a previous version or installed a UF2 on an nRF52 device, perform a factory reset to activate Dragon Con mode.\n\n### Learn More\n\n- [Dragon Con Firmware Flasher](https://dragon.meshtastic.org)\n- [Quick Start Guide](https://docs.meshtastic.org/en/guides/quick_start)\n- [Meshtastic Discord](https://discord.gg/eXUBcCEJuH)"
+        "releaseNotes": "## Welcome to Dragon Con 2026! 🐉\n\n### ⚠️ Flash the Latest 2026 Firmware\n\nFlash your node with the latest Dragon Con 2026 firmware before joining the mesh. Use the [Dragon Con Firmware Flasher](https://dragon.meshtastic.org) to install the current release.\n\nThis Dragon Con firmware includes event defaults tuned for Atlanta, including the MEDIUM_FAST modem preset, frequency slot 45, event channels, and event routing limits.\n\n### ⚠️ Important: Backup Before Flashing\n\nIf you care about what is currently stored on your node, back up your keys and configuration before proceeding. A full erase is not required for a normal update, but installation and reset choices can replace saved configuration.\n\nIf you updated from a previous version or installed a UF2 on an nRF52 device, perform a factory reset to activate Dragon Con mode.\n\n### Learn More\n\n- [Dragon Con Firmware Flasher](https://dragon.meshtastic.org)\n- [Quick Start Guide](https://docs.meshtastic.org/en/guides/quick_start)\n- [EFF @ Dragon Con](https://www.eff.org/event/eff-dragoncon-1)\n- [Meshtastic Discord](https://discord.gg/meshtastic)"
       }
     }
   ]


### PR DESCRIPTION
Pulls [meshtastic/api#128](https://github.com/meshtastic/api/pull/128) ("Dragontastic: Fix URLs") into the flasher's offline snapshot, following #417 and #418.

## Changes

Three URL corrections to the `DRAGON_CON` edition:

| | before | after |
|---|---|---|
| Event Website | `dragoncon.com` | `dragoncon.org` |
| EFF link | — | `www.eff.org/event/eff-dragoncon-1` (added to `links[]` **and** the release notes) |
| Release-notes Discord | `discord.gg/eXUBcCEJuH` | `discord.gg/meshtastic` |

`public/data/event_firmware.json` is `cmp`-identical to upstream `data/eventFirmware.json` at HEAD again.

## Verification

Since the PR's whole purpose is fixing URLs, I resolved each one rather than assuming:

- `dragoncon.com` → **fails to connect entirely** (curl `000`), so this was a genuinely dead link on the event page. `dragoncon.org` → 200.
- `www.eff.org/event/eff-dragoncon-1` → 200.
- `discord.gg/meshtastic` → 200, the official Meshtastic server. The old `eXUBcCEJuH` invite is live but is the **Burning Mesh** server — it came along when these release notes were adapted from the Burning Man edition, so the swap is correct rather than cosmetic.
- `mtnme.sh` and `dragon.meshtastic.org`, the two links the PR didn't touch → both 200.

Also confirmed the api repo's default-branch HEAD equals #128's merge commit, so nothing newer is being skipped. 257 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Dragon Con 2026 event links.
  - Added the Electronic Frontier Foundation event page.
  - Updated the event website and Meshtastic Discord invite URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->