### PR TITLE
feat: STM32 (AN3155 UART bootloader) web flasher

### DIFF
--- a/components/Flash.vue
+++ b/components/Flash.vue
@@ -58,6 +58,7 @@
               <div class="flex-1 overflow-y-auto p-3 sm:p-4 relative z-10">
                 <TargetsUf2 v-if="['nrf52840', 'rp2040'].includes(deviceStore.selectedArchitecture)" />
                 <TargetsEsp32 v-if="deviceStore.selectedArchitecture.startsWith('esp32')" />
+                <TargetsStm32 v-if="deviceStore.isSelectedStm32" />
               </div>
             </div>
           </div>
@@ -147,6 +148,10 @@ const preflightCheck = async () => {
   if (['nrf52840', 'rp2040'].includes(deviceStore.selectedArchitecture)) {
     const firmwareVersion = firmwareStore.selectedFirmware!.id.replace('v', '')
     const firmwareFile = `firmware-${deviceStore.selectedTarget.platformioTarget}-${firmwareVersion}.uf2`
+    fileExistsOnServer.value = await checkIfRemoteFileExists(firmwareStore.getReleaseFileUrl(firmwareFile))
+  }
+  else if (deviceStore.isSelectedStm32) {
+    const firmwareFile = `firmware-${deviceStore.selectedTarget.platformioTarget}-${firmwareStore.firmwareVersion}.bin`
     fileExistsOnServer.value = await checkIfRemoteFileExists(firmwareStore.getReleaseFileUrl(firmwareFile))
   }
   else if (deviceStore.selectedArchitecture.startsWith('esp32')) {

--- a/components/targets/Stm32.vue
+++ b/components/targets/Stm32.vue
@@ -1,0 +1,198 @@
+<template>
+  <div class="space-y-6">
+    <ReleaseNotes />
+    <ol
+      v-if="firmwareStore.canShowFlash"
+      class="relative ms-3.5 mb-6 border-theme-left"
+    >
+      <!-- Step 1: Enter the ROM bootloader -->
+      <li class="mb-10 ms-8">
+        <span class="absolute -start-4 step-badge">1</span>
+        <div class="p-4 rounded-lg shadow-sm step-card">
+          <h3 class="flex items-center mb-3 text-lg font-semibold text-theme">
+            {{ $t('flash.uf2.enter_dfu') }}
+          </h3>
+          <div
+            class="flex p-4 mb-4 text-sm rounded-lg alert-box"
+            role="alert"
+          >
+            <Info class="flex-shrink-0 inline w-5 h-5 me-3 mt-0.5" />
+            <span>
+              {{ $t('flash.uf2.dfu_firmware_clause') }} &lt; {{ deviceStore.enterStm32BootloaderVersion }},
+              {{ $t('flash.uf2.dfu_firmware_clause_2') }} {{ deviceStore.dfuStepAction }}
+            </span>
+          </div>
+          <button
+            type="button"
+            class="inline-flex items-center gap-2 px-4 py-2.5 text-sm font-medium text-gray-900 bg-meshtastic rounded-lg hover:bg-green-300 focus:ring-4 focus:ring-green-800 transition-colors"
+            @click="tryBootloader"
+          >
+            <FolderDown class="w-4 h-4" />
+            {{ $t('flash.uf2.enter_dfu') }}
+          </button>
+        </div>
+      </li>
+
+      <!-- Step 2: Flash -->
+      <li class="ms-8">
+        <span class="absolute -start-4 step-badge">2</span>
+        <div class="p-4 rounded-lg shadow-sm step-card">
+          <h3 class="flex items-center mb-3 text-lg font-semibold text-theme">
+            {{ $t('flash.esp32.step_3_flash') }}
+          </h3>
+
+          <label class="relative inline-flex items-center cursor-pointer mb-4">
+            <input
+              v-model="firmwareStore.$state.shouldCleanInstall"
+              type="checkbox"
+              class="sr-only peer"
+            >
+            <div class="w-11 h-6 bg-gray-400 dark:bg-gray-600 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-red-800 rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-red-600" />
+            <span class="ms-3 text-sm font-medium text-theme-muted">{{ $t('flash.esp32.full_erase') }}</span>
+          </label>
+
+          <div
+            v-if="firmwareStore.$state.shouldCleanInstall"
+            class="flex flex-col p-4 mb-4 text-sm text-red-400 border border-red-800 rounded-lg bg-surface-primary"
+            role="alert"
+          >
+            <div class="flex items-center">
+              <Info class="flex-shrink-0 inline w-5 h-5 me-3" />
+              <span>{{ $t('flash.esp32.backup_warning') }}</span>
+            </div>
+            <a
+              href="https://meshtastic.org/docs/configuration/radio/security/#security-keys---backup-and-restore"
+              target="_blank"
+              class="inline-flex items-center gap-1 mt-2 text-red-400 hover:text-red-300 underline transition-colors"
+            >
+              <Link class="w-4 h-4" />
+              {{ $t('flash.esp32.doc_guide') }}
+            </a>
+          </div>
+          <p
+            v-else
+            class="text-sm text-theme-muted mb-4"
+          >
+            {{ updateNote }}
+          </p>
+
+          <div
+            class="flex p-4 mb-3 text-sm rounded-lg alert-box"
+            role="alert"
+          >
+            <Info class="flex-shrink-0 inline w-5 h-5 me-3" />
+            <span>{{ parityNote }}</span>
+          </div>
+          <div
+            class="flex p-4 text-sm rounded-lg alert-box"
+            role="alert"
+          >
+            <Info class="flex-shrink-0 inline w-5 h-5 me-3" />
+            <span>{{ $t('flash.esp32.reset_after_flash') }}</span>
+          </div>
+        </div>
+      </li>
+    </ol>
+
+    <!-- Flash actions -->
+    <div
+      v-if="firmwareStore.canShowFlash"
+      class="space-y-4"
+    >
+      <div v-if="firmwareStore.$state.prDownload">
+        <div class="flex justify-between mb-1">
+          <span class="text-sm font-medium text-theme">{{ $t('firmware.pr.downloading', { arch: firmwareStore.$state.prDownload.arch }) }}</span>
+          <span class="text-sm font-medium text-accent">{{ firmwareStore.prDownloadPercent }}%</span>
+        </div>
+        <div class="w-full rounded-full h-2.5 progress-track">
+          <div
+            class="bg-gradient-to-r from-amber-400 to-amber-600 h-2.5 rounded-full transition-all duration-300"
+            :style="{ width: `${firmwareStore.prDownloadPercent}%` }"
+          />
+        </div>
+      </div>
+      <button
+        v-if="showFlashButton"
+        type="button"
+        class="w-full text-gray-900 bg-gradient-to-r from-green-400 via-green-500 to-green-600 hover:bg-gradient-to-br focus:ring-4 focus:outline-none focus:ring-green-800 shadow-lg shadow-green-800/50 font-medium rounded-lg text-sm px-5 py-3 text-center transition-all"
+        @click="flash"
+      >
+        {{ firmwareStore.$state.shouldCleanInstall ? $t('flash.esp32.erase_and_install') : $t('flash.esp32.update') }}
+      </button>
+      <button
+        v-if="firmwareStore.$state.flashPercentDone > 0 && !firmwareStore.$state.isFlashing"
+        type="button"
+        class="w-full text-theme hover:opacity-80 focus:ring-4 focus:outline-none focus:ring-gray-600 font-medium rounded-lg text-sm px-5 py-2.5 text-center transition-colors step-card"
+        @click="startOver"
+      >
+        {{ $t('flash.esp32.start_over') }}
+      </button>
+
+      <div v-if="firmwareStore.$state.flashPercentDone > 0">
+        <div class="flex justify-between mb-1">
+          <span class="text-sm font-medium text-theme">{{ $t('flash.esp32.flashing_complete') }}</span>
+          <span class="text-sm font-medium text-accent">{{ firmwareStore.percentDone }}</span>
+        </div>
+        <div class="w-full rounded-full h-2.5 progress-track">
+          <div
+            class="bg-gradient-to-r from-green-400 to-green-600 h-2.5 rounded-full transition-all duration-300"
+            :style="{ width: firmwareStore.percentDone }"
+          />
+        </div>
+      </div>
+    </div>
+
+    <div
+      id="terminal"
+      class="rounded-lg overflow-hidden relative z-10 bg-black/40"
+    />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import '@xterm/xterm/css/xterm.css'
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import { FolderDown, Info, Link } from 'lucide-vue-next'
+
+import { useDeviceStore } from '../../stores/deviceStore'
+import { useFirmwareStore } from '../../stores/firmwareStore'
+import ReleaseNotes from './ReleaseNotes.vue'
+
+const { t } = useI18n()
+const deviceStore = useDeviceStore()
+const firmwareStore = useFirmwareStore()
+
+// STM32-specific copy that has no Crowdin key yet (i18n/locales is a protected
+// path). Inline until a maintainer adds flash.stm32.* strings.
+const updateNote = 'Update keeps your configuration and filesystem — only the application flash is erased.'
+const parityNote = 'The STM32 bootloader uses 8E1 serial framing. Most USB-serial adapters support this; some low-cost clones do not.'
+
+const showFlashButton = computed(() =>
+  !firmwareStore.$state.isFlashing && firmwareStore.$state.flashPercentDone < 1,
+)
+
+const startOver = () => {
+  firmwareStore.$state.isFlashing = false
+  firmwareStore.$state.flashPercentDone = 0
+}
+
+const tryBootloader = async () => {
+  try {
+    await deviceStore.enterStm32Bootloader(t)
+  }
+  catch {
+    // A toast is already shown; the user can fall back to the manual BOOT0 steps.
+  }
+}
+
+const flash = async () => {
+  const selectedTarget = deviceStore.$state.selectedTarget
+  if (!selectedTarget) {
+    console.error('No target selected')
+    return
+  }
+  await firmwareStore.flashStm32(selectedTarget)
+}
+</script>

--- a/stores/deviceStore.test.ts
+++ b/stores/deviceStore.test.ts
@@ -89,3 +89,25 @@ describe('deviceStore factory-erase UF2 selection', () => {
     expect(store.isSoftDevice7point3).toBe(false)
   })
 })
+
+describe('deviceStore STM32 selection', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it.each(['stm32', 'stm32wl'])('recognises architecture %s as STM32', (architecture) => {
+    const store = useDeviceStore()
+    store.selectedTarget = makeTarget({ architecture })
+    expect(store.isSelectedStm32).toBe(true)
+  })
+
+  it.each(['esp32', 'esp32-s3', 'nrf52840', 'rp2040'])('does not treat %s as STM32', (architecture) => {
+    const store = useDeviceStore()
+    store.selectedTarget = makeTarget({ architecture })
+    expect(store.isSelectedStm32).toBe(false)
+  })
+
+  it('pins the STM32 bootloader-entry firmware to 2.7.22', () => {
+    expect(useDeviceStore().enterStm32BootloaderVersion).toBe('2.7.22')
+  })
+})

--- a/stores/deviceStore.ts
+++ b/stores/deviceStore.ts
@@ -10,6 +10,7 @@ import { addRumAction, boardAttributes, eventAttributes, setTelemetryContext } f
 
 import { MeshDevice } from '@meshtastic/core'
 import { TransportWebSerial } from '@meshtastic/transport-web-serial'
+import { rebootMeshtasticToBootloader } from '~/utils/stm32/meshtasticBootloader'
 
 // biome-ignore lint/style/useImportType: WUT?
 import type { DeviceHardware } from '../types/api'
@@ -159,6 +160,18 @@ export const useDeviceStore = defineStore('device', {
       }
       return this.isSoftDevice7point3 ? '/uf2/nrf_erase_sd7_3.uf2' : '/uf2/nrf_erase2.uf2'
     },
+    isSelectedStm32(): boolean {
+      return this.selectedArchitecture.startsWith('stm32')
+    },
+    /**
+     * Minimum firmware whose STM32 build handles the enter_dfu_mode_request
+     * admin message (meshtastic/firmware commit 01bd4cfb, PR #10158, first
+     * released in v2.7.22). Below this the software bootloader entry is a no-op
+     * and the user must trigger the ROM bootloader with BOOT0.
+     */
+    enterStm32BootloaderVersion(): string {
+      return '2.7.22'
+    },
     enterDfuVersion(): string {
       if (this.isSelectedNrf) {
         return '2.2.17'
@@ -170,6 +183,11 @@ export const useDeviceStore = defineStore('device', {
 
       if (this.isSelectedNrf) {
         return t('flash.dfu_action_doubleclick')
+      }
+      if (this.isSelectedStm32) {
+        // No Crowdin key yet (i18n/locales is a protected path); inline until a
+        // maintainer adds flash.dfu_action_boot0.
+        return 'pressing and holding the BOOT0 button while power-cycling the device.'
       }
       return t('flash.dfu_action_bootsel')
     },
@@ -424,6 +442,53 @@ export const useDeviceStore = defineStore('device', {
       // Give the device a moment to recognize the 1200 baud connection
       await new Promise(resolve => setTimeout(resolve, 500))
       await this.port?.close()
+    },
+    /**
+     * Reboot a running STM32 Meshtastic device into its AN3155 ROM bootloader
+     * and return the SAME serial port — closed, but still granted — so the
+     * flasher can reopen it at 8E1 without a second port picker. If the request
+     * is a no-op (firmware < enterStm32BootloaderVersion, or the device is
+     * unresponsive), the port is still returned; the flasher's sync() then fails
+     * and tells the user to use the manual BOOT0 steps.
+     */
+    async enterStm32Bootloader(tFunc?: (key: string) => string): Promise<SerialPort> {
+      const toastStore = useToastStore()
+      const firmwareStore = useFirmwareStore()
+      const serialMonitorStore = useSerialMonitorStore()
+
+      const isPortBusy = firmwareStore.isConnected || firmwareStore.isReaderLocked
+        || serialMonitorStore.isConnected || serialMonitorStore.isReaderLocked
+      if (isPortBusy) {
+        toastStore.error(
+          tFunc?.('serial.busy_title') || 'Serial Port Busy',
+          tFunc?.('serial.busy_message') || 'A serial connection is already open. Please close it before flashing.',
+        )
+        throw new Error('serial port busy')
+      }
+
+      this.isConnecting = true
+      try {
+        const port = this.port ?? await navigator.serial.requestPort()
+        this.port = port
+        try {
+          await rebootMeshtasticToBootloader(port)
+        }
+        catch (error) {
+          // Unresponsive / pre-2.7.22: the AN3155 sync that follows will fail
+          // and prompt the user for manual BOOT0.
+          console.warn('enterStm32Bootloader:', error)
+          try {
+            await port.close()
+          }
+          catch { /* already closed */ }
+        }
+        // Let the MCU reset and the USB-serial bridge settle before the reopen.
+        await new Promise(resolve => setTimeout(resolve, 400))
+        return port
+      }
+      finally {
+        this.isConnecting = false
+      }
     },
     async autoSelectHardware(tFunc?: (key: string) => string) {
       const toastStore = useToastStore()

--- a/stores/firmwareStore.stm32.test.ts
+++ b/stores/firmwareStore.stm32.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { setGlobalI18n } from '~/utils/i18n'
+import type { DeviceHardware } from '~/types/api'
+import { useDeviceStore } from './deviceStore'
+import { useFirmwareStore } from './firmwareStore'
+
+vi.hoisted(() => {
+  (globalThis as any).window = { location: { host: 'localhost:3000', protocol: 'https:', href: 'https://localhost:3000/' } }
+})
+
+const { addRumAction, logTelemetry, setTelemetryContext } = vi.hoisted(() => ({
+  addRumAction: vi.fn(),
+  logTelemetry: vi.fn(),
+  setTelemetryContext: vi.fn(),
+}))
+vi.mock('~/utils/telemetry', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/utils/telemetry')>()
+  return { ...actual, addRumAction, logTelemetry, setTelemetryContext }
+})
+vi.mock('@vercel/analytics', () => ({ track: vi.fn() }))
+vi.mock('~/utils/terminal', () => ({
+  openTerminal: vi.fn(async () => ({ writeln: vi.fn(), write: vi.fn(), clear: vi.fn() })),
+}))
+
+const { flashStm32Firmware } = vi.hoisted(() => ({
+  flashStm32Firmware: vi.fn<(port: unknown, image: Uint8Array, opts: any) => Promise<void>>(async () => {}),
+}))
+vi.mock('~/utils/stm32/flashStm32', () => ({ flashStm32Firmware }))
+
+vi.stubGlobal('navigator', {
+  userAgent: 'vitest',
+  serial: { requestPort: vi.fn() },
+})
+
+const russell: DeviceHardware = {
+  hwModel: 99,
+  hwModelSlug: 'RAK3172',
+  platformioTarget: 'russell',
+  architecture: 'stm32wl',
+  activelySupported: true,
+  displayName: 'RAK3172 (Russell)',
+  supportLevel: 1,
+}
+
+const STABLE = { id: 'v2.7.22.abcdef0', title: 'Meshtastic Firmware 2.7.22' }
+
+function actionNamed(name: string) {
+  return addRumAction.mock.calls.find(([n]) => n === name)?.[1]
+}
+function actionsNamed(name: string) {
+  return addRumAction.mock.calls.filter(([n]) => n === name)
+}
+
+function fakePort() {
+  return { open: vi.fn(async () => {}), close: vi.fn(async () => {}), ondisconnect: null as any }
+}
+
+function stm32Store() {
+  const store = useFirmwareStore()
+  store.selectedFirmware = STABLE
+  store.fetchBinaryContent = vi.fn(async () => '\x01\x02\x03\x04')
+  store.readSerial = vi.fn(async () => {})
+  const device = useDeviceStore()
+  device.enterStm32Bootloader = vi.fn(async () => fakePort() as any)
+  return { store, device }
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  setGlobalI18n({ t: (key: string) => key })
+  addRumAction.mockReset()
+  logTelemetry.mockReset()
+  flashStm32Firmware.mockReset()
+  flashStm32Firmware.mockResolvedValue(undefined)
+})
+
+describe('flashStm32', () => {
+  it('downloads the .bin, runs the AN3155 flow and reports one device-verified success', async () => {
+    const { store } = stm32Store()
+
+    await store.flashStm32(russell)
+
+    expect(store.fetchBinaryContent).toHaveBeenCalledWith('firmware-russell-2.7.22.abcdef0.bin')
+    expect(flashStm32Firmware).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.any(Uint8Array),
+      expect.objectContaining({ massErase: false }),
+    )
+    expect(store.flashPercentDone).toBe(100)
+    expect(store.isFlashing).toBe(false)
+
+    expect(actionsNamed('flash_success')).toHaveLength(1)
+    expect(actionNamed('flash_start')).toMatchObject({ method: 'stm32', clean_install: false })
+    expect(actionNamed('flash_success')).toMatchObject({
+      platformio_target: 'russell',
+      method: 'stm32',
+      outcome_source: 'device',
+    })
+  })
+
+  it('passes a full mass-erase through when clean install is selected', async () => {
+    const { store } = stm32Store()
+    store.shouldCleanInstall = true
+
+    await store.flashStm32(russell)
+
+    expect(flashStm32Firmware).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.any(Uint8Array),
+      expect.objectContaining({ massErase: true }),
+    )
+    expect(actionNamed('flash_success')).toMatchObject({ clean_install: true })
+  })
+
+  it('maps write progress to 0-90% and verify progress to 90-100%', async () => {
+    const { store } = stm32Store()
+    flashStm32Firmware.mockImplementation(async (_port, _image, opts: any) => {
+      opts.onProgress('write', 45, 90)
+      expect(store.flashPercentDone).toBe(45)
+      opts.onProgress('verify', 5, 10)
+      expect(store.flashPercentDone).toBe(95)
+    })
+
+    await store.flashStm32(russell)
+    expect(store.flashPercentDone).toBe(100)
+  })
+
+  it('classifies a dismissed port picker as a user cancellation', async () => {
+    const { store, device } = stm32Store()
+    const cancelled = new Error('No port selected by the user.')
+    cancelled.name = 'NotFoundError'
+    device.enterStm32Bootloader = vi.fn(() => Promise.reject(cancelled))
+
+    await store.flashStm32(russell)
+
+    expect(actionsNamed('flash_success')).toHaveLength(0)
+    expect(actionNamed('flash_error')).toMatchObject({ error_kind: 'user_cancelled' })
+  })
+
+  it('reports a flash failure and clears the flashing flag when the protocol throws', async () => {
+    const { store } = stm32Store()
+    flashStm32Firmware.mockRejectedValue(new Error('bootloader did not respond'))
+
+    await store.flashStm32(russell)
+
+    expect(actionsNamed('flash_success')).toHaveLength(0)
+    expect(store.isFlashing).toBe(false)
+    expect(actionNamed('flash_error')).toMatchObject({ method: 'stm32', error_kind: 'flash_failed' })
+  })
+})

--- a/stores/firmwareStore.ts
+++ b/stores/firmwareStore.ts
@@ -10,6 +10,7 @@ import { defineStore } from 'pinia'
 import type { Terminal } from '@xterm/xterm'
 import { supportsNew8MBPartitionTable } from '~/utils/versionUtils'
 import { convertToBinaryString } from '~/utils/fileUtils'
+import { flashStm32Firmware } from '~/utils/stm32/flashStm32'
 import { openTerminal } from '~/utils/terminal'
 import {
   currentPrerelease,
@@ -39,7 +40,7 @@ import {
 import { track } from '@vercel/analytics'
 import { useSessionStorage } from '@vueuse/core'
 import { extractZipEntry } from '~/utils/zipUtils'
-import { buildPrReleaseNotes } from '~/utils/prBuild'
+import { artifactArchForDevice, buildPrReleaseNotes } from '~/utils/prBuild'
 import { t } from '~/utils/i18n'
 
 import type {
@@ -57,6 +58,7 @@ import {
   type ReleaseManifest,
 } from '../types/manifest'
 
+import { useDeviceStore } from './deviceStore'
 import { createUrl } from './store'
 import { useToastStore } from './toastStore'
 
@@ -576,6 +578,70 @@ export const useFirmwareStore = defineStore('firmware', {
       terminal.writeln('')
       terminal.writeln(`\x1b[38;5;9m${error}\x1b[0m`)
       this.trackFlashError(error)
+    },
+    /**
+     * Flash an STM32 target over the AN3155 USART ROM bootloader. Mirrors the
+     * ESP32 actions for terminal / telemetry / progress; the low-level protocol
+     * lives in utils/stm32. `shouldCleanInstall` selects a full mass-erase over
+     * a firmware-region-only erase that keeps the LittleFS/config tail.
+     */
+    async flashStm32(selectedTarget: DeviceHardware) {
+      const deviceStore = useDeviceStore()
+      const terminal = await openTerminal()
+      const cleanInstall = this.shouldCleanInstall
+      this.trackFlashStart(selectedTarget, { method: 'stm32', cleanInstall })
+
+      try {
+        if (this.isPrBuild) {
+          this.prActiveArch = artifactArchForDevice(selectedTarget.architecture)
+        }
+        const fileName = `firmware-${selectedTarget.platformioTarget}-${this.firmwareVersion}.bin`
+        terminal.writeln(`\x1b[33mLoading ${fileName}\x1b[0m`)
+        const binaryString = await this.fetchBinaryContent(fileName)
+        const image = Uint8Array.from(binaryString, c => c.charCodeAt(0) & 0xff)
+
+        terminal.writeln('\x1b[33mRequesting bootloader mode…\x1b[0m')
+        const port = await deviceStore.enterStm32Bootloader(t)
+
+        this.port = port
+        this.isConnected = true
+        this.isFlashing = true
+        this.flashPercentDone = 0
+        port.ondisconnect = () => {
+          this.isConnected = false
+        }
+
+        // Write fills 0-90%, read-back verify the last 10%.
+        await flashStm32Firmware(port, image, {
+          massErase: cleanInstall,
+          onStatus: line => terminal.writeln(`\x1b[36m${line}\x1b[0m`),
+          onProgress: (phase, done, total) => {
+            this.flashPercentDone = phase === 'write'
+              ? Math.round((done / total) * 90)
+              : 90 + Math.round((done / total) * 10)
+          },
+        })
+
+        this.flashPercentDone = 100
+        this.isFlashing = false
+        this.trackDownload(selectedTarget, cleanInstall, 'stm32')
+
+        // Reopen at 8N1 and stream the boot log, like the ESP32 path. A monitor
+        // failure must not fail an already-completed flash.
+        terminal.writeln('\x1b[32mFlash complete — reading boot log…\x1b[0m')
+        try {
+          await new Promise(resolve => setTimeout(resolve, 400))
+          await port.open({ baudRate: 115200 })
+          await this.readSerial(port, terminal)
+        }
+        catch (monitorError) {
+          terminal.writeln(`\x1b[33mCould not open the serial monitor: ${monitorError}\x1b[0m`)
+        }
+      }
+      catch (error: any) {
+        this.isFlashing = false
+        this.handleError(error, terminal)
+      }
     },
     /**
      * Get the partition offset from the manifest for a given partition name

--- a/test/stm32FakeBootloader.ts
+++ b/test/stm32FakeBootloader.ts
@@ -1,0 +1,202 @@
+// Test-only in-memory STM32 system bootloader. Not part of the app bundle
+// (outside utils/ and composables/, so Nuxt does not auto-import it).
+
+import { STM32_FLASH_BASE } from '~/utils/stm32/an3155'
+
+const ACK = 0x79
+const NACK = 0x1f
+
+/**
+ * A byte-fed AN3155 state machine wired to a WritableStream (host -> device) and
+ * a ReadableStream (device -> host), so an AN3155Client can be driven against it
+ * with no hardware.
+ */
+export class FakeStm32 {
+  flash = new Uint8Array(256 * 1024).fill(0xff)
+  supportedCommands = [0x00, 0x11, 0x21, 0x31, 0x44]
+  version = 0x31
+
+  massErased = false
+  erasedPages: number[] = []
+  wroteAt: number[] = []
+  wentTo = -1
+
+  /** Swallow this many leading sync bytes without answering (autobaud race). */
+  ignoreSyncs = 0
+  /** NACK every Write Memory block. */
+  nackWriteAlways = false
+  /** NACK the first Write Memory block only. */
+  nackWriteOnce = false
+  /** Flip this flash offset when serving Read Memory (verify-mismatch test). */
+  corruptReadAt = -1
+  /** NACK the Go command. */
+  goNack = false
+
+  readable: ReadableStream<Uint8Array>
+  writable: WritableStream<Uint8Array>
+
+  private controller!: ReadableStreamDefaultController<Uint8Array>
+  private rx: number[] = []
+  private gen: Generator<number, void, number[]>
+  private want = 1
+
+  constructor() {
+    this.readable = new ReadableStream<Uint8Array>({ start: c => (this.controller = c) })
+    this.writable = new WritableStream<Uint8Array>({ write: chunk => this.feed(chunk) })
+    this.gen = this.protocol()
+    this.want = this.gen.next().value as number
+  }
+
+  /** Push unsolicited bytes to the host (stale boot-log noise). */
+  injectNoise(bytes: number[]) {
+    this.controller.enqueue(new Uint8Array(bytes))
+  }
+
+  private feed(chunk: Uint8Array) {
+    for (const b of chunk) this.rx.push(b)
+    while (this.rx.length >= this.want) {
+      const bytes = this.rx.splice(0, this.want)
+      const res = this.gen.next(bytes)
+      if (res.done) return
+      this.want = res.value
+    }
+  }
+
+  private send(bytes: number[]) {
+    this.controller.enqueue(new Uint8Array(bytes))
+  }
+
+  private addr(frame: number[]): number {
+    return ((frame[0] << 24) | (frame[1] << 16) | (frame[2] << 8) | frame[3]) >>> 0
+  }
+
+  private* protocol(): Generator<number, void, number[]> {
+    for (;;) {
+      const [b] = yield 1
+
+      if (b === 0x7f) {
+        if (this.ignoreSyncs > 0) {
+          this.ignoreSyncs--
+          continue
+        }
+        this.send([ACK])
+        continue
+      }
+
+      const [c] = yield 1
+      if ((b ^ c) !== 0xff) {
+        this.send([NACK])
+        continue
+      }
+      this.send([ACK])
+
+      switch (b) {
+        case 0x00: // Get
+          this.send([this.supportedCommands.length, this.version, ...this.supportedCommands, ACK])
+          break
+
+        case 0x11: { // Read Memory
+          const a = this.addr(yield 5)
+          this.send([ACK])
+          const [n] = yield 2
+          this.send([ACK])
+          const len = n + 1
+          const off = a - STM32_FLASH_BASE
+          const out = Array.from(this.flash.subarray(off, off + len))
+          if (this.corruptReadAt >= off && this.corruptReadAt < off + len) {
+            out[this.corruptReadAt - off] ^= 0xff
+          }
+          this.send(out)
+          break
+        }
+
+        case 0x21: { // Go
+          const a = this.addr(yield 5)
+          if (this.goNack) {
+            this.send([NACK])
+          }
+          else {
+            this.wentTo = a
+            this.send([ACK])
+          }
+          break
+        }
+
+        case 0x31: { // Write Memory
+          const a = this.addr(yield 5)
+          this.send([ACK])
+          const [m] = yield 1
+          const dataLen = m + 1
+          const rest = yield dataLen + 1 // data + checksum
+          if (this.nackWriteAlways || this.nackWriteOnce) {
+            this.nackWriteOnce = false
+            this.send([NACK])
+            break
+          }
+          this.flash.set(rest.slice(0, dataLen), a - STM32_FLASH_BASE)
+          this.wroteAt.push(a)
+          this.send([ACK])
+          break
+        }
+
+        case 0x44: { // Extended Erase
+          const [h, l] = yield 2
+          if (h === 0xff && l === 0xff) {
+            yield 1 // checksum
+            this.flash.fill(0xff)
+            this.massErased = true
+          }
+          else {
+            const count = ((h << 8) | l) + 1
+            const pages = yield count * 2 + 1 // page indices + checksum
+            for (let i = 0; i < count; i++) {
+              const pg = (pages[i * 2] << 8) | pages[i * 2 + 1]
+              this.erasedPages.push(pg)
+              this.flash.fill(0xff, pg * 2048, pg * 2048 + 2048)
+            }
+          }
+          this.send([ACK])
+          break
+        }
+
+        default:
+          this.send([NACK])
+      }
+    }
+  }
+}
+
+/**
+ * Minimal Web Serial `SerialPort` over a FakeStm32: `open()` exposes the fake's
+ * streams, `close()` withdraws them. `failOpensBeforeSuccess` makes the first N
+ * `open()` calls throw (adapter-busy / already-open recovery path).
+ */
+export class FakeSerialPort {
+  opened = false
+  openOptions: SerialOptions[] = []
+  closeCount = 0
+  failOpensBeforeSuccess = 0
+
+  readable: ReadableStream<Uint8Array> | null = null
+  writable: WritableStream<Uint8Array> | null = null
+
+  constructor(private dev: FakeStm32) {}
+
+  async open(options: SerialOptions): Promise<void> {
+    if (this.failOpensBeforeSuccess > 0) {
+      this.failOpensBeforeSuccess--
+      throw new DOMException('Failed to open serial port.', 'NetworkError')
+    }
+    this.openOptions.push(options)
+    this.opened = true
+    this.readable = this.dev.readable
+    this.writable = this.dev.writable
+  }
+
+  async close(): Promise<void> {
+    this.closeCount++
+    this.opened = false
+    this.readable = null
+    this.writable = null
+  }
+}

--- a/utils/prBuild.test.ts
+++ b/utils/prBuild.test.ts
@@ -15,6 +15,8 @@ describe('prBuild', () => {
       ['esp32-c6', 'esp32c6'],
       ['nrf52840', 'nrf52840'],
       ['rp2040', 'rp2040'],
+      ['stm32', 'stm32'],
+      ['stm32wl', 'stm32'],
     ])('maps device architecture %s to artifact arch %s', (device, artifact) => {
       const result = artifactArchForDevice(device)
       expect(result).toBe(artifact)

--- a/utils/prBuild.ts
+++ b/utils/prBuild.ts
@@ -3,9 +3,11 @@ import type { PrBuildResponse } from '~/types/api'
 /**
  * Map a device hardware architecture to the firmware CI artifact arch token.
  * Artifacts are named firmware-{arch}-{version} where arch has no dashes
- * (e.g. device 'esp32-s3' → artifact 'esp32s3').
+ * (e.g. device 'esp32-s3' → artifact 'esp32s3'). All STM32 variants (STM32WL
+ * today) share one 'stm32' artifact bundle.
  */
 export function artifactArchForDevice(architecture: string): string {
+  if (architecture.toLowerCase().startsWith('stm32')) return 'stm32'
   return architecture.replace(/-/g, '')
 }
 

--- a/utils/stm32/an3155.test.ts
+++ b/utils/stm32/an3155.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from 'vitest'
+import { FakeStm32 } from '~/test/stm32FakeBootloader'
+import {
+  AN3155Client,
+  addressFrame,
+  buildExtendedEraseFrame,
+  ByteReader,
+  STM32_FLASH_BASE,
+} from './an3155'
+
+function clientFor(dev: FakeStm32) {
+  return new AN3155Client(dev.readable.getReader(), dev.writable.getWriter())
+}
+
+describe('pure framing helpers', () => {
+  it('addressFrame is big-endian + XOR', () => {
+    expect([...addressFrame(0x08000000)]).toEqual([0x08, 0x00, 0x00, 0x00, 0x08])
+    expect([...addressFrame(0x08010204)]).toEqual([0x08, 0x01, 0x02, 0x04, 0x0f])
+  })
+
+  it('buildExtendedEraseFrame matches hand-computed vectors', () => {
+    expect(buildExtendedEraseFrame(0, 1)).toEqual([0x00, 0x00, 0x00, 0x00, 0x00])
+    expect(buildExtendedEraseFrame(0, 2)).toEqual([0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00])
+    const f = buildExtendedEraseFrame(5, 3)
+    expect(f.slice(0, -1)).toEqual([0x00, 0x02, 0x00, 0x05, 0x00, 0x06, 0x00, 0x07])
+    expect(f[f.length - 1]).toBe(f.slice(0, -1).reduce((a, b) => a ^ b, 0))
+  })
+})
+
+describe('ByteReader', () => {
+  it('times out clearly and never drops a read that is still in flight', async () => {
+    let resolveRead: (r: ReadableStreamReadResult<Uint8Array>) => void
+    const reader = {
+      read: vi.fn(() => new Promise<ReadableStreamReadResult<Uint8Array>>((res) => { resolveRead = res })),
+    } as unknown as ReadableStreamDefaultReader<Uint8Array>
+    const br = new ByteReader(reader)
+
+    await expect(br.readBytes(2, 20)).rejects.toThrow('timed out waiting for a response')
+
+    // next call re-races the SAME pending read before it settles
+    const p = br.readBytes(2, 50)
+    resolveRead!({ done: false, value: new Uint8Array([0xaa, 0xbb]) })
+    expect(await p).toEqual([0xaa, 0xbb])
+    expect(reader.read).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('AN3155Client against a fake bootloader', () => {
+  it('syncs, retrying past swallowed sync bytes', async () => {
+    const dev = new FakeStm32()
+    dev.ignoreSyncs = 2
+    await expect(clientFor(dev).sync(5, 30)).resolves.toBeUndefined()
+  })
+
+  it('sync eventually throws with the manual-BOOT0 hint', async () => {
+    const dev = new FakeStm32()
+    dev.ignoreSyncs = 99
+    await expect(clientFor(dev).sync(2, 20)).rejects.toThrow('BOOT0')
+  })
+
+  it('get() parses version and command list', async () => {
+    const info = await clientFor(new FakeStm32()).get()
+    expect(info.blVersion).toBe('3.1')
+    expect(info.commands).toEqual([0x00, 0x11, 0x21, 0x31, 0x44])
+  })
+
+  it('flushInput drains a stale burst then returns', async () => {
+    const dev = new FakeStm32()
+    const client = clientFor(dev)
+    dev.injectNoise([0x11, 0x22, 0x33])
+    await expect(client.flushInput(20)).resolves.toBeUndefined()
+  })
+
+  it('massErase clears the whole model', async () => {
+    const dev = new FakeStm32()
+    dev.flash.fill(0x00)
+    await clientFor(dev).massErase()
+    expect(dev.massErased).toBe(true)
+    expect(dev.flash.every(b => b === 0xff)).toBe(true)
+  })
+
+  it('eraseForImage erases exactly the covered pages and refuses oversize images', async () => {
+    const dev = new FakeStm32()
+    const client = clientFor(dev)
+    expect(await client.eraseForImage(5000)).toBe(3)
+    expect(dev.erasedPages).toEqual([0, 1, 2])
+    await expect(client.eraseForImage(129 * 2048)).rejects.toThrow('firmware too large')
+  })
+
+  it('writeMemory splits into blocks, pads the tail to x4, reports progress, retries once', async () => {
+    const dev = new FakeStm32()
+    dev.nackWriteOnce = true
+    const client = clientFor(dev)
+    const image = new Uint8Array(602).map((_, i) => i & 0xff)
+    const progress: number[] = []
+    await client.writeMemory(STM32_FLASH_BASE, image, { onProgress: d => progress.push(d) })
+
+    expect(dev.wroteAt).toEqual([STM32_FLASH_BASE, STM32_FLASH_BASE + 256, STM32_FLASH_BASE + 512])
+    expect(progress).toEqual([256, 512, 602])
+    expect([...dev.flash.subarray(0, 602)]).toEqual([...image])
+    expect(dev.flash[602]).toBe(0xff) // tail padded with the erased value
+  })
+
+  it('writeMemory gives up after repeated NACKs, naming the address', async () => {
+    const dev = new FakeStm32()
+    dev.nackWriteAlways = true
+    await expect(
+      clientFor(dev).writeMemory(STM32_FLASH_BASE, new Uint8Array(8), { attempts: 2 }),
+    ).rejects.toThrow(/write failed at 0x8000000/)
+  })
+
+  it('verifyMemory passes on a match and throws with the offset on a mismatch', async () => {
+    const dev = new FakeStm32()
+    const client = clientFor(dev)
+    const image = new Uint8Array(300).map((_, i) => (i * 7) & 0xff)
+    dev.flash.set(image, 0)
+    await expect(client.verifyMemory(STM32_FLASH_BASE, image)).resolves.toBeUndefined()
+
+    dev.corruptReadAt = 260
+    await expect(client.verifyMemory(STM32_FLASH_BASE, image)).rejects.toThrow('0x8000104')
+  })
+
+  it('go() sends the entry address; NACK surfaces as an error', async () => {
+    const dev = new FakeStm32()
+    await clientFor(dev).go(STM32_FLASH_BASE)
+    expect(dev.wentTo).toBe(STM32_FLASH_BASE)
+
+    const dev2 = new FakeStm32()
+    dev2.goNack = true
+    await expect(clientFor(dev2).go(STM32_FLASH_BASE)).rejects.toThrow('NACK')
+  })
+})

--- a/utils/stm32/an3155.ts
+++ b/utils/stm32/an3155.ts
@@ -1,0 +1,341 @@
+// SPDX-License-Identifier: MIT
+//
+// STM32 AN3155 USART bootloader protocol client for the Web Serial API.
+//
+// Protocol framing (sync byte, command/checksum layout, GET/erase/write/go byte
+// sequences) ported from Gamadril/stm-serial-flasher (MIT), src/api/STMapi.js:
+// https://github.com/Gamadril/stm-serial-flasher
+//
+// TypeScript port of the JS reference at graw-dfm-17/webconfig/an3155.js, extended
+// for the Meshtastic Web Flasher with Read Memory (0x11) read-back verification and
+// Extended Erase (0x44) page-range erase (so an "update" flash preserves the
+// LittleFS/config tail). Trimmed to what the STM32WL system bootloader needs: no
+// BOOT0/NRST pin control, no STM8, no read-protection commands.
+
+const SYNC = 0x7f
+const ACK = 0x79
+const NACK = 0x1f
+
+const CMD_GET = 0x00
+const CMD_READ_MEMORY = 0x11
+const CMD_GO = 0x21
+const CMD_WRITE = 0x31
+const CMD_EXTENDED_ERASE = 0x44
+
+/** AN3155 max Write Memory payload; must be a multiple of 4. */
+const WRITE_BLOCK_SIZE = 256
+/** AN3155 max Read Memory payload. */
+const READ_BLOCK_SIZE = 256
+
+/** STM32 flash is mapped here; the Meshtastic STM32WL build has no bootloader offset. */
+export const STM32_FLASH_BASE = 0x08000000
+/** STM32WLE5xx flash page size (RM0453). */
+export const STM32WL_PAGE_SIZE = 2048
+/** STM32WLE5CCU6 = 256 KB / 2 KB. */
+export const STM32WL_PAGE_COUNT = 128
+
+export type ProgressFn = (done: number, total: number) => void
+
+export interface GetResult {
+  blVersion: string
+  commands: number[]
+}
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function xor(bytes: ArrayLike<number>): number {
+  let result = 0
+  for (let i = 0; i < bytes.length; i++) result ^= bytes[i]
+  return result
+}
+
+function cmdFrame(cmd: number): Uint8Array {
+  return new Uint8Array([cmd, 0xff ^ cmd])
+}
+
+/** 4 address bytes, MSB first, followed by their XOR. Exported for tests. */
+export function addressFrame(address: number): Uint8Array {
+  const bytes = [
+    (address >>> 24) & 0xff,
+    (address >>> 16) & 0xff,
+    (address >>> 8) & 0xff,
+    address & 0xff,
+  ]
+  bytes.push(xor(bytes))
+  return new Uint8Array(bytes)
+}
+
+/**
+ * Extended Erase (0x44) page-range payload (everything after the command frame):
+ * (count-1) big-endian, each page index big-endian, then one XOR checksum over
+ * all of those bytes. Exported for tests.
+ */
+export function buildExtendedEraseFrame(startPage: number, count: number): number[] {
+  const n = count - 1
+  const payload = [(n >> 8) & 0xff, n & 0xff]
+  for (let p = startPage; p < startPage + count; p++) {
+    payload.push((p >> 8) & 0xff, p & 0xff)
+  }
+  payload.push(xor(payload))
+  return payload
+}
+
+/**
+ * Buffers raw bytes off a ReadableStreamDefaultReader<Uint8Array> with per-call
+ * timeouts. Never issues a second reader.read() while one is still outstanding --
+ * a pending read always drains into `queue` when it resolves, whether or not a
+ * caller is still waiting on it, so nothing is dropped across a timed-out wait.
+ */
+export class ByteReader {
+  queue: number[] = []
+  private pendingRead: Promise<void> | null = null
+  private closed = false
+
+  constructor(private reader: ReadableStreamDefaultReader<Uint8Array>) {}
+
+  private nextRead(): Promise<void> {
+    if (!this.pendingRead) {
+      this.pendingRead = this.reader.read().then((result) => {
+        this.pendingRead = null
+        if (result.done) {
+          this.closed = true
+          return
+        }
+        for (const b of result.value) this.queue.push(b)
+      })
+    }
+    return this.pendingRead
+  }
+
+  async readBytes(n: number, timeoutMs: number): Promise<number[]> {
+    const deadline = Date.now() + timeoutMs
+    while (this.queue.length < n) {
+      if (this.closed) throw new Error('port closed while waiting for a response')
+      const remaining = deadline - Date.now()
+      if (remaining <= 0) throw new Error('timed out waiting for a response')
+      let timer: ReturnType<typeof setTimeout>
+      const timeout = new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error('timed out waiting for a response')), remaining)
+      })
+      try {
+        await Promise.race([this.nextRead(), timeout])
+      }
+      finally {
+        clearTimeout(timer!)
+      }
+    }
+    return this.queue.splice(0, n)
+  }
+
+  async readByte(timeoutMs: number): Promise<number> {
+    return (await this.readBytes(1, timeoutMs))[0]
+  }
+}
+
+export class AN3155Client {
+  commands: number[] = []
+  blVersion = ''
+
+  private byteReader: ByteReader
+
+  constructor(
+    reader: ReadableStreamDefaultReader<Uint8Array>,
+    private writer: WritableStreamDefaultWriter<Uint8Array>,
+  ) {
+    this.byteReader = new ByteReader(reader)
+  }
+
+  private write(bytes: Uint8Array | number[]): Promise<void> {
+    return this.writer.write(bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes))
+  }
+
+  /**
+   * Discards whatever is already sitting in the OS-level receive buffer -- stale
+   * boot-log bytes, or framing noise from the baud/parity switch -- before starting
+   * a protocol exchange. Without this a leftover byte gets consumed as if it were
+   * the bootloader's response to the first command, desyncing everything after it.
+   */
+  async flushInput(idleTimeoutMs = 100): Promise<void> {
+    this.byteReader.queue = []
+    for (;;) {
+      try {
+        await this.byteReader.readBytes(1, idleTimeoutMs)
+      }
+      catch {
+        return
+      }
+    }
+  }
+
+  private async expectAck(timeoutMs: number): Promise<void> {
+    const b = await this.byteReader.readByte(timeoutMs)
+    if (b === ACK) return
+    if (b === NACK) throw new Error('device NACKed')
+    throw new Error(`unexpected response byte 0x${b.toString(16)}`)
+  }
+
+  /** Single sync attempt -- never throws, returns whether a bootloader answered. */
+  async probe(timeoutMs: number): Promise<boolean> {
+    try {
+      await this.write([SYNC])
+      const b = await this.byteReader.readByte(timeoutMs)
+      return b === ACK || b === NACK
+    }
+    catch {
+      return false
+    }
+  }
+
+  /**
+   * Retries the sync handshake -- reopening the port right at the DFU disconnect
+   * margin can still race the bootloader's autobaud lock-on.
+   */
+  async sync(attempts = 10, timeoutMs = 500): Promise<void> {
+    for (let i = 0; i < attempts; i++) {
+      if (await this.probe(timeoutMs)) return
+      await sleep(300)
+    }
+    throw new Error('bootloader did not respond -- try the manual BOOT0 steps, then Flash again')
+  }
+
+  async get(): Promise<GetResult> {
+    await this.write(cmdFrame(CMD_GET))
+    await this.expectAck(2000)
+    const n = await this.byteReader.readByte(2000) // count of command bytes after the version byte
+    const version = await this.byteReader.readByte(2000)
+    const commands = await this.byteReader.readBytes(n, 2000)
+    await this.expectAck(2000)
+    this.commands = commands
+    this.blVersion = `${version >> 4}.${version & 0x0f}`
+    return { blVersion: this.blVersion, commands }
+  }
+
+  /** Read Memory (0x11). `length` must be 1..256. */
+  async readMemory(address: number, length: number): Promise<Uint8Array> {
+    if (length < 1 || length > READ_BLOCK_SIZE) {
+      throw new Error(`readMemory length out of range: ${length}`)
+    }
+    await this.write(cmdFrame(CMD_READ_MEMORY))
+    await this.expectAck(2000)
+    await this.write(addressFrame(address))
+    await this.expectAck(2000)
+    const n = length - 1
+    await this.write([n, 0xff ^ n])
+    await this.expectAck(2000)
+    return new Uint8Array(await this.byteReader.readBytes(length, 5000))
+  }
+
+  /** Extended Erase (0x44) global mass erase. */
+  async massErase(): Promise<void> {
+    await this.write(cmdFrame(CMD_EXTENDED_ERASE))
+    await this.expectAck(2000)
+    await this.write([0xff, 0xff, 0x00]) // 0xFFFF mass-erase code + checksum
+    await this.expectAck(30000)
+  }
+
+  /**
+   * Extended Erase (0x44) of `count` consecutive pages starting at `startPage`.
+   * Frame after the command: (count-1) big-endian, then each page index big-endian,
+   * then a single XOR checksum over all of those bytes.
+   */
+  async extendedErasePages(startPage: number, count: number): Promise<void> {
+    if (count < 1) return
+    await this.write(cmdFrame(CMD_EXTENDED_ERASE))
+    await this.expectAck(2000)
+    await this.write(buildExtendedEraseFrame(startPage, count))
+    await this.expectAck(count * 800 + 5000)
+  }
+
+  /** Erase exactly the pages an image of `imageLen` bytes occupies, from page 0. */
+  async eraseForImage(imageLen: number): Promise<number> {
+    const pages = Math.ceil(imageLen / STM32WL_PAGE_SIZE)
+    if (pages > STM32WL_PAGE_COUNT) {
+      throw new Error(`firmware too large: ${imageLen} bytes needs ${pages} pages, device has ${STM32WL_PAGE_COUNT}`)
+    }
+    await this.extendedErasePages(0, pages)
+    return pages
+  }
+
+  private async writeMemoryBlock(address: number, data: Uint8Array): Promise<void> {
+    await this.write(cmdFrame(CMD_WRITE))
+    await this.expectAck(2000)
+    await this.write(addressFrame(address))
+    await this.expectAck(2000)
+    const frame = new Uint8Array(data.length + 2)
+    frame[0] = data.length - 1
+    frame.set(data, 1)
+    frame[frame.length - 1] = xor(data) ^ (data.length - 1)
+    await this.write(frame)
+    await this.expectAck(5000)
+  }
+
+  /**
+   * Writes `bytes` to flash starting at `address`, in <=256-byte blocks (padded to
+   * a multiple of 4 with 0xFF, matching erased-flash value). Retries each block a
+   * bounded number of times before giving up.
+   */
+  async writeMemory(
+    address: number,
+    bytes: Uint8Array,
+    { onProgress, attempts = 3 }: { onProgress?: ProgressFn, attempts?: number } = {},
+  ): Promise<void> {
+    const total = bytes.length
+    for (let start = 0; start < total; start += WRITE_BLOCK_SIZE) {
+      let block = bytes.subarray(start, start + WRITE_BLOCK_SIZE)
+      if (block.length % 4 !== 0) {
+        const padded = new Uint8Array(block.length + (4 - (block.length % 4)))
+        padded.set(block)
+        padded.fill(0xff, block.length)
+        block = padded
+      }
+      let lastErr: unknown
+      let ok = false
+      for (let attempt = 0; attempt < attempts; attempt++) {
+        try {
+          await this.writeMemoryBlock(address + start, block)
+          ok = true
+          break
+        }
+        catch (e) {
+          lastErr = e
+          await sleep(200)
+        }
+      }
+      if (!ok) {
+        throw new Error(`write failed at 0x${(address + start).toString(16)}: ${(lastErr as Error)?.message}`)
+      }
+      onProgress?.(Math.min(start + WRITE_BLOCK_SIZE, total), total)
+    }
+  }
+
+  /** Read the written region back and compare it against `expected`. */
+  async verifyMemory(
+    address: number,
+    expected: Uint8Array,
+    { onProgress }: { onProgress?: ProgressFn } = {},
+  ): Promise<void> {
+    const total = expected.length
+    for (let off = 0; off < total; off += READ_BLOCK_SIZE) {
+      const len = Math.min(READ_BLOCK_SIZE, total - off)
+      const got = await this.readMemory(address + off, len)
+      for (let i = 0; i < len; i++) {
+        if (got[i] !== expected[off + i]) {
+          throw new Error(
+            `verify failed at 0x${(address + off + i).toString(16)}: `
+            + `wrote 0x${expected[off + i].toString(16)}, read 0x${got[i].toString(16)}`,
+          )
+        }
+      }
+      onProgress?.(off + len, total)
+    }
+  }
+
+  async go(address: number): Promise<void> {
+    await this.write(cmdFrame(CMD_GO))
+    await this.expectAck(2000)
+    await this.write(addressFrame(address))
+    await this.expectAck(2000)
+  }
+}

--- a/utils/stm32/flashStm32.test.ts
+++ b/utils/stm32/flashStm32.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import { FakeSerialPort, FakeStm32 } from '~/test/stm32FakeBootloader'
+import { STM32_FLASH_BASE } from './an3155'
+import { flashStm32Firmware } from './flashStm32'
+
+function setup() {
+  const dev = new FakeStm32()
+  const port = new FakeSerialPort(dev)
+  const status: string[] = []
+  const progress: Array<[string, number, number]> = []
+  const opts = {
+    massErase: false,
+    onStatus: (l: string) => status.push(l),
+    onProgress: (phase: 'write' | 'verify', done: number, total: number) =>
+      progress.push([phase, done, total]),
+  }
+  return { dev, port, status, progress, opts }
+}
+
+const image = new Uint8Array(600).map((_, i) => (i * 3) & 0xff)
+
+describe('flashStm32Firmware', () => {
+  it('erases the firmware region, writes, verifies and jumps to the app', async () => {
+    const { dev, port, status, progress, opts } = setup()
+    await flashStm32Firmware(port as unknown as SerialPort, image, opts)
+
+    expect(port.openOptions[0]).toMatchObject({ baudRate: 115200, dataBits: 8, parity: 'even', stopBits: 1 })
+    expect(dev.massErased).toBe(false)
+    expect(dev.erasedPages).toEqual([0]) // ceil(600 / 2048) = 1 page
+    expect([...dev.flash.subarray(0, 600)]).toEqual([...image])
+    expect(dev.wentTo).toBe(STM32_FLASH_BASE)
+
+    const phases = status.join('\n')
+    expect(phases).toMatch(/Erasing firmware region/)
+    expect(phases).toMatch(/configuration preserved/)
+    expect(phases).toMatch(/Verified OK/)
+
+    const write = progress.filter(p => p[0] === 'write').map(p => p[1])
+    const verify = progress.filter(p => p[0] === 'verify').map(p => p[1])
+    expect(write).toEqual([256, 512, 600])
+    expect(verify).toEqual([256, 512, 600])
+
+    expect(port.opened).toBe(false)
+    expect(port.closeCount).toBeGreaterThanOrEqual(1)
+  })
+
+  it('mass-erases when asked', async () => {
+    const { dev, port, opts } = setup()
+    await flashStm32Firmware(port as unknown as SerialPort, image, { ...opts, massErase: true })
+    expect(dev.massErased).toBe(true)
+  })
+
+  it('does not throw when Go is refused — tells the user to press RESET', async () => {
+    const { dev, port, status, opts } = setup()
+    dev.goNack = true
+    await flashStm32Firmware(port as unknown as SerialPort, image, opts)
+    expect(status.join('\n')).toMatch(/press the RESET button/)
+  })
+
+  it('throws on a verify mismatch', async () => {
+    const { dev, port, opts } = setup()
+    dev.corruptReadAt = 300
+    await expect(flashStm32Firmware(port as unknown as SerialPort, image, opts))
+      .rejects.toThrow('verify failed')
+    expect(port.opened).toBe(false) // still cleaned up
+  })
+
+  it('recycles the port when the first open() fails', async () => {
+    const { dev, port, opts } = setup()
+    port.failOpensBeforeSuccess = 1
+    await flashStm32Firmware(port as unknown as SerialPort, image, opts)
+    expect(dev.wentTo).toBe(STM32_FLASH_BASE)
+    expect(port.closeCount).toBeGreaterThanOrEqual(2) // one recycle + final
+  })
+
+  it('releases the port even when writing fails', async () => {
+    const { dev, port, opts } = setup()
+    dev.nackWriteAlways = true
+    await expect(flashStm32Firmware(port as unknown as SerialPort, image, opts))
+      .rejects.toThrow('write failed')
+    expect(port.opened).toBe(false)
+    expect(port.closeCount).toBeGreaterThanOrEqual(1)
+  })
+})

--- a/utils/stm32/flashStm32.ts
+++ b/utils/stm32/flashStm32.ts
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: MIT
+//
+// Choreography around AN3155Client: open an already-granted Web Serial port at
+// the STM32 system bootloader's framing (8E1), erase/write/verify an image, jump
+// to it, and always release the port. Kept separate from an3155.ts (pure
+// protocol) and from the Pinia store (telemetry / UI state) so each layer is
+// testable on its own.
+
+import { AN3155Client, STM32_FLASH_BASE } from './an3155'
+
+export interface Stm32FlashOptions {
+  /** true = full mass-erase (wipes config + filesystem); false = erase only the pages the image covers. */
+  massErase: boolean
+  /** Bootloader baud; the ROM autobauds, 115200 is the norm. */
+  baudRate?: number
+  /** Issue the Go command when done (default true). */
+  run?: boolean
+  /** Human-readable progress lines for the terminal. */
+  onStatus?: (line: string) => void
+  onProgress?: (phase: 'write' | 'verify', done: number, total: number) => void
+}
+
+const OPEN_8E1 = (baudRate: number) => ({
+  baudRate,
+  dataBits: 8 as const,
+  parity: 'even' as const,
+  stopBits: 1 as const,
+  bufferSize: 4096,
+  flowControl: 'none' as const,
+})
+
+export async function flashStm32Firmware(
+  port: SerialPort,
+  image: Uint8Array,
+  opts: Stm32FlashOptions,
+): Promise<void> {
+  const status = opts.onStatus ?? (() => {})
+  const baudRate = opts.baudRate ?? 115200
+
+  try {
+    await port.open(OPEN_8E1(baudRate))
+  }
+  catch (e) {
+    // Most likely already open from a previous attempt — recycle it once.
+    try {
+      await port.close()
+    }
+    catch {
+      throw e
+    }
+    await port.open(OPEN_8E1(baudRate))
+  }
+
+  if (!port.readable || !port.writable) {
+    throw new Error('serial port has no readable/writable stream after open')
+  }
+  const reader = port.readable.getReader()
+  const writer = port.writable.getWriter()
+  const client = new AN3155Client(reader, writer)
+
+  try {
+    await client.flushInput(150)
+
+    status('Syncing with the bootloader…')
+    await client.sync(10, 500)
+
+    const info = await client.get()
+    status(`Bootloader v${info.blVersion}`)
+    if (!info.commands.includes(0x31) || !info.commands.includes(0x44)) {
+      throw new Error('bootloader does not advertise Write Memory / Extended Erase')
+    }
+
+    if (opts.massErase) {
+      status('Mass-erasing flash…')
+      await client.massErase()
+    }
+    else {
+      status('Erasing firmware region…')
+      const pages = await client.eraseForImage(image.length)
+      status(`Erased ${pages} pages — configuration preserved`)
+    }
+
+    status(`Writing ${image.length} bytes…`)
+    await client.writeMemory(STM32_FLASH_BASE, image, {
+      onProgress: (done, total) => opts.onProgress?.('write', done, total),
+    })
+
+    status('Verifying…')
+    await client.verifyMemory(STM32_FLASH_BASE, image, {
+      onProgress: (done, total) => opts.onProgress?.('verify', done, total),
+    })
+    status('Verified OK')
+
+    if (opts.run !== false) {
+      try {
+        await client.go(STM32_FLASH_BASE)
+        status('Starting firmware…')
+      }
+      catch {
+        status('Could not auto-start — press the RESET button on the board')
+      }
+    }
+  }
+  finally {
+    try {
+      await reader.cancel()
+    }
+    catch { /* stream already gone */ }
+    try {
+      await writer.abort()
+    }
+    catch { /* stream already gone */ }
+    try {
+      await port.close()
+    }
+    catch { /* already closed */ }
+  }
+}

--- a/utils/stm32/meshtasticBootloader.test.ts
+++ b/utils/stm32/meshtasticBootloader.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+import { rebootMeshtasticToBootloader } from './meshtasticBootloader'
+
+// Framed FromRadio{ my_info: MyNodeInfo{ my_node_num: 4660 } }
+//   FromRadio.my_info  = field 3, message  -> tag 0x1A, len 0x03
+//   MyNodeInfo.my_node_num = field 1, varint -> tag 0x08, varint(4660) = B4 24
+const MY_INFO_FRAME = [0x94, 0xc3, 0x00, 0x05, 0x1a, 0x03, 0x08, 0xb4, 0x24]
+
+function includesSeq(haystack: number[], needle: number[]): boolean {
+  return haystack.some((_, i) => needle.every((b, j) => haystack[i + j] === b))
+}
+
+/** Minimal Web Serial port backed by a stub that answers wantConfigId with my_info. */
+class FakeMeshtasticPort {
+  opened = false
+  closeCount = 0
+  readable: ReadableStream<Uint8Array> | null = null
+  writable: WritableStream<Uint8Array> | null = null
+  received: number[] = []
+  answerConfig = true
+
+  lastReadable: ReadableStream<Uint8Array> | null = null
+  lastWritable: WritableStream<Uint8Array> | null = null
+
+  private rx: ReadableStreamDefaultController<Uint8Array> | null = null
+
+  async open() {
+    this.opened = true
+    this.readable = new ReadableStream<Uint8Array>({ start: c => (this.rx = c) })
+    this.writable = new WritableStream<Uint8Array>({ write: chunk => this.onHostBytes(chunk) })
+    this.lastReadable = this.readable
+    this.lastWritable = this.writable
+  }
+
+  async close() {
+    this.closeCount++
+    this.opened = false
+    this.readable = null
+    this.writable = null
+    this.rx = null
+  }
+
+  private onHostBytes(chunk: Uint8Array) {
+    for (const b of chunk) this.received.push(b)
+    if (this.answerConfig && this.rx) {
+      this.answerConfig = false
+      queueMicrotask(() => {
+        try {
+          this.rx?.enqueue(new Uint8Array(MY_INFO_FRAME))
+        }
+        catch { /* stream gone */ }
+      })
+    }
+  }
+}
+
+// @meshtastic/core's queue waits 200ms before every write, so give configure
+// (1 packet) and the DFU send (1 packet) enough headroom.
+const fast = { configureMs: 700, dfuAckMs: 600 }
+
+describe('rebootMeshtasticToBootloader', () => {
+  it('learns the node number, sends enter_dfu_mode_request, and releases the port', async () => {
+    const port = new FakeMeshtasticPort()
+    await rebootMeshtasticToBootloader(port as unknown as SerialPort, fast)
+
+    // AdminMessage{ enter_dfu_mode_request: true } = A8 01 01 (field 21, bool)
+    expect(includesSeq(port.received, [0xa8, 0x01, 0x01])).toBe(true)
+    // MeshPacket.to = field 2 fixed32 -> 15 34 12 00 00 (our own node 4660)
+    expect(includesSeq(port.received, [0x15, 0x34, 0x12, 0x00, 0x00])).toBe(true)
+
+    expect(port.closeCount).toBeGreaterThanOrEqual(1)
+    expect(port.lastReadable!.locked).toBe(false)
+    expect(port.lastWritable!.locked).toBe(false)
+  })
+
+  it('still completes when the device never reports its node number', async () => {
+    const port = new FakeMeshtasticPort()
+    port.answerConfig = false
+    await rebootMeshtasticToBootloader(port as unknown as SerialPort, fast)
+
+    expect(includesSeq(port.received, [0xa8, 0x01, 0x01])).toBe(true)
+    expect(port.closeCount).toBeGreaterThanOrEqual(1)
+    expect(port.lastReadable!.locked).toBe(false)
+    expect(port.lastWritable!.locked).toBe(false)
+  })
+
+  it('recovers if the port is already open', async () => {
+    const port = new FakeMeshtasticPort()
+    await port.open()
+    await rebootMeshtasticToBootloader(port as unknown as SerialPort, fast)
+    expect(port.closeCount).toBeGreaterThanOrEqual(1)
+  })
+})

--- a/utils/stm32/meshtasticBootloader.ts
+++ b/utils/stm32/meshtasticBootloader.ts
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MIT
+//
+// Reboot a running Meshtastic device into its DFU / ROM bootloader by sending
+// the enter_dfu_mode_request admin message, then release the serial port so the
+// AN3155 flasher can take it over.
+//
+// @meshtastic/transport-web-serial locks port.readable / port.writable in stream
+// pipes it never tears down, so the flasher's usual MeshDevice cleanup can only
+// free the port with port.forget() -- which revokes the grant and forces a
+// second port picker. Here the two pipes are built locally, each gated by an
+// AbortController, so aborting them cancels the port's streams and a plain
+// port.close() succeeds with the grant intact.
+
+import { MeshDevice, Utils } from '@meshtastic/core'
+
+const delay = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms))
+
+function frameHeader(length: number): Uint8Array {
+  return new Uint8Array([0x94, 0xc3, (length >> 8) & 0xff, length & 0xff])
+}
+
+export interface RebootToBootloaderOptions {
+  /** Wait at most this long for the config exchange (needed to learn our node number). */
+  configureMs?: number
+  /** enterDfuMode() never gets an ACK (the MCU resets first); stop waiting after this. */
+  dfuAckMs?: number
+  baudRate?: number
+}
+
+export async function rebootMeshtasticToBootloader(
+  port: SerialPort,
+  { configureMs = 4000, dfuAckMs = 1500, baudRate = 115200 }: RebootToBootloaderOptions = {},
+): Promise<void> {
+  try {
+    await port.open({ baudRate })
+  }
+  catch (e) {
+    try {
+      await port.close()
+    }
+    catch {
+      throw e
+    }
+    await port.open({ baudRate })
+  }
+  if (!port.readable || !port.writable) {
+    throw new Error('serial port has no streams after open')
+  }
+
+  const rxAbort = new AbortController()
+  const txAbort = new AbortController()
+
+  // device -> host: raw bytes -> decoded DeviceOutput frames.
+  // preventAbort keeps the abort from erroring fromTransform (MeshDevice pipes
+  // its readable side with no .catch); we close that side explicitly instead.
+  const fromTransform = Utils.fromDeviceStream()
+  const rxPipe = port.readable
+    .pipeTo(fromTransform.writable, { signal: rxAbort.signal, preventAbort: true })
+    .catch(() => {})
+
+  // host -> device: unframed ToRadio -> length-framed bytes -> port
+  const toTransform = new TransformStream<Uint8Array, Uint8Array>({
+    transform(chunk, controller) {
+      controller.enqueue(new Uint8Array([...frameHeader(chunk.length), ...chunk]))
+    },
+  })
+  const txPipe = toTransform.readable
+    .pipeTo(port.writable, { signal: txAbort.signal, preventAbort: true, preventClose: true })
+    .catch(() => {})
+
+  const device = new MeshDevice({
+    fromDevice: fromTransform.readable,
+    toDevice: toTransform.writable,
+  })
+
+  try {
+    // configure() frequently never resolves even though my_info has arrived;
+    // race it so we still send the admin message with our node number set.
+    try {
+      await Promise.race([device.configure(), delay(configureMs)])
+    }
+    catch { /* proceed regardless */ }
+
+    await Promise.race([device.enterDfuMode().catch(() => {}), delay(dfuAckMs)])
+  }
+  finally {
+    try {
+      device.queue.clear()
+    }
+    catch { /* no queue */ }
+    rxAbort.abort()
+    txAbort.abort()
+    // Close the decode transform so MeshDevice's internal
+    // fromDevice.pipeTo(decodePacket) resolves instead of hanging.
+    try {
+      await fromTransform.writable.close()
+    }
+    catch { /* already unlocked/closed */ }
+    await Promise.allSettled([rxPipe, txPipe])
+    await delay(50)
+    try {
+      await port.close()
+    }
+    catch { /* already closed */ }
+  }
+}

--- a/utils/telemetry.ts
+++ b/utils/telemetry.ts
@@ -21,7 +21,7 @@ import type { DeviceHardware, FirmwareResource } from '~/types/api'
 import type { EventModeConfig } from '~/types/resources'
 
 /** How the firmware reached the device. */
-export type FlashMethod = 'esptool' | 'uf2'
+export type FlashMethod = 'esptool' | 'uf2' | 'stm32'
 
 export type FirmwareChannel
   = | 'stable'


### PR DESCRIPTION
## Description

Adds a browser flashing path for STM32WL boards (RAK3172 "russell", etc.), which currently have no Web Flasher support — Meshtastic only flashes them over ST-Link/SWD. STM32WL's ROM system bootloader speaks the AN3155 USART protocol (8E1, autobaud) over the board's USB-serial bridge; entry is the `enter_dfu_mode_request` admin message, added to firmware in v2.7.22 (meshtastic/firmware#10158).

New `utils/stm32/` layer, split for testability: `an3155.ts` (protocol client ported from the MIT-licensed graw-dfm-17 reference, extended with page-range Extended Erase and Read-Memory verification), `flashStm32.ts` (`flashStm32Firmware` — open the port 8E1, then erase / write / verify / jump, always releasing the port), and `meshtasticBootloader.ts` (`rebootMeshtasticToBootloader` — send the DFU admin message and free the port without `port.forget()`).

Wired in as a fourth architecture next to ESP32 and UF2: `deviceStore.enterStm32Bootloader`, `firmwareStore.flashStm32` (mirroring `updateEspFlash` for terminal / telemetry / progress reuse), a `Stm32.vue` card that reuses the existing UF2 and ESP32 strings, and `Flash.vue` routing + a `firmware-<target>-<version>.bin` preflight check. `shouldCleanInstall` toggles a full mass-erase versus a firmware-region-only erase that preserves the LittleFS / config tail.

### The serial handoff

`@meshtastic/transport-web-serial` locks the port streams in pipes with no teardown — the existing UF2 flow can only free the port with `port.forget()`, which forces a second port picker mid-flash. `rebootMeshtasticToBootloader` instead drives `MeshDevice` over locally-owned pipes gated by `AbortController`s, so `port.close()` succeeds with the grant intact and the flash reopens the same port at 8E1 with no second prompt. Verified against `@meshtastic/core` 2.6.4 that nothing is transmitted between the DFU request and the flasher's first AN3155 sync byte (`enterDfuMode()` writes once, and the library has no heartbeat/poll loop).

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

- [ ] I have tested these changes locally — build-verified only, no STM32 hardware test yet
- [x] I have added/updated tests as appropriate
- [x] All existing tests pass

New unit tests across `utils/stm32/**` run against a fake byte-level AN3155 bootloader (no hardware), plus `deviceStore` / `firmwareStore` / `prBuild` additions — 309 tests pass. `pnpm build` succeeds. No new dependencies.

## TODOs before this is user-facing

- [ ] Hardware test on a real RAK3172 / russell: software-DFU path, config preservation on an update flash, manual BOOT0 fallback, `go()` versus a physical RESET, and 8E1 across CH340 / CP2102 adapters. Tune the timeouts in `meshtasticBootloader.ts` and `an3155.ts` against real timing.
- [ ] An `stm32` entry must appear in the Meshtastic `deviceHardware` API before a board becomes selectable — it then flows through `setTargetsList()` automatically (no flasher change needed).
- [ ] `firmware-<target>-<version>.bin` must be published to `meshtastic.github.io` releases. The `stm32` CI artifact bundle is already expected (see `utils/prBuild.test.ts` / `stores/firmwareStore.pr.test.ts`).
- [ ] i18n: three STM32-specific strings are inlined in `components/targets/Stm32.vue` and `stores/deviceStore.ts` (marked with comments) because `i18n/locales/**` is a protected path. A maintainer should add `flash.dfu_action_boot0`, `flash.stm32.parity_note`, and `flash.stm32.update_note` via Crowdin and switch these call sites back to `$t()`.

## Protected files

No protected files are modified. See the last TODO for the pending i18n strings.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added STM32 firmware flashing support for STM32 and STM32WL devices.
  * Added a dedicated STM32 flashing interface with bootloader entry, clean install, progress tracking, verification, restart controls, and terminal output.
  * Added firmware availability checks and support for shared STM32 firmware bundles.
* **Bug Fixes**
  * Improved bootloader and serial-port recovery during flashing.
* **Tests**
  * Added coverage for STM32 detection, flashing, bootloader communication, verification, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->