### PR TITLE
Reveal not-actively-supported boards behind the Konami code

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -482,7 +482,9 @@ window.addEventListener('keydown', (event) => {
     konamiCodeIndex.value++
     if (konamiCodeIndex.value === konamiKeys.length) {
       // Pre-release and nightly builds are available to everyone now, so the
-      // code only turns on the easter eggs.
+      // code turns on the easter eggs and reveals the boards the device
+      // registry hides as not activelySupported - those can only be flashed
+      // with the nightly, see utils/unsupportedDevices.ts.
       console.log('Unlocking easter eggs')
       firmwareStore.$state.konamiUnlocked = true
       document.body.classList.add('konami-code')

--- a/components/DeviceDetail.vue
+++ b/components/DeviceDetail.vue
@@ -21,6 +21,13 @@
         {{ props.device.architecture.replace('-', '') }}
       </span>
       <span
+        v-if="isUnsupportedDevice(props.device)"
+        class="text-xs font-medium me-2 px-2.5 py-0.5 h-6 rounded bg-cyan-700 dark:bg-cyan-800 text-white dark:text-gray-100"
+        :title="$t('device.not_actively_supported')"
+      >
+        {{ $t('firmware.nightly') }}
+      </span>
+      <span
         v-for="tag in props.device.tags"
         class="text-xs font-medium px-2.5 py-0.5 h-6 rounded bg-indigo-600 dark:bg-indigo-500 text-white dark:text-gray-100 me-1"
       >
@@ -82,6 +89,7 @@
 import type { DeviceHardware } from '~/types/api'
 import { supportedVendorDeviceTags } from '~/types/resources'
 import { requiresHamLicense } from '~/utils/deviceBadges'
+import { isUnsupportedDevice } from '~/utils/unsupportedDevices'
 import { useFirmwareStore } from '../stores/firmwareStore'
 import { computed } from 'vue'
 

--- a/components/DeviceDetail.vue
+++ b/components/DeviceDetail.vue
@@ -25,7 +25,7 @@
         class="text-xs font-medium me-2 px-2.5 py-0.5 h-6 rounded bg-cyan-700 dark:bg-cyan-800 text-white dark:text-gray-100"
         :title="$t('device.not_actively_supported')"
       >
-        {{ $t('firmware.nightly') }}
+        {{ $t('device.unreleased') }}
       </span>
       <span
         v-for="tag in props.device.tags"

--- a/components/Firmware.vue
+++ b/components/Firmware.vue
@@ -51,6 +51,30 @@
           </ul>
         </template>
 
+        <!-- Board hidden as not actively supported: nightly is the only build -->
+        <template v-else-if="nightlyOnly">
+          <div class="px-4 py-2 text-sm text-cyan-400 font-semibold border-theme-bottom">
+            {{ $t('firmware.nightly') }}
+          </div>
+          <ul
+            class="py-2 text-sm text-theme-muted"
+            aria-labelledby="dropdownInformationButton"
+          >
+            <li>
+              <a
+                href="#"
+                class="block px-4 py-2 hover:text-meshtastic-dark hover:bg-surface-secondary cursor-pointer transition-colors"
+                @click="setSelectedFirmware(store.unlockNightly!)"
+              >
+                {{ (store.unlockNightly?.title || '').replace('Meshtastic Firmware ', '') }}
+              </a>
+            </li>
+          </ul>
+          <div class="px-4 py-3 w-full sm:w-96 max-w-sm text-xs text-warning break-words">
+            {{ $t('firmware.nightly_only_unsupported') }}
+          </div>
+        </template>
+
         <!-- Normal Mode: Full firmware list -->
         <template v-else>
           <div
@@ -213,6 +237,7 @@ import { useDeviceStore } from '../stores/deviceStore'
 import { useFirmwareStore } from '../stores/firmwareStore'
 import type { FirmwareResource } from '~/types/api'
 import { useEventMode } from '~/composables/useEventMode'
+import { isUnsupportedDevice } from '~/utils/unsupportedDevices'
 
 const { t } = useI18n()
 
@@ -234,6 +259,16 @@ const selectedVersion = computed(() => {
 
 const canSelectFirmware = computed(() => {
   return (deviceStore.selectedTarget?.hwModel ?? 0) > 0
+})
+
+/**
+ * For a board the registry does not mark activelySupported, develop is the only
+ * branch guaranteed to still build its variant, so the nightly is the single
+ * build offered. The Konami reveal is itself gated on that nightly existing, so
+ * this branch never renders an empty list.
+ */
+const nightlyOnly = computed(() => {
+  return isUnsupportedDevice(deviceStore.selectedTarget) && !!store.unlockNightly
 })
 
 const openFile = () => {

--- a/components/Firmware.vue
+++ b/components/Firmware.vue
@@ -52,7 +52,7 @@
         </template>
 
         <!-- Board hidden as not actively supported: nightly is the only build -->
-        <template v-else-if="nightlyOnly">
+        <template v-else-if="nightlyOnly && store.unlockNightly">
           <div class="px-4 py-2 text-sm text-cyan-400 font-semibold border-theme-bottom">
             {{ $t('firmware.nightly') }}
           </div>
@@ -61,13 +61,13 @@
             aria-labelledby="dropdownInformationButton"
           >
             <li>
-              <a
-                href="#"
-                class="block px-4 py-2 hover:text-meshtastic-dark hover:bg-surface-secondary cursor-pointer transition-colors"
+              <button
+                type="button"
+                class="block w-full text-left px-4 py-2 hover:text-meshtastic-dark hover:bg-surface-secondary cursor-pointer transition-colors"
                 @click="setSelectedFirmware(store.unlockNightly!)"
               >
                 {{ (store.unlockNightly?.title || '').replace('Meshtastic Firmware ', '') }}
-              </a>
+              </button>
             </li>
           </ul>
           <div class="px-4 py-3 w-full sm:w-96 max-w-sm text-xs text-warning break-words">
@@ -197,15 +197,16 @@
     </Teleport>
     <button
       data-tooltip-target="tooltip-file"
-      class="btn-icon mx-2"
+      class="btn-icon mx-2 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:scale-100 disabled:hover:shadow-none"
       type="button"
       for="file-upload"
       accept=".zip,.bin"
+      :disabled="nightlyOnly"
       @click="openFile()"
     >
       <FolderOpen
         class="h-4 w-4"
-        :class="{ 'animate-bounce text-meshtastic': (store.couldntFetchFirmwareApi && canSelectFirmware) }"
+        :class="{ 'animate-bounce text-meshtastic': (store.couldntFetchFirmwareApi && canSelectFirmware && !nightlyOnly) }"
       />
     </button>
     <div
@@ -213,7 +214,7 @@
       role="tooltip"
       class="absolute z-10 invisible inline-block px-3 py-2 text-sm font-medium text-theme transition-opacity duration-300 rounded-lg shadow-sm opacity-0 tooltip bg-surface-modal"
     >
-      {{ $t('firmware.upload_tooltip') }}
+      {{ nightlyOnly ? $t('firmware.upload_disabled_unsupported') : $t('firmware.upload_tooltip') }}
       <div
         class="tooltip-arrow"
         data-popper-arrow
@@ -237,7 +238,6 @@ import { useDeviceStore } from '../stores/deviceStore'
 import { useFirmwareStore } from '../stores/firmwareStore'
 import type { FirmwareResource } from '~/types/api'
 import { useEventMode } from '~/composables/useEventMode'
-import { isUnsupportedDevice } from '~/utils/unsupportedDevices'
 
 const { t } = useI18n()
 
@@ -264,18 +264,22 @@ const canSelectFirmware = computed(() => {
 /**
  * For a board the registry does not mark activelySupported, develop is the only
  * branch guaranteed to still build its variant, so the nightly is the single
- * build offered. The Konami reveal is itself gated on that nightly existing, so
- * this branch never renders an empty list.
+ * build offered: the dropdown lists nothing else and the upload control is
+ * refused, since a zip or bin from anywhere else was built for different
+ * hardware. The Konami reveal is itself gated on that nightly existing, so the
+ * dropdown branch never renders an empty list.
  */
-const nightlyOnly = computed(() => {
-  return isUnsupportedDevice(deviceStore.selectedTarget) && !!store.unlockNightly
-})
+const nightlyOnly = computed(() => deviceStore.nightlyOnlyTarget)
 
 const openFile = () => {
+  if (nightlyOnly.value) return
   document.getElementById('file_upload')?.click()
 }
 
 const setFirmwareFile = (event: any) => {
+  // Guarded here too: the markup disables the control, but a file must never
+  // reach the store for a board pinned to the nightly.
+  if (nightlyOnly.value) return
   store.setFirmwareFile(event.target.files[0])
 }
 

--- a/components/Flash.vue
+++ b/components/Flash.vue
@@ -179,6 +179,10 @@ const preflightCheck = async () => {
 // Either we have a custom zip file or a selected firmware release
 const canFlash = computed(() => {
   const hasDevice = deviceStore.selectedTarget?.hwModel > 0
+  // A board the registry does not mark activelySupported is pinned to the
+  // nightly, so a local upload is never a valid source for one - Firmware.vue
+  // refuses the upload, and this refuses to flash anything that slipped past.
+  if (deviceStore.nightlyOnlyTarget && firmwareStore.hasFirmwareFile) return false
   const hasFirmware = firmwareStore.hasFirmwareFile || firmwareStore.hasOnlineFirmware
   return !serialMonitorStore.isConnected && hasDevice && hasFirmware
     && (fileExistsOnServer.value || firmwareStore.hasFirmwareFile)

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -33,7 +33,8 @@
     "auto_detect": "Auto-detect",
     "supported_devices": "Supported Devices",
     "diy_devices": "Community Supported Devices",
-    "ham_license_required": "Amateur radio band — an amateur radio license is required to transmit"
+    "ham_license_required": "Amateur radio band — an amateur radio license is required to transmit",
+    "not_actively_supported": "Not actively supported — nightly firmware only"
   },
   "firmware": {
     "title": "Firmware",
@@ -67,7 +68,8 @@
     "refresh_later": "Refresh the page later to try again.",
     "upload_alternative": "Alternatively, you can upload a firmware.zip file from the Github releases or an individual firmware-update.bin file for an ESP32 based device by clicking the icon.",
     "upload_tooltip": "Upload your own firmware release zip or bin.",
-    "icon": "icon"
+    "icon": "icon",
+    "nightly_only_unsupported": "This board is not actively supported. Nightly builds are the only firmware offered for it, because develop is the only branch guaranteed to still build its variant."
   },
   "flash": {
     "title": "Flash",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -34,7 +34,8 @@
     "supported_devices": "Supported Devices",
     "diy_devices": "Community Supported Devices",
     "ham_license_required": "Amateur radio band — an amateur radio license is required to transmit",
-    "not_actively_supported": "Not actively supported — nightly firmware only"
+    "not_actively_supported": "Not actively supported — nightly firmware only",
+    "unreleased": "Unreleased"
   },
   "firmware": {
     "title": "Firmware",
@@ -69,7 +70,8 @@
     "upload_alternative": "Alternatively, you can upload a firmware.zip file from the Github releases or an individual firmware-update.bin file for an ESP32 based device by clicking the icon.",
     "upload_tooltip": "Upload your own firmware release zip or bin.",
     "icon": "icon",
-    "nightly_only_unsupported": "This board is not actively supported. Nightly builds are the only firmware offered for it, because develop is the only branch guaranteed to still build its variant."
+    "nightly_only_unsupported": "This board is not actively supported. Nightly builds are the only firmware offered for it, because develop is the only branch guaranteed to still build its variant.",
+    "upload_disabled_unsupported": "Uploading your own firmware is unavailable for a board that is not actively supported — only the nightly build is offered."
   },
   "flash": {
     "title": "Flash",

--- a/stores/deviceStore.ts
+++ b/stores/deviceStore.ts
@@ -5,6 +5,7 @@ import {
   vendorCobrandingTag,
 } from '~/types/resources'
 import { applyEventDeviceOverrides } from '~/utils/eventDevices'
+import { isUnsupportedDevice } from '~/utils/unsupportedDevices'
 import { addRumAction, boardAttributes, eventAttributes, setTelemetryContext } from '~/utils/telemetry'
 
 import { MeshDevice } from '@meshtastic/core'
@@ -41,6 +42,10 @@ export const useDeviceStore = defineStore('device', {
       selectedTarget: <DeviceHardware | undefined>undefined,
       tag: <string | undefined>undefined,
       apiTargets: <DeviceHardware[]>[],
+      // Boards the registry does not mark activelySupported - both the too-new
+      // and the long-retired. Held back from `targets` until the Konami code
+      // reveals them; see unsupportedTargetsUnlocked below.
+      unsupportedApiTargets: <DeviceHardware[]>[],
       isConnecting: false,
       abortController: <AbortController | undefined>undefined,
       readerClosed: <Promise<any> | undefined>undefined,
@@ -58,7 +63,18 @@ export const useDeviceStore = defineStore('device', {
     targets(): DeviceHardware[] {
       // Co-branded builds are pinned to one vendor's devices; never widen them.
       if (vendorCobrandingTag.length > 0) return this.apiTargets
-      return applyEventDeviceOverrides(this.apiTargets, eventMode.enabled ? eventMode.eventTag : undefined)
+      const base = applyEventDeviceOverrides(this.apiTargets, eventMode.enabled ? eventMode.eventTag : undefined)
+      if (!this.unsupportedTargetsUnlocked) return base
+      return base.concat(this.unsupportedApiTargets)
+    },
+    /**
+     * Whether boards the registry does not mark activelySupported are showing.
+     * Gated on the Konami code *and* a published nightly of the eligible
+     * series, so a revealed board always has a build to flash it with.
+     */
+    unsupportedTargetsUnlocked(): boolean {
+      if (vendorCobrandingTag.length > 0 || eventMode.enabled) return false
+      return useFirmwareStore().unsupportedDevicesUnlocked
     },
     filteredDevices(): DeviceHardware[] {
       if (this.tag) {
@@ -173,19 +189,22 @@ export const useDeviceStore = defineStore('device', {
       }
     },
     setTargetsList(targets: DeviceHardware[]) {
+      // meshtasticd targets are never flashable from here, whatever their
+      // support status, so they are dropped from both lists up front.
+      const flashable = targets.filter(
+        (t: DeviceHardware) => !t.architecture.toLowerCase().startsWith('portduino'),
+      )
       if (vendorCobrandingTag.length > 0) {
-        this.apiTargets = targets.filter(
-          (t: DeviceHardware) => t.activelySupported
-            && !t.architecture.toLowerCase().startsWith('portduino')
-            && t.tags?.includes(vendorCobrandingTag),
+        this.apiTargets = flashable.filter(
+          (t: DeviceHardware) => t.activelySupported && t.tags?.includes(vendorCobrandingTag),
         )
+        // Co-branded builds are pinned to one vendor's supported devices and
+        // are never widened, so nothing is held back for them.
+        this.unsupportedApiTargets = []
+        return
       }
-      else {
-        this.apiTargets = targets.filter(
-          (t: DeviceHardware) => t.activelySupported
-            && !t.architecture.toLowerCase().startsWith('portduino'),
-        )
-      }
+      this.apiTargets = flashable.filter((t: DeviceHardware) => t.activelySupported)
+      this.unsupportedApiTargets = flashable.filter(isUnsupportedDevice)
     },
     async setSelectedTarget(target: DeviceHardware) {
       this.selectedTarget = target
@@ -193,7 +212,17 @@ export const useDeviceStore = defineStore('device', {
       const firmwareStore = useFirmwareStore()
 
       await new Promise(_ => setTimeout(_, 250))
-      if (!firmwareStore.hasFirmwareFile && !firmwareStore.hasOnlineFirmware && !firmwareStore.prDeepLinkPending && firmwareStore.stable.length > 0) {
+      // A board the registry does not mark activelySupported is pinned to the
+      // nightly, overriding whatever was selected for the previous target:
+      // develop is the only branch guaranteed to still build its variant.
+      // Firmware.vue offers nothing else while such a board is selected, so
+      // this is the only build it can ever be flashed with. The reveal is
+      // gated on this nightly existing, so it is present here.
+      if (isUnsupportedDevice(target)) {
+        const nightly = firmwareStore.unlockNightly
+        if (nightly) firmwareStore.setSelectedFirmware(nightly)
+      }
+      else if (!firmwareStore.hasFirmwareFile && !firmwareStore.hasOnlineFirmware && !firmwareStore.prDeepLinkPending && firmwareStore.stable.length > 0) {
         firmwareStore.setSelectedFirmware(firmwareStore.stable[0])
       }
 

--- a/stores/deviceStore.ts
+++ b/stores/deviceStore.ts
@@ -76,6 +76,17 @@ export const useDeviceStore = defineStore('device', {
       if (vendorCobrandingTag.length > 0 || eventMode.enabled) return false
       return useFirmwareStore().unsupportedDevicesUnlocked
     },
+    /**
+     * Whether the selected board is one the registry does not mark
+     * activelySupported. Those are pinned to the nightly - `develop` is the
+     * only branch guaranteed to still build the variant - so neither another
+     * release nor a locally uploaded zip or bin may be flashed onto one: both
+     * would carry firmware built for different hardware. Firmware.vue offers
+     * only the nightly and refuses the upload; Flash.vue enforces the same.
+     */
+    nightlyOnlyTarget(): boolean {
+      return isUnsupportedDevice(this.selectedTarget)
+    },
     filteredDevices(): DeviceHardware[] {
       if (this.tag) {
         return this.targets.filter(t => t.tags?.includes(this.tag ?? '') || t.architecture === this.tag)

--- a/stores/deviceStore.unsupported.test.ts
+++ b/stores/deviceStore.unsupported.test.ts
@@ -37,9 +37,18 @@ describe('not-actively-supported devices behind the Konami code', () => {
     // vi.hoisted() because a global `document` present at import time sends
     // @vue/runtime-dom down its browser path and it fails on createElement.
     ;(globalThis as any).document = { getElementById: () => null }
+    // setSelectedTarget calls setSelectedFirmware without awaiting it, and that
+    // fetches release notes and the release manifest. Stub both so the tests
+    // stay offline and leave no request running past the assertion.
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      text: async () => '',
+      json: async () => ({ version: '', targets: [] }),
+    })))
   })
 
   afterEach(() => {
+    vi.unstubAllGlobals()
     delete (globalThis as any).document
   })
 
@@ -98,5 +107,36 @@ describe('not-actively-supported devices behind the Konami code', () => {
 
     await store.setSelectedTarget(SUPPORTED)
     expect(firmware.selectedFirmware?.id).toBe(STABLE.id)
+  })
+
+  it('marks a not-actively-supported board as nightly-only, and no other board', async () => {
+    const store = useDeviceStore()
+    const firmware = useFirmwareStore()
+    firmware.nightly = [NIGHTLY]
+    firmware.stable = [STABLE]
+
+    expect(store.nightlyOnlyTarget).toBe(false)
+
+    await store.setSelectedTarget(UNSUPPORTED)
+    expect(store.nightlyOnlyTarget).toBe(true)
+
+    await store.setSelectedTarget(SUPPORTED)
+    expect(store.nightlyOnlyTarget).toBe(false)
+  })
+
+  it('drops a locally uploaded file when a not-actively-supported board is selected', async () => {
+    const store = useDeviceStore()
+    const firmware = useFirmwareStore()
+    firmware.nightly = [NIGHTLY]
+    firmware.stable = [STABLE]
+    await firmware.setFirmwareFile({ name: 'firmware-2.7.11.zip' } as File)
+    expect(firmware.hasFirmwareFile).toBe(true)
+
+    // Firmware.vue refuses the upload control for these boards, so the only way
+    // a file can be present is from a board selected earlier. The nightly pin
+    // has to clear it, or downloadUf2FileSystem would still prefer the file.
+    await store.setSelectedTarget(UNSUPPORTED)
+    expect(firmware.hasFirmwareFile).toBe(false)
+    expect(firmware.selectedFirmware?.id).toBe(NIGHTLY.id)
   })
 })

--- a/stores/deviceStore.unsupported.test.ts
+++ b/stores/deviceStore.unsupported.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import type { DeviceHardware, FirmwareResource } from '~/types/api'
+import { useDeviceStore } from './deviceStore'
+import { useFirmwareStore } from './firmwareStore'
+
+// The store module reads window.location at import time (createUrl).
+vi.hoisted(() => {
+  (globalThis as any).window = { location: { host: 'localhost:3000', protocol: 'https:' } }
+})
+
+function makeTarget(overrides: Partial<DeviceHardware>): DeviceHardware {
+  return {
+    hwModel: 1,
+    hwModelSlug: 'TEST',
+    platformioTarget: 'test',
+    architecture: 'esp32-s3',
+    activelySupported: true,
+    displayName: 'Test',
+    ...overrides,
+  }
+}
+
+const SUPPORTED = makeTarget({ hwModel: 43, platformioTarget: 'heltec-v3' })
+const UNSUPPORTED = makeTarget({ hwModel: 139, platformioTarget: 'heltec-mesh-tower-v2', activelySupported: false })
+const MESHTASTICD = makeTarget({ hwModel: 121, platformioTarget: 'native', architecture: 'portduino', activelySupported: false })
+
+const NIGHTLY: FirmwareResource = { id: 'v2.8.2.bbb2222', title: 'Meshtastic Firmware 2.8.2 Nightly' }
+const OLD_NIGHTLY: FirmwareResource = { id: 'v2.7.9.aaa1111', title: 'Meshtastic Firmware 2.7.9 Nightly' }
+const STABLE: FirmwareResource = { id: 'v2.7.11.ccc3333', title: 'Meshtastic Firmware 2.7.11' }
+
+describe('not-actively-supported devices behind the Konami code', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    // setSelectedTarget dismisses the device modal through the DOM. The suite
+    // runs on the 'node' environment; this is stubbed here rather than in
+    // vi.hoisted() because a global `document` present at import time sends
+    // @vue/runtime-dom down its browser path and it fails on createElement.
+    ;(globalThis as any).document = { getElementById: () => null }
+  })
+
+  afterEach(() => {
+    delete (globalThis as any).document
+  })
+
+  it('hides boards the registry does not mark actively supported', () => {
+    const store = useDeviceStore()
+    store.setTargetsList([SUPPORTED, UNSUPPORTED])
+    expect(store.targets.map(t => t.platformioTarget)).toEqual(['heltec-v3'])
+  })
+
+  it('keeps them hidden when the code is entered but no eligible nightly exists', () => {
+    const store = useDeviceStore()
+    const firmware = useFirmwareStore()
+    store.setTargetsList([SUPPORTED, UNSUPPORTED])
+    firmware.konamiUnlocked = true
+    expect(store.targets.map(t => t.platformioTarget)).toEqual(['heltec-v3'])
+
+    firmware.nightly = [OLD_NIGHTLY]
+    expect(store.targets.map(t => t.platformioTarget)).toEqual(['heltec-v3'])
+  })
+
+  it('reveals them once the code is entered and an eligible nightly is published', () => {
+    const store = useDeviceStore()
+    const firmware = useFirmwareStore()
+    store.setTargetsList([SUPPORTED, UNSUPPORTED])
+    firmware.konamiUnlocked = true
+    firmware.nightly = [NIGHTLY]
+    expect(store.targets.map(t => t.platformioTarget)).toEqual(['heltec-v3', 'heltec-mesh-tower-v2'])
+  })
+
+  it('never reveals meshtasticd targets, which are not flashable from here', () => {
+    const store = useDeviceStore()
+    const firmware = useFirmwareStore()
+    store.setTargetsList([SUPPORTED, MESHTASTICD])
+    firmware.konamiUnlocked = true
+    firmware.nightly = [NIGHTLY]
+    expect(store.targets.map(t => t.platformioTarget)).toEqual(['heltec-v3'])
+  })
+
+  it('pins a not-actively-supported board to the nightly, replacing an already selected release', async () => {
+    const store = useDeviceStore()
+    const firmware = useFirmwareStore()
+    firmware.nightly = [NIGHTLY]
+    firmware.stable = [STABLE]
+    firmware.selectedFirmware = STABLE
+
+    await store.setSelectedTarget(UNSUPPORTED)
+    expect(firmware.selectedFirmware?.id).toBe(NIGHTLY.id)
+  })
+
+  it('leaves an actively supported board on the default stable selection', async () => {
+    const store = useDeviceStore()
+    const firmware = useFirmwareStore()
+    firmware.nightly = [NIGHTLY]
+    firmware.stable = [STABLE]
+    firmware.selectedFirmware = undefined
+
+    await store.setSelectedTarget(SUPPORTED)
+    expect(firmware.selectedFirmware?.id).toBe(STABLE.id)
+  })
+})

--- a/stores/firmwareStore.ts
+++ b/stores/firmwareStore.ts
@@ -23,6 +23,7 @@ import {
   nightlyState,
   setNightlyVersion,
 } from '~/utils/firmwareUrl'
+import { findUnlockNightly } from '~/utils/unsupportedDevices'
 import {
   addRumAction,
   boardAttributes,
@@ -169,7 +170,8 @@ export const useFirmwareStore = defineStore('firmware', {
       isConnected: false,
       port: <SerialPort | undefined>{},
       couldntFetchFirmwareApi: false,
-      // Konami code easter eggs (retro theme + chirpy flash background) only.
+      // Konami code: retro theme, chirpy flash background, and the boards the
+      // registry hides as not activelySupported (see unlockNightly).
       konamiUnlocked: useSessionStorage('konamiUnlocked', false),
       hasManifest: false,
       manifest: <FirmwareManifest | undefined>undefined,
@@ -207,6 +209,21 @@ export const useFirmwareStore = defineStore('firmware', {
         alphaIds: state.alpha.map(f => f.id),
         previewIds: state.previews.map(f => f.id),
       })
+    },
+    /**
+     * The nightly that boards hidden as not activelySupported may be flashed
+     * with, once the Konami code has revealed them. Undefined before the
+     * nightly index resolves, in event mode (pinned to a single build), and for
+     * any nightly below the series floor - each of which keeps those boards out
+     * of the picker, so a revealed board always has something to flash.
+     */
+    unlockNightly(state): FirmwareResource | undefined {
+      if (eventMode.enabled) return undefined
+      return findUnlockNightly(state.nightly)
+    },
+    /** Whether the picker should reveal the boards the registry hides. */
+    unsupportedDevicesUnlocked(): boolean {
+      return this.konamiUnlocked && !!this.unlockNightly
     },
     firmwareVersion: state => state.selectedFirmware?.id ? state.selectedFirmware.id.replace('v', '') : '.+',
     canShowFlash: state => state.selectedFirmware?.id ? state.hasSeenReleaseNotes : true,

--- a/utils/unsupportedDevices.test.ts
+++ b/utils/unsupportedDevices.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import type { DeviceHardware, FirmwareResource } from '~/types/api'
+import { findUnlockNightly, isUnlockNightlySeries, isUnsupportedDevice } from './unsupportedDevices'
+
+const nightly = (id: string): FirmwareResource => ({ id, title: `Meshtastic Firmware ${id} Nightly` })
+
+describe('isUnlockNightlySeries', () => {
+  it('accepts the 2.8 nightlies the gate was opened for', () => {
+    expect(isUnlockNightlySeries('v2.8.0.abc1234')).toBe(true)
+    expect(isUnlockNightlySeries('2.8.13.deadbee')).toBe(true)
+  })
+
+  it('accepts later series so the gate does not close when develop opens 2.9', () => {
+    expect(isUnlockNightlySeries('v2.9.0.abc1234')).toBe(true)
+    expect(isUnlockNightlySeries('v3.0.0.abc1234')).toBe(true)
+  })
+
+  it('rejects anything below the floor', () => {
+    expect(isUnlockNightlySeries('v2.7.11.abc1234')).toBe(false)
+    expect(isUnlockNightlySeries('v1.9.0.abc1234')).toBe(false)
+  })
+
+  it('rejects ids it cannot parse rather than guessing', () => {
+    expect(isUnlockNightlySeries(undefined)).toBe(false)
+    expect(isUnlockNightlySeries('')).toBe(false)
+    expect(isUnlockNightlySeries('nightly')).toBe(false)
+    expect(isUnlockNightlySeries('v2.8')).toBe(false)
+  })
+})
+
+describe('findUnlockNightly', () => {
+  it('returns nothing when no nightly is published', () => {
+    expect(findUnlockNightly([])).toBeUndefined()
+  })
+
+  it('returns nothing when the only nightly predates the floor', () => {
+    expect(findUnlockNightly([nightly('v2.7.9.abc1234')])).toBeUndefined()
+  })
+
+  it('returns the eligible nightly', () => {
+    const eligible = nightly('v2.8.2.bbb2222')
+    expect(findUnlockNightly([eligible])).toBe(eligible)
+  })
+})
+
+describe('isUnsupportedDevice', () => {
+  const device = (activelySupported: boolean): DeviceHardware => ({
+    hwModel: 1,
+    hwModelSlug: 'TEST',
+    platformioTarget: 'test',
+    architecture: 'esp32-s3',
+    activelySupported,
+    displayName: 'Test',
+  })
+
+  it('is true only for boards the registry has not promoted', () => {
+    expect(isUnsupportedDevice(device(false))).toBe(true)
+    expect(isUnsupportedDevice(device(true))).toBe(false)
+    expect(isUnsupportedDevice(undefined)).toBe(false)
+  })
+})

--- a/utils/unsupportedDevices.ts
+++ b/utils/unsupportedDevices.ts
@@ -1,0 +1,39 @@
+import type { DeviceHardware, FirmwareResource } from '~/types/api'
+
+/**
+ * Boards the device registry does not mark `activelySupported` never reach the
+ * picker. That covers both ends of a board's life: hardware too new to have
+ * been promoted, and hardware retired years ago. The Konami code reveals them
+ * all, but only a nightly may be flashed onto one - `develop` is the only
+ * branch guaranteed to still build the variant, whether it landed last week or
+ * is only kept alive at `board_level = extra`.
+ *
+ * Nightlies are cut from `develop`, so their series is always the one in
+ * progress - 2.8 when this gate was added. Treated as a floor rather than an
+ * exact match so the gate does not quietly close the day `develop` opens 2.9.
+ */
+export const MIN_UNLOCK_NIGHTLY_SERIES: readonly [number, number] = [2, 8]
+
+/**
+ * Whether a firmware id belongs to a series at or past the floor above.
+ * Ids look like `v2.8.0.abc1234`; anything unparsable is treated as too old.
+ */
+export function isUnlockNightlySeries(id?: string): boolean {
+  if (!id) return false
+  const match = /^v?(\d+)\.(\d+)\./.exec(id)
+  if (!match) return false
+  const [major, minor] = [Number(match[1]), Number(match[2])]
+  const [minMajor, minMinor] = MIN_UNLOCK_NIGHTLY_SERIES
+  if (major !== minMajor) return major > minMajor
+  return minor >= minMinor
+}
+
+/** The published nightly eligible to flash a not-actively-supported board. */
+export function findUnlockNightly(nightly: FirmwareResource[]): FirmwareResource | undefined {
+  return nightly.find(release => isUnlockNightlySeries(release.id))
+}
+
+/** Boards hidden from the picker until the Konami code is entered. */
+export function isUnsupportedDevice(device?: DeviceHardware): boolean {
+  return !!device && !device.activelySupported
+}


### PR DESCRIPTION
`setTargetsList` drops every board the device registry does not mark `activelySupported`, so none of them is reachable from the picker even when the firmware still builds a variant. On the live API that is 27 of 110 entries, and it spans both ends of a board's life — hardware too new to have been promoted (Heltec MeshTower V2, ThinkNode M8/M9) and hardware retired years ago (T-LoRa V1, Heltec V2.0, T-Beam 0.7).

The Konami code now reveals them, with a condition in each direction.

## Reveal: only when an eligible nightly exists

They appear only when a nightly of **2.8 or later** has been published. Gating the reveal on the build existing means there is never a revealed board with nothing to flash it with.

The series check is a floor rather than an exact match on 2.8. Nightlies are cut from `develop`, so their series is always the one in progress; an exact match would close the gate the day `develop` opens 2.9. `MIN_UNLOCK_NIGHTLY_SERIES` in `utils/unsupportedDevices.ts` is the one place to change if that is not wanted.

## Flash: only with that nightly

Selecting one of these boards pins the firmware to the nightly:

- `setSelectedTarget` selects it, **overriding** whatever release the previous target had chosen — so stepping from a supported board on stable to an unsupported one cannot leave stable selected.
- `Firmware.vue` renders a nightly-only branch while such a board is selected, so there is nothing else in the dropdown to pick.

`develop` is the only branch guaranteed to still build these variants. A stable or alpha release either predates a new board's variant or postdates a retired one, and in both cases would flash firmware built for different hardware.

## Unchanged

- **Co-branded builds** — pinned to one vendor's supported devices, never widened. `unsupportedApiTargets` is left empty for them.
- **Event mode** — pinned to a single build, so the reveal is off and `unlockNightly` is undefined.
- **meshtasticd targets** — dropped from both lists up front; they were never flashable from here whatever their support status.

## UI

Revealed boards carry a cyan `nightly` pill in the picker, and the firmware dropdown explains why it only offers one build.

## Tests

14 new tests across `utils/unsupportedDevices.test.ts` and `stores/deviceStore.unsupported.test.ts` cover the series floor, the reveal gate in both directions, meshtasticd exclusion, and the firmware pinning. Full suite: 271 passing.

Checked against production: the published nightly is `v2.8.0.4de2018`, so the gate opens as intended today.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an unlock flow for viewing unsupported device boards.
  * Unsupported devices now display an “Unreleased” badge.
  * Eligible nightly firmware is automatically selected for unsupported devices.
  * Added warnings and localized messaging for nightly-only firmware and disabled custom firmware uploads.

* **Bug Fixes**
  * Prevented unsupported and non-flashable devices from appearing in standard or restricted device lists.
  * Blocked local firmware flashing for nightly-only targets.

* **Tests**
  * Added coverage for filtering, unlock eligibility, nightly firmware selection, and version handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->