### PR TITLE
feat: serve nightly firmware from nightly.meshtastic.org

### DIFF
--- a/stores/firmwareStore.ts
+++ b/stores/firmwareStore.ts
@@ -18,8 +18,7 @@ import {
 } from '~/types/resources'
 import {
   getFirmwareBaseUrl,
-  GITHUB_IO_BASE,
-  NIGHTLY_DIR,
+  NIGHTLY_BASE,
   nightlyState,
   setNightlyVersion,
 } from '~/utils/firmwareUrl'
@@ -299,13 +298,13 @@ export const useFirmwareStore = defineStore('firmware', {
     },
     /**
      * Discover the current develop "nightly" build published to
-     * meshtastic.github.io/firmware-nightly/. Skipped entirely in event mode
-     * (never on event firmwares).
+     * nightly.meshtastic.org. Skipped entirely in event mode (never on event
+     * firmwares).
      */
     async fetchNightly() {
       if (eventMode.enabled) return
       try {
-        const response = await fetch(`${GITHUB_IO_BASE}/${NIGHTLY_DIR}/index.json`)
+        const response = await fetch(`${NIGHTLY_BASE}/index.json`)
         if (!response.ok) return // 404 before the first nightly is published -> no section
         const data = await response.json() as { version?: string, id?: string, title?: string }
         const id = data.id ?? (data.version ? `v${data.version}` : undefined)
@@ -313,7 +312,7 @@ export const useFirmwareStore = defineStore('firmware', {
           console.warn('Nightly index.json missing id/version', data)
           return // malformed pointer -> don't surface a broken entry
         }
-        setNightlyVersion(id) // register so getManifestBasePath routes it to firmware-nightly/
+        setNightlyVersion(id) // register so getFirmwareBaseUrl routes it to NIGHTLY_BASE
         const version = id.replace(/^v/, '')
         this.nightly = [{
           id,

--- a/utils/firmwareUrl.test.ts
+++ b/utils/firmwareUrl.test.ts
@@ -1,5 +1,12 @@
-import { describe, it, expect } from 'vitest'
-import { getManifestBasePath, getFirmwareBaseUrl, GITHUB_IO_BASE } from './firmwareUrl'
+import { describe, it, expect, afterEach } from 'vitest'
+import {
+  getManifestBasePath,
+  getFirmwareBaseUrl,
+  isNightlyVersion,
+  setNightlyVersion,
+  GITHUB_IO_BASE,
+  NIGHTLY_BASE,
+} from './firmwareUrl'
 import { eventMode } from '~/types/resources'
 
 // Derived from the active event config so the tests don't go stale when the
@@ -77,10 +84,51 @@ describe('firmwareUrl', () => {
     })
   })
 
-  describe('GITHUB_IO_BASE', () => {
-    it('has the correct base URL', () => {
+  // Nightlies are served flat from their own host, not a firmware-<version>/ folder
+  describe('nightly', () => {
+    const nightlyId = 'v2.8.1.97d916e'
+
+    // Module-level state; clear it or later cases inherit the pin
+    afterEach(() => setNightlyVersion(''))
+
+    it('routes the registered nightly to the nightly host', () => {
+      setNightlyVersion(nightlyId)
+      expect(getFirmwareBaseUrl(nightlyId)).toBe(NIGHTLY_BASE)
+    })
+
+    it('routes the nightly without the v prefix too', () => {
+      setNightlyVersion(nightlyId)
+      expect(getFirmwareBaseUrl('2.8.1.97d916e')).toBe(NIGHTLY_BASE)
+      expect(isNightlyVersion('2.8.1.97d916e')).toBe(true)
+    })
+
+    it('matches a nightly id registered without the v prefix', () => {
+      setNightlyVersion('2.8.1.97d916e')
+      expect(getFirmwareBaseUrl(nightlyId)).toBe(NIGHTLY_BASE)
+    })
+
+    it('leaves every other version on meshtastic.github.io', () => {
+      setNightlyVersion(nightlyId)
+      expect(getFirmwareBaseUrl('2.7.19.abcdef')).toBe(`${GITHUB_IO_BASE}/firmware-2.7.19.abcdef`)
+      expect(getFirmwareBaseUrl(eventVersion)).toBe(`${GITHUB_IO_BASE}/${eventBasePath}`)
+      expect(isNightlyVersion('2.7.19.abcdef')).toBe(false)
+    })
+
+    it('matches nothing before a nightly has been discovered', () => {
+      expect(isNightlyVersion(nightlyId)).toBe(false)
+      expect(getFirmwareBaseUrl(nightlyId)).toBe(`${GITHUB_IO_BASE}/firmware-2.8.1.97d916e`)
+    })
+  })
+
+  describe('base URLs', () => {
+    it('has the correct github.io base URL', () => {
       console.log(`[BASE URL] GITHUB_IO_BASE = ${GITHUB_IO_BASE}`)
       expect(GITHUB_IO_BASE).toBe('https://raw.githubusercontent.com/meshtastic/meshtastic.github.io/master')
+    })
+
+    it('has the correct nightly base URL', () => {
+      console.log(`[BASE URL] NIGHTLY_BASE = ${NIGHTLY_BASE}`)
+      expect(NIGHTLY_BASE).toBe('https://nightly.meshtastic.org')
     })
   })
 })

--- a/utils/firmwareUrl.ts
+++ b/utils/firmwareUrl.ts
@@ -3,13 +3,14 @@ import { eventMode } from '~/types/resources'
 
 export const GITHUB_IO_BASE = 'https://raw.githubusercontent.com/meshtastic/meshtastic.github.io/master'
 
-// Single, stable github.io folder that always holds the current develop nightly build.
-export const NIGHTLY_DIR = 'firmware-nightly'
+// Nightlies moved off meshtastic.github.io to their own host, same flat layout
+// as the old firmware-nightly/ folder: everything sits at the root.
+export const NIGHTLY_BASE = 'https://nightly.meshtastic.org'
 
 // Nightly (develop) build version, discovered at runtime from
-// firmware-nightly/index.json (never surfaced in event mode). Reactive so the
-// dropdown re-renders when it resolves; read synchronously below to route this
-// version to the firmware-nightly/ folder.
+// nightly.meshtastic.org/index.json (never surfaced in event mode). Reactive so
+// the dropdown re-renders when it resolves; read synchronously below to route
+// this version to the nightly host.
 export const nightlyState = reactive<{ id: string }>({ id: '' })
 
 /** Record the current nightly firmware version id (e.g. 'v2.8.0.abc1234'). */
@@ -17,18 +18,20 @@ export function setNightlyVersion(id: string): void {
   nightlyState.id = id
 }
 
+/** Whether this version is the nightly discovered from NIGHTLY_BASE. */
+export function isNightlyVersion(version: string): boolean {
+  if (!nightlyState.id) return false
+  return version.replace(/^v/, '') === nightlyState.id.replace(/^v/, '')
+}
+
 /**
- * Determine the correct base path for a firmware version
+ * Determine the correct base path for a firmware version within meshtastic.github.io
  * Event firmware uses a special path, while normal firmware uses the standard path
  * @param version - The firmware version (with or without 'v' prefix)
  * @returns The base path for fetching firmware files
  */
 export function getManifestBasePath(version: string): string {
   const cleanVersion = version.replace(/^v/, '')
-  // Nightly (develop) build lives in a single stable folder, not firmware-<version>/
-  if (nightlyState.id && cleanVersion === nightlyState.id.replace(/^v/, '')) {
-    return NIGHTLY_DIR
-  }
   const eventVersion = eventMode.firmware.id.replace(/^v/, '')
   // Check if this is the event firmware version
   if (cleanVersion === eventVersion) {
@@ -43,5 +46,7 @@ export function getManifestBasePath(version: string): string {
  * @returns The base URL for the firmware files directory
  */
 export function getFirmwareBaseUrl(version: string): string {
+  // The nightly lives on its own host, flat at the root
+  if (isNightlyVersion(version)) return NIGHTLY_BASE
   return `${GITHUB_IO_BASE}/${getManifestBasePath(version)}`
 }


### PR DESCRIPTION
# Description

Nightly (develop) firmware builds have moved out of the `firmware-nightly/` folder in `meshtastic.github.io` and onto their own host, `https://nightly.meshtastic.org`, keeping the same flat layout at the root (`index.json`, `firmware-<version>.json`, the per-target `.mt.json` manifests, `release_notes.md` and the binaries).

This reroutes the nightly index and everything derived from it. Stable, alpha, preview and event releases are unaffected and still come from `meshtastic.github.io`.

- `utils/firmwareUrl.ts`: `NIGHTLY_DIR` becomes `NIGHTLY_BASE = 'https://nightly.meshtastic.org'`. The version match moves out of `getManifestBasePath()` — which resolves a path *within* `meshtastic.github.io`, where nightlies no longer live — and into `getFirmwareBaseUrl()`, behind a new `isNightlyVersion()` helper.
- `stores/firmwareStore.ts`: `fetchNightly()` reads `${NIGHTLY_BASE}/index.json`.

Everything downstream already routes through `getFirmwareBaseUrl()` (`fetchReleaseNotes`, `fetchReleaseManifest`, `fetchTargetManifest`, `getReleaseFileUrl`, `fetchBinaryContent`, and the `checkIfRemoteFileExists` probes in `Flash.vue` / `Esp32.vue` / `Uf2.vue`), so no other call sites needed changing.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests as appropriate
- [x] All existing tests pass

Full suite: 279 passing. `tsc --noEmit` clean. `eslint` reports the same 15 pre-existing problems before and after this change.

`utils/firmwareUrl.test.ts` gains nightly coverage, which the file did not have before: routing with and without the `v` prefix on either side of the match, non-nightly versions staying on `meshtastic.github.io`, and no version matching before a nightly has been discovered.

I also verified the new host's layout directly — `index.json`, `firmware-2.8.1.97d916e.json`, `firmware-tbeam-2.8.1.97d916e.mt.json`, `release_notes.md` and the `.bin` all return 200 at the root.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated nightly firmware discovery to use the dedicated nightly firmware host.
  * Improved firmware URL selection for nightly versions, including optional `v` prefixes and fallback handling.
  * Preserved existing routing for standard firmware versions.
* **Tests**
  * Expanded coverage for nightly version detection, URL generation, and state reset behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->