### PR TITLE
Rename e-paper-mini-kit.svg to mini-epaper-s3.svg

### DIFF
--- a/public/img/devices/mini-epaper-s3.svg
+++ b/public/img/devices/mini-epaper-s3.svg
@@ -3,7 +3,7 @@
    viewBox="0 0 395.49007 737.69002"
    version="1.1"
    id="svg93"
-   sodipodi:docname="e-paper-mini-kit.svg"
+   sodipodi:docname="mini-epaper-s3.svg"
    inkscape:version="1.4 (e7c3feb1, 2024-10-09)"
    width="395.49008"
    height="737.69"


### PR DESCRIPTION
`hardware-list.json` maps `MINI_EPAPER_S3` (LilyGo Mini E-paper S3) to `mini-epaper-s3.svg`, but the asset was committed as `e-paper-mini-kit.svg`, so the device image did not resolve.

Renames the file to match the hardware list and updates the `sodipodi:docname` attribute to the new filename. Git tracks it as a rename; the artwork is unchanged.

Nothing else referenced the old name.