### PR TITLE
Add t5s3_epaper_v2.svg device asset

### DIFF
--- a/public/img/devices/t5s3_epaper_v2.svg
+++ b/public/img/devices/t5s3_epaper_v2.svg
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 335.7 620.90996"
+   version="1.1"
+   id="svg73"
+   sodipodi:docname="t5s3_epaper.svg"
+   width="335.70001"
+   height="620.90997"
+   inkscape:version="1.4 (e7c3feb1, 2024-10-09)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview73"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.4073647"
+     inkscape:cx="35.527395"
+     inkscape:cy="558.84592"
+     inkscape:window-width="1728"
+     inkscape:window-height="1056"
+     inkscape:window-x="0"
+     inkscape:window-y="33"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="Layer_2" />
+  <defs
+     id="defs1">
+    <style
+       id="style1">.cls-1{fill:#757a83;}.cls-2{fill:#c9d3d3;}.cls-3{fill:#bbbbb8;}.cls-4{fill:#1d1d1b;}.cls-5,.cls-6{fill:none;stroke:#1d1d1b;stroke-miterlimit:10;}.cls-5{stroke-width:1.4px;}.cls-7{fill:#dee5e7;}</style>
+  </defs>
+  <g
+     id="Layer_2"
+     data-name="Layer 2"
+     transform="translate(-273.95,-119.37)">
+    <path
+       class="cls-1"
+       d="M 609.15,682.1 V 177.54 A 57.75,57.75 0 0 0 551.47,119.86 H 332.13 a 57.75,57.75 0 0 0 -57.68,57.68 V 682.1 a 57.75,57.75 0 0 0 57.68,57.68 h 219.34 a 57.75,57.75 0 0 0 57.68,-57.68 z m -277,51.68 A 51.74,51.74 0 0 1 280.47,682.1 V 177.54 a 51.74,51.74 0 0 1 51.68,-51.68 h 219.32 a 51.74,51.74 0 0 1 51.68,51.68 V 682.1 a 51.74,51.74 0 0 1 -51.68,51.68 z"
+       id="path1" />
+    <path
+       class="cls-2"
+       d="M 603.15,682.1 V 177.54 A 51.74,51.74 0 0 0 551.47,125.86 H 332.13 a 51.74,51.74 0 0 0 -51.68,51.68 V 682.1 a 51.74,51.74 0 0 0 51.68,51.68 H 551.47 A 51.74,51.74 0 0 0 603.15,682.1 Z M 300.09,670.67 V 172.31 h 282.64 v 498.36 z"
+       id="path2" />
+    <rect
+       class="cls-3"
+       x="300.09"
+       y="172.31"
+       width="282.64001"
+       height="498.35999"
+       id="rect2" />
+    <rect
+       class="cls-6"
+       x="192.22"
+       y="280.17001"
+       width="498.37"
+       height="282.64001"
+       transform="rotate(90,441.405,421.495)"
+       id="rect71" />
+    <path
+       class="cls-6"
+       d="M 274.45,682.1 V 177.54 a 57.73,57.73 0 0 1 57.67,-57.67 h 219.35 a 57.74,57.74 0 0 1 57.68,57.67 V 682.1 a 57.75,57.75 0 0 1 -57.68,57.68 H 332.12 A 57.74,57.74 0 0 1 274.45,682.1 Z M 603.15,177.54 A 51.74,51.74 0 0 0 551.47,125.87 H 332.12 a 51.73,51.73 0 0 0 -51.67,51.67 V 682.1 a 51.73,51.73 0 0 0 51.67,51.68 h 219.35 a 51.74,51.74 0 0 0 51.68,-51.68 z"
+       id="path72" />
+    <path
+       class="cls-7"
+       d="m 461.28,695.09 a 21.39,21.39 0 1 0 -21.38,21.38 21.38,21.38 0 0 0 21.38,-21.38 z m -37.21,0 a 15.83,15.83 0 1 1 15.83,15.83 15.82,15.82 0 0 1 -15.83,-15.83 z"
+       id="path73" />
+  </g>
+  <g
+     id="v2-badge"
+     transform="translate(75,102) scale(0.5243) translate(-121.7,-647.2)">
+    <circle fill="#ffffff" cx="121.7" cy="647.2" r="66.8" id="v2-badge-ring" />
+    <circle fill="#66e792" cx="121.7" cy="647.2" r="59.6" id="v2-badge-fill" />
+    <path fill="#202938" d="M93.7,672.1l-16.8-48h10.9l7.7,23.2c.9,2.9,1.9,6.1,2.8,9.7.9,3.5,1.9,7.4,3,11.5h-2.1c1-4.2,2-8.1,2.9-11.6.9-3.5,1.8-6.7,2.7-9.6l7.4-23.2h10.9l-16.4,48h-12.9Z" id="v2-badge-v" />
+    <path fill="#202938" d="M128.5,672.1v-7.1l17-16c1.5-1.4,2.7-2.7,3.7-3.9,1-1.1,1.8-2.3,2.3-3.4.5-1.1.8-2.3.8-3.6s-.3-2.7-1-3.7c-.6-1-1.5-1.8-2.6-2.4-1.1-.6-2.4-.8-3.8-.8s-2.8.3-3.9.9c-1.1.6-2,1.5-2.6,2.6-.6,1.1-.9,2.5-.9,4h-9.4c0-3.1.7-5.8,2.1-8.1,1.4-2.3,3.4-4.1,5.9-5.4,2.5-1.3,5.5-1.9,8.8-1.9s6.4.6,8.9,1.8c2.5,1.2,4.5,2.9,5.9,5,1.4,2.1,2.1,4.6,2.1,7.4s-.3,3.5-1,5.3-1.9,3.7-3.7,5.9c-1.8,2.2-4.3,4.7-7.6,7.8l-7.3,7.2v.4h20.3v8.1h-34Z" id="v2-badge-2" />
+  </g>
+</svg>


### PR DESCRIPTION
Stages a V2 variant of the T5S3 e-paper device art.

The file is a copy of `t5s3_epaper.svg` with the V2 badge from `rak-wismesh-tap-v2.svg` appended as a single sibling group — the base drawing is untouched.

- Badge geometry copied verbatim (white ring, `#66e792` fill, `#202938` glyph)
- Scaled 0.5243 (335.7 ÷ 640.3) so it keeps the same proportion to device width as on the RAK
- Placed top-left to match the RAK

Asset only — no wiring up in this PR.