### PR TITLE
feat(api): point the flasher at apiv2.meshtastic.org

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -3,10 +3,16 @@
   "configurations": [
     {
       "name": "flasher-dev",
-      "runtimeExecutable": "env",
-      "runtimeArgs": ["API_PROXY_TARGET=http://localhost:4000", "pnpm", "dev"],
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["dev"],
       "port": 3000,
       "autoPort": true
+    },
+    {
+      "name": "flasher-static",
+      "runtimeExecutable": "npx",
+      "runtimeArgs": ["-y", "serve", ".output/public", "-l", "5055", "-s"],
+      "port": 5055
     }
   ]
 }

--- a/.github/workflows/update-hardware-list.yml
+++ b/.github/workflows/update-hardware-list.yml
@@ -5,6 +5,14 @@ on:
     - cron: '0 0,6,12,18 * * *'  # Run every 6 hours
   workflow_dispatch:     # Allow manual triggering
 
+# Same deployment the app itself talks to (see API_ORIGIN in nuxt.config.ts), so the
+# offline fallback snapshot below can never disagree with what the flasher fetches at
+# runtime. Edge caching does not make this stale: /resource/deviceHardware is a document
+# compiled into the Worker bundle, and the Worker sets cross_version_cache: false, so the
+# only thing that can change it -- a deploy -- also cold-starts the cache.
+env:
+  API_ORIGIN: https://apiv2.meshtastic.org
+
 jobs:
   update-hardware-list:
     runs-on: ubuntu-latest
@@ -24,8 +32,9 @@ jobs:
       - name: Fetch latest device hardware data
         id: fetch-data
         run: |
-          # Fetch data from API
-          curl -s --fail https://api.meshtastic.org/resource/deviceHardware > /tmp/new-hardware-list.json
+          # Fetch data from API. --fail aborts the step on a non-2xx rather than
+          # writing an error page over the snapshot.
+          curl -s --fail "$API_ORIGIN/resource/deviceHardware" > /tmp/new-hardware-list.json
           
           # Ensure the output is valid JSON
           if ! jq empty /tmp/new-hardware-list.json 2>/dev/null; then

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,6 +1,12 @@
 // nuxt.config.ts
 import { defineNuxtConfig } from 'nuxt/config'
 
+// Origin the built app's `api/...` calls resolve to, and the default target of the
+// dev proxy below — so one variable moves the whole app between API deployments.
+// apiv2.meshtastic.org is the Cloudflare Worker rewrite of api.meshtastic.org;
+// API_ORIGIN=https://api.meshtastic.org rolls back to the Railway server.
+const apiOrigin = process.env.API_ORIGIN || 'https://apiv2.meshtastic.org'
+
 const ignoredDevWatchPaths = [
   '**/.claude/**',
   '**/.git/**',
@@ -69,6 +75,12 @@ export default defineNuxtConfig({
 
   vite: {
     plugins: [],
+    // Vite statically replaces `process.env.NODE_ENV` and nothing else; in the
+    // browser `process.env` is an empty unenv shim. Inline the API origin the
+    // same way so stores/store.ts reads a real value client-side.
+    define: {
+      'process.env.API_ORIGIN': JSON.stringify(apiOrigin),
+    },
     // xz-decompress is a UMD bundle (with inlined WASM). Pre-bundle it so esbuild
     // takes its CommonJS branch; served raw, its UMD global path dereferences an
     // undefined `this` in ESM context and throws.
@@ -84,9 +96,9 @@ export default defineNuxtConfig({
       },
       proxy: {
         '^/api/.*': {
-          // Point at a local api.meshtastic.org instance with e.g.
-          // API_PROXY_TARGET=http://localhost:4000 pnpm dev
-          target: process.env.API_PROXY_TARGET ?? 'https://api.meshtastic.org/',
+          // Follows API_ORIGIN by default; point at a local API instance with
+          // e.g. API_PROXY_TARGET=http://localhost:4000 pnpm dev
+          target: process.env.API_PROXY_TARGET ?? apiOrigin,
           changeOrigin: true,
           followRedirects: true,
           rewrite: path => path.replace(/^\/api/, ''),

--- a/stores/firmwareStore.pr.test.ts
+++ b/stores/firmwareStore.pr.test.ts
@@ -98,7 +98,7 @@ describe('firmwareStore PR builds', () => {
       const payload = await loadPr(store)
 
       expect(fetchMock).toHaveBeenCalledTimes(1)
-      expect(fetchMock).toHaveBeenCalledWith('https://api.meshtastic.org/github/firmware/pr/10665')
+      expect(fetchMock).toHaveBeenCalledWith('https://apiv2.meshtastic.org/github/firmware/pr/10665')
 
       expect(store.selectedFirmware?.id).toBe('v2.8.0.7a414be')
       expect(store.selectedFirmware?.prBuild?.prNumber).toBe(10665)
@@ -151,7 +151,7 @@ describe('firmwareStore PR builds', () => {
       expect(second).toBe(first)
       // 1 metadata call + 1 artifact download
       expect(fetchMock).toHaveBeenCalledTimes(2)
-      expect(fetchMock).toHaveBeenLastCalledWith('https://api.meshtastic.org/github/firmware/artifact/7523942107/download')
+      expect(fetchMock).toHaveBeenLastCalledWith('https://apiv2.meshtastic.org/github/firmware/artifact/7523942107/download')
       expect(store.prDownload).toBeUndefined()
     })
 

--- a/stores/firmwareStore.ts
+++ b/stores/firmwareStore.ts
@@ -326,7 +326,8 @@ export const useFirmwareStore = defineStore('firmware', {
     },
     /**
      * Load a pull request's CI build as a selectable firmware version.
-     * Resolves PR metadata and artifact info through api.meshtastic.org.
+     * Resolves PR metadata and artifact info through the API origin
+     * (API_ORIGIN — see stores/store.ts).
      * @param prNumber - The meshtastic/firmware pull request number
      * @returns True if the PR build was loaded and selected
      */

--- a/stores/store.test.ts
+++ b/stores/store.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { API_ORIGIN, createUrl } from './store'
+
+// createUrl reads window.location for the same-origin paths.
+vi.hoisted(() => {
+  (globalThis as any).window = { location: { host: 'localhost:3000', protocol: 'http:' } }
+})
+
+describe('createUrl', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('defaults to the v2 API deployment', () => {
+    expect(API_ORIGIN).toBe('https://apiv2.meshtastic.org')
+  })
+
+  it('strips the api/ prefix and resolves against the API origin', () => {
+    expect(createUrl('api/resource/deviceHardware')).toBe('https://apiv2.meshtastic.org/resource/deviceHardware')
+    expect(createUrl('api/github/firmware/list')).toBe('https://apiv2.meshtastic.org/github/firmware/list')
+    expect(createUrl('api/resource/eventFirmware')).toBe('https://apiv2.meshtastic.org/resource/eventFirmware')
+  })
+
+  it('keeps the API on https even when the page is not', () => {
+    // window.location.protocol is http: above; the API is https-only.
+    expect(createUrl('api/resource/deviceHardware')).toMatch(/^https:/)
+  })
+
+  it('keeps api/ same-origin in development so the Vite proxy handles it', () => {
+    vi.stubEnv('NODE_ENV', 'development')
+    expect(createUrl('api/resource/deviceHardware')).toBe('http://localhost:3000/api/resource/deviceHardware')
+  })
+
+  it('leaves non-api paths on the page origin', () => {
+    expect(createUrl('data/event_firmware.json')).toBe('http://localhost:3000/data/event_firmware.json')
+  })
+})
+
+describe('API_ORIGIN override', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.resetModules()
+  })
+
+  it('honours API_ORIGIN, which is how a rollback to the v1 server is deployed', async () => {
+    vi.stubEnv('API_ORIGIN', 'https://api.meshtastic.org')
+    const fresh = await import('./store')
+    expect(fresh.API_ORIGIN).toBe('https://api.meshtastic.org')
+    expect(fresh.createUrl('api/github/firmware/list')).toBe('https://api.meshtastic.org/github/firmware/list')
+  })
+})

--- a/stores/store.ts
+++ b/stores/store.ts
@@ -1,9 +1,28 @@
+/**
+ * Origin every `api/...` call resolves to in a built app.
+ *
+ * apiv2.meshtastic.org is the Cloudflare Worker rewrite of the API (meshtastic/api
+ * `v2` branch). It serves the same documents as api.meshtastic.org — byte-identical
+ * for /resource/deviceHardware — behind Workers Caching, and sends a static
+ * `Access-Control-Allow-Origin: *` rather than the old per-origin allowlist.
+ *
+ * Overridable at BUILD time (`API_ORIGIN=https://api.meshtastic.org pnpm build`),
+ * which is what makes a rollback a redeploy with one env var instead of a code
+ * change. Vite inlines the value into the client bundle; see `vite.define` in
+ * nuxt.config.ts, without which `process.env` is an empty shim in the browser.
+ */
+export const API_ORIGIN = process.env.API_ORIGIN || 'https://apiv2.meshtastic.org'
+
 export function createUrl(relativeUrl: string) {
-  let host = window.location.host
-  if (process.env.NODE_ENV !== 'development' && relativeUrl.startsWith('api')) {
-    host = 'api.meshtastic.org'
-    relativeUrl = relativeUrl.replace('api/', '')
+  // In development the `api/` prefix is kept and served same-origin, so Vite's
+  // proxy (nuxt.config.ts) forwards it — no CORS round trip while developing,
+  // and API_PROXY_TARGET can point the whole app at a local API.
+  if (relativeUrl.startsWith('api') && process.env.NODE_ENV !== 'development') {
+    // The API is https-only; window.location.protocol would downgrade it on a
+    // plain-http preview, and every flasher host is https anyway (Web Serial
+    // requires a secure context).
+    return `${API_ORIGIN}/${relativeUrl.replace('api/', '')}`
   }
-  const base = `${window.location.protocol}//${host}`
+  const base = `${window.location.protocol}//${window.location.host}`
   return `${base}/${relativeUrl}`
 }

--- a/utils/eventManifest.ts
+++ b/utils/eventManifest.ts
@@ -1,5 +1,6 @@
 import type { EventFirmwareEdition, EventFirmwareResponse, EventFirmwareTheme } from '~/types/eventFirmware'
 import type { EventModeConfig } from '~/types/resources'
+import { createUrl } from '~/stores/store'
 
 // Same-origin bundled snapshot gates first paint, so it gets a short timeout;
 // the cross-origin live API only refreshes in the background and can wait longer.
@@ -37,13 +38,17 @@ export async function fetchBundledManifest(): Promise<EventFirmwareResponse> {
 }
 
 /**
- * Live manifest from the API (source of truth, fresh dates/versions). The `/api`
- * prefix is proxied to api.meshtastic.org (see nuxt.config.ts). Returns null on
- * any failure; the caller keeps the bundled result. Fetched in the background so
- * a slow/unreachable API never blocks first paint.
+ * Live manifest from the API (source of truth, fresh dates/versions). Returns
+ * null on any failure; the caller keeps the bundled result. Fetched in the
+ * background so a slow/unreachable API never blocks first paint.
+ *
+ * Goes through createUrl, NOT a bare `/api/...`: same-origin only works behind
+ * the dev proxy. In production flash.meshtastic.org has no /api rewrite, so the
+ * SPA fallback answered with its own index.html — a 200 whose json() threw, and
+ * this refresh silently never resolved an edition.
  */
 export async function fetchApiManifest(): Promise<EventFirmwareResponse | null> {
-  return fetchManifest('/api/resource/eventFirmware', API_TIMEOUT_MS)
+  return fetchManifest(createUrl('api/resource/eventFirmware'), API_TIMEOUT_MS)
 }
 
 /**


### PR DESCRIPTION
apiv2.meshtastic.org is the Cloudflare Worker rewrite of the API (meshtastic/api `v2`). Verified against a production build and the dev server: /resource/deviceHardware, /github/firmware/list and /resource/eventFirmware all answer 200, and deviceHardware is currently byte-identical to api.meshtastic.org.

The host is now one build-time variable rather than a literal, so a rollback is a redeploy with `API_ORIGIN=https://api.meshtastic.org` instead of a code change. It drives both createUrl and the dev proxy target. Vite only statically replaces process.env.NODE_ENV -- in the browser process.env is an empty unenv shim -- so the value reaches the client bundle through vite.define.

Also fixes the live event-manifest refresh, which has been dead in production. fetchApiManifest used a bare `/api/resource/eventFirmware`, which only resolves behind the dev proxy; flash.meshtastic.org has no /api rewrite, so the SPA fallback answered with its own index.html -- a 200 whose json() threw, leaving the background refresh silently unable to ever resolve an edition. It now goes through createUrl.

update-hardware-list.yml follows the same origin, so the offline fallback snapshot cannot disagree with what the flasher fetches at runtime. Edge caching does not make it stale: deviceHardware is compiled into the Worker bundle and the Worker sets cross_version_cache: false, so the only thing that can change it -- a deploy -- also cold-starts the cache.

.claude/launch.json drops its API_PROXY_TARGET=localhost:4000 override, which is now the wrong default, and gains a config for serving a built app so the production code path can be exercised locally.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - API connections now use the latest API service by default.
  - API deployments can be configured for different environments.
  - Added a static preview option for locally viewing production builds.

- **Bug Fixes**
  - Firmware metadata, downloads, and event manifests now resolve through the configured API service, improving compatibility across environments.

- **Tests**
  - Added coverage for API URL resolution, development proxy behavior, and configurable API origins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->